### PR TITLE
adding params to build.ps1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Updated `build.ps1` to add DscTestTag, DscTestExcludeTag parameters.
+
 ## [0.98.1] - 2019-12-24
 
 ## Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,12 +70,12 @@ prefixed with just 'Sql'
 Helper functions that are only used by one resource
 so preferably be put in the same script file as the resource.
 Helper function that can used by more than one resource can preferably
-be placed in the resource module file [DscResource.Common](/Modules/DscResource.Common/DscResource.Common.psm1).
+be placed in the resource module file [DscResource.Common](https://github.com/dsccommunity/DscResource.Common).
 
 ### Localization
 
 Please see the localization section in the [style guideline](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#localization).
-The helper functions is found in the module [DscResource.LocalizationHelper](/Modules/DscResource.LocalizationHelper/DscResource.LocalizationHelper.psm1).
+The helper functions is found in the module [DscResource.Common](https://github.com/dsccommunity/DscResource.Common/blob/master/source/Public/Get-LocalizedData.ps1).
 
 ### Unit tests
 
@@ -134,11 +134,8 @@ Invoke-Pester .\DSCResource.Tests\Meta.Tests.ps1
 Integration tests should be written for resources so they can be validated by
 the automated test framework which is run in AppVeyor when commits are pushed
 to a Pull Request (PR).
-Please see the [Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md)
+Please see the [Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines/)
 for common DSC Resource Kit testing guidelines.
-There are also configurations made by existing integration tests that can be reused
-to write integration tests for other resources. This is documented in the
-[Integration tests README](/Tests/Integration/README.md).
 
 #### AppVeyor
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Sampler module in itself serves several purposes:
 
 When you clone this module locally, or if you create a module from its template,
 the `build.ps1` is how you interact with the built-in pipeline automation, and
-`build.yml` how you configure and customize it.
+`build.yaml` how you configure and customize it.
 
 ### Bootstrapping repository and Resolve-Dependency
 
@@ -28,7 +28,7 @@ Quick Start:
 ```PowerShell
 PS C:\src\Sampler> build.ps1 -ResolveDependency
 # this will first bootstrap the environment by downloading dependencies required for the automation
-# then run the '.' task workflow as defined in build.yml (a list of Invoke-Build tasks)
+# then run the '.' task workflow as defined in build.yaml (a list of Invoke-Build tasks)
 ```
 
 The `build.ps1` is the _entry point_ to invoke any task or a list of build tasks (workflow),
@@ -46,7 +46,7 @@ Invoking `build.ps1` with the `-ResolveDependency` parameter will prepare your e
 PackageManagement (`version -gt 1.6`) or install it from *a* gallery
 1. Download or install the `PowerShell-yaml` and `PSDepend` modules needed for
 further dependency management
-1. Read the `Build.yml` configuration
+1. Read the `Build.yaml` configuration
 1. Invoke [PSDepend](https://github.com/RamblingCookieMonster/PSDepend) on
 the RequiredModules.psd1
 1. hand over the task executions to `Invoke-Build` to run the workflow
@@ -187,7 +187,7 @@ Handled by the `.build.ps1`'s **BEGIN** block, and `Resolve-Dependency.ps1`:
 
 As seen in the bootstrap process above, the different workflows can be configured by editing the `build.psd1`: new tasks can be loaded, and the sequence can be added under the `BuildWorkflow` key by listing the names.
 
-In our case, [the Build.psd1](Build.psd1#L5) defines 2 workflows (. and test) that can be called by using:
+In our case, [the Build.psd1](Build.yaml#L89) defines several workflows (., build, pack, hqrmtest,test, and publish) that can be called by using:
 ```PowerShell
  .build.ps1 -Tasks Workflow_or_task_Name
 ```
@@ -201,7 +201,7 @@ The detail of the **default workflow** is as follow (InvokeBuild defaults to the
 - **Invoke_pester_tests**: run `Invoke-Pester -Script $TestFolder` and other arguments
 - **Upload_Test_Results_To_AppVeyor**: push the Test results XML to AppVeyor [if running in AppVeyor](.build/tasks/Invoke-Pester.pester.build.ps1#L139)
 - **Fail_Build_if_Pester_Tests_failed**: Fails the build if any test failed
-- **Pester_if_Code_Coverage_Under_Threshold**: This fails the build if the Pester Code Coverage is under the [configured](.build.ps1#L21) threshold.
+- **Pester_if_Code_Coverage_Under_Threshold**: This fails the build if the Pester Code Coverage is under the [configured](build.yaml#L69) threshold.
 
 ### What needs to be added next
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Invoking `build.ps1` with the `-ResolveDependency` parameter will prepare your e
 PackageManagement (`version -gt 1.6`) or install it from *a* gallery
 1. Download or install the `PowerShell-yaml` and `PSDepend` modules needed for
 further dependency management
-1. Read the `Build.yaml` configuration
+1. Read the `build.yaml` configuration
 1. Invoke [PSDepend](https://github.com/RamblingCookieMonster/PSDepend) on
 the RequiredModules.psd1
 1. hand over the task executions to `Invoke-Build` to run the workflow
@@ -187,7 +187,7 @@ Handled by the `.build.ps1`'s **BEGIN** block, and `Resolve-Dependency.ps1`:
 
 As seen in the bootstrap process above, the different workflows can be configured by editing the `build.psd1`: new tasks can be loaded, and the sequence can be added under the `BuildWorkflow` key by listing the names.
 
-In our case, [the Build.psd1](Build.yaml#L89) defines several workflows (., build, pack, hqrmtest,test, and publish) that can be called by using:
+In our case, [the Build.psd1](build.yaml#L89) defines several workflows (., build, pack, hqrmtest,test, and publish) that can be called by using:
 ```PowerShell
  .build.ps1 -Tasks Workflow_or_task_Name
 ```

--- a/build.ps1
+++ b/build.ps1
@@ -35,21 +35,33 @@ param
     [Parameter()]
     $RequiredModulesDirectory = $(Join-Path 'output' 'RequiredModules'),
 
+    [Parameter()]
+    [string[]]
+    $PesterScript,
+
     # Filter which tags to run when invoking Pester tests
     # This is used in the Invoke-Pester.pester.build.ps1 tasks
     [Parameter()]
     [string[]]
     $PesterTag,
 
-    [Parameter()]
-    [string[]]
-    $PesterScript,
-
     # Filter which tags to exclude when invoking Pester tests
     # This is used in the Invoke-Pester.pester.build.ps1 tasks
     [Parameter()]
     [string[]]
     $PesterExcludeTag,
+
+    # Filter which tags to run when invoking DSC Resource tests
+    # This is used in the DscResource.Test.build.ps1 tasks
+    [Parameter()]
+    [string[]]
+    $DscTestTag,
+
+    # Filter which tags to exclude when invoking DSC Resource tests
+    # This is used in the DscResource.Test.build.ps1 tasks
+    [Parameter()]
+    [string[]]
+    $DscTestExcludeTag,
 
     [Parameter()]
     [Alias('bootstrap')]

--- a/build.yaml
+++ b/build.yaml
@@ -72,6 +72,8 @@ DscTest:
   ExcludeTag:
     - "Common Tests - New Error-Level Script Analyzer Rules"
     - "Common Tests - Validate Localization"
+    - "Common Tests - Validate Example Files To Be Published"
+    - "Common Tests - Validate Example Files"
   Tag:
   ExcludeSourceFile:
     - output


### PR DESCRIPTION
As discussed, allowing DscTestTag & DscTestExcludeTag parameters to be set when invoking `build.ps1`.