### PR TITLE
fixing codecoverage parameter handling logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Fixing the codecoverage threshold issues reported by Daniel (As param set to 0 should not bypass).
+
 ## [0.98.0] - 2019-12-22
 
 ### Added

--- a/build.ps1
+++ b/build.ps1
@@ -11,7 +11,7 @@ param
     [string[]]$Tasks = '.',
 
     [Parameter()]
-    [int]
+    [String]
     $CodeCoverageThreshold = '',
 
     [Parameter()]


### PR DESCRIPTION
Now setting the CodeCoverageThreshold to `0` will bypass the codecoverage (no calculation in pester) but will still assert no tests were failing.

Also, setting CodeCoverageThreshold to 0 from parameters will not be overridden by Config File anymore.

Also checking keys before loading from config file.