### PR TITLE
making a simplemodule template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- build.yaml, RequiredModules.psd1 and Resolve-Dependency.psd1 are now templated
+assets with conditional content.
+- HQRM tests to run only when using the dsccommunity module type.
+- Updated simple module to not contain sample scripts & tests.
+- supports setting CustomRepo to pull dependencies from a private gallery
+ other than PSGallery.
+
 ## [0.99.2] - 2020-01-16
 
 ### Added

--- a/Sampler/Assets/RequiredModules.psd1.template
+++ b/Sampler/Assets/RequiredModules.psd1.template
@@ -1,0 +1,39 @@
+@{
+    # Set up a mini virtual environment...
+    PSDependOptions      = @{
+        AddToPath  = $True
+        Target     = 'output\RequiredModules'
+        Parameters = @{
+<%
+                If ($PLASTER_PARAM_CustomRepo -ne 'PSGallery') {
+                    # Pull Modules from Custom Repository Name
+"           Repository = '$PLASTER_PARAM_CustomRepo'"
+                }
+%>
+        }
+    }
+
+    invokeBuild                 = 'latest'
+    PSScriptAnalyzer            = 'latest'
+    pester                      = 'latest'
+    Plaster                     = 'latest'
+    ModuleBuilder               = '1.0.0'
+    ChangelogManagement         = 'latest'
+    Sampler                     = 'latest'
+<%
+    If ($PLASTER_PARAM_ModuleType -eq 'dsccommunity') {
+@"
+    MarkdownLinkCheck           = 'latest'
+    'DscResource.Test'          = 'latest'
+    'DscResource.AnalyzerRules' = 'latest'
+    xDscResourceDesigner        = 'latest'
+
+    # PSPKI                       = 'latest'
+    # 'DscResource.Common' = @{
+    #     Target     = 'Source/Modules'
+    #     Version    = 'latest'
+    # }
+"@
+    }
+%>
+}

--- a/Sampler/Assets/Resolve-Dependency.psd1.template
+++ b/Sampler/Assets/Resolve-Dependency.psd1.template
@@ -1,0 +1,13 @@
+@{
+<%
+    if($PLASTER_PARAM_CustomRepo -ne 'PSGallery') {
+"    Gallery = '$PLASTER_PARAM_CustomRepo'"
+    }
+    else {
+"    Gallery         = 'PSGallery'"
+
+    }
+%>
+    AllowPrerelease = $false
+    WithYAML        = $true # Will also bootstrap PowerShell-Yaml to read other config files
+}

--- a/Sampler/Assets/build.yaml.template
+++ b/Sampler/Assets/build.yaml.template
@@ -8,12 +8,20 @@
 # OutputDirectory: ../output/Sampler
 CopyDirectories:
   - en-US
-  - DSCResources
+<%
+    if($PLASTER_PARAM_ModuleType -eq 'dsccommunity') {
+"  - DSCResources"
+    }
+    else {
+"#  - DSCResources"
+    }
+%>
   # - Modules
 Encoding: UTF8 # With BOM in WinPS, noBOM in PSCore.
-# SemVer: '1.2.3'
+
 # Suffix to add to Root module PSM1 after merge (here, the Set-Alias exporting IB tasks)
 # suffix: suffix.ps1
+# prefix: prefix.ps1
 VersionedOutputDirectory: true
 
 ####################################################
@@ -56,7 +64,11 @@ BuildWorkflow:
   test:
     - Pester_Tests_Stop_On_Fail
     - Pester_if_Code_Coverage_Under_Threshold
-    - hqrmtest
+<%
+    if($PLASTER_PARAM_ModuleType -eq 'dsccommunity') {
+"    - hqrmtest"
+    }
+%>
 
   publish:
     - Publish_release_to_GitHub
@@ -85,7 +97,9 @@ Pester: #Passthru, OutputFile, CodeCoverageOutputFile not supported
     - TestQuality
   Tag:
   CodeCoverageThreshold: 85 # Set to 0 to bypass
-
+<%
+    if($PLASTER_PARAM_ModuleType -eq 'dsccommunity') {
+@"
 DscTest:
   ExcludeTag:
     - "Common Tests - New Error-Level Script Analyzer Rules"
@@ -95,19 +109,21 @@ DscTest:
   ExcludeModuleFile:
   #  - Templates
   #  - Modules/DscResource.Common
+"@
+    }
+%>
+
 
 Resolve-Dependency: #Parameters for Resolve-Dependency
   #PSDependTarget: ./output/modules
   #Proxy: ''
   #ProxyCredential:
-  Gallery: 'PSGallery'
-  # AllowOldPowerShellGetModule: true
+  Gallery: '<%=$PLASTER_PARAM_CustomRepo%>'
   #MinimumPSDependVersion = '0.3.0'
   AllowPrerelease: false
   Verbose: false
 
 ModuleBuildTasks:
-  # - ModuleName: 'alias to search'
   Sampler:
     - '*.build.Sampler.ib.tasks' # this means: import (dot source) all aliases ending with .ib.tasks exported by sampler module
 
@@ -122,10 +138,15 @@ TaskHeader: |
   Write-Build DarkGray "  $Path"
   Write-Build DarkGray "  $($Task.InvocationInfo.ScriptName):$($Task.InvocationInfo.ScriptLineNumber)"
   ""
-
+<%
+    if($PLASTER_PARAM_ModuleType -eq 'dsccommunity') {
+@"
 GitHubConfig:
   GitHubFilesToAdd:
     - 'CHANGELOG.md'
   GitHubConfigUserName: dscbot
   GitHubConfigUserEmail: dsccommunity@outlook.com
   UpdateChangelogOnPrerelease: false
+"@
+    }
+%>

--- a/Sampler/Templates/Sampler/plasterManifest.xml
+++ b/Sampler/Templates/Sampler/plasterManifest.xml
@@ -39,7 +39,8 @@
     </parameter>
     <parameter store="text"  name="ModuleAuthor" type="text" prompt="Author's name" default="$Env:Username" condition='${PLASTER_PARAM_ModuleType} -notin @("dsccommunity")' />
     <parameter store="text"  name="ModuleName" type="text" prompt="Name of your module" />
-    <parameter store="text"  name="ModuleDescription" type="text" prompt="Description of this module"  condition='${PLASTER_PARAM_ModuleType} -notin @("dsccommunity")' />
+    <parameter  name="ModuleDescription" type="text" prompt="Description of this module"  condition='${PLASTER_PARAM_ModuleType} -notin @("dsccommunity")' />
+    <parameter name="CustomRepo" default="PSGallery" type="text" prompt="Do you pull from default repository (PSGallery) or a custom repository?" condition='${PLASTER_PARAM_ModuleType} -notin @("dsccommunity")' />
     <parameter name="ModuleVersion" type="text" prompt="Module version"  default="0.0.1" condition='${PLASTER_PARAM_ModuleType} -notin @("dsccommunity")' />
 
     <parameter store="text"  name="License" type="choice" prompt="Do you want to include a License to your project?" default="1" condition='$PLASTER_PARAM_ModuleType -eq "CustomModule"' >
@@ -182,13 +183,19 @@
     <!--   UNIT TESTS Private Functions Sample Files -->
     <file source='tests/Unit/Private/**'
           destination='${PLASTER_PARAM_ModuleName}/tests/Unit/Private/'
-          condition='${PLASTER_PARAM_ModuleType} -in @("SimpleModule","SimpleModule_NoBuild","CompleteModule","CompleteModule_NoBuild") -or (${PLASTER_PARAM_Features} -Contains "All" -or (${PLASTER_PARAM_Features} -Contains "UnitTests" -and ${PLASTER_PARAM_Features} -contains "SampleScripts"))'
+          condition='${PLASTER_PARAM_ModuleType} -in @("CompleteModule","CompleteModule_NoBuild") -or (${PLASTER_PARAM_Features} -Contains "All" -or (${PLASTER_PARAM_Features} -Contains "UnitTests" -and ${PLASTER_PARAM_Features} -contains "SampleScripts"))'
     />
 
     <!--   UNIT TESTS Public Functions Sample Files -->
     <file source='tests/Unit/Public/**'
           destination='${PLASTER_PARAM_ModuleName}/tests/Unit/Public/'
-          condition='${PLASTER_PARAM_ModuleType} -in @("SimpleModule","SimpleModule_NoBuild","CompleteModule","CompleteModule_NoBuild") -or (${PLASTER_PARAM_Features} -Contains "All" -or (${PLASTER_PARAM_Features} -Contains "UnitTests" -and ${PLASTER_PARAM_Features} -contains "SampleScripts"))'
+          condition='${PLASTER_PARAM_ModuleType} -in @("CompleteModule","CompleteModule_NoBuild") -or (${PLASTER_PARAM_Features} -Contains "All" -or (${PLASTER_PARAM_Features} -Contains "UnitTests" -and ${PLASTER_PARAM_Features} -contains "SampleScripts"))'
+    />
+
+    <!--   UNIT TESTS DSC Resources Sample Files -->
+    <file source='tests/Unit/DSCResources/**'
+          destination='${PLASTER_PARAM_ModuleName}/tests/Unit/DSCResources'
+          condition='${PLASTER_PARAM_ModuleType} -in @("CompleteModule","CompleteModule_NoBuild") -or (${PLASTER_PARAM_Features} -Contains "All" -or (${PLASTER_PARAM_Features} -Contains "UnitTests" -and ${PLASTER_PARAM_Features} -contains "DSCResources"))'
     />
 
     <!--   QUALITY TESTS for Module -->
@@ -261,7 +268,8 @@
     />
 
     <!--   REQUIRED MODULES MANIFEST -->
-    <file source='Sampler/Assets/RequiredModules.psd1'
+
+    <templateFile source='Sampler/Assets/RequiredModules.psd1.template'
           destination='${PLASTER_PARAM_ModuleName}/RequiredModules.psd1'
           condition='${PLASTER_PARAM_ModuleType} -in @("dsccommunity","SimpleModule","CompleteModule","SharedDscConfig") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("Build")'
     />
@@ -272,14 +280,13 @@
           condition='${PLASTER_PARAM_ModuleType} -in @("dsccommunity","SimpleModule","CompleteModule","SharedDscConfig") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("Build")'
     />
 
-    <!--   RESOLVE DEPENDENCY Configuration Manifest -->
-    <file source='Resolve-Dependency.psd1'
+    <templateFile source='Sampler/Assets/Resolve-Dependency.psd1.template'
           destination='${PLASTER_PARAM_ModuleName}/Resolve-Dependency.psd1'
           condition='${PLASTER_PARAM_ModuleType} -in @("dsccommunity","SimpleModule","CompleteModule","SharedDscConfig") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("Build")'
     />
 
     <!--   BUILD YAML CONFIGURATION -->
-    <file source='Sampler/Assets/build.yaml'
+    <templateFile source='Sampler/Assets/build.yaml.template'
           destination='${PLASTER_PARAM_ModuleName}/build.yaml'
           condition='${PLASTER_PARAM_ModuleType} -in @("dsccommunity","SimpleModule","CompleteModule","SharedDscConfig") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("Build")'
     />
@@ -302,7 +309,7 @@
 
     <file source=''
           destination='${PLASTER_PARAM_ModuleName}/${PLASTER_PARAM_SourceDirectory}/DSCResources'
-          condition='${PLASTER_PARAM_ModuleType} -in @("CompleteModule","CompleteModule_NoBuild") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("DSCResources")'
+          condition='${PLASTER_PARAM_ModuleType} -in @("CompleteModule","CompleteModule_NoBuild","SimpleModule") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("DSCResources")'
     />
 
 
@@ -334,7 +341,8 @@
         moduleVersion='$PLASTER_PARAM_ModuleVersion'
         author='$PLASTER_PARAM_ModuleAuthor'
         description='$PLASTER_PARAM_ModuleDescription'
-        condition='${PLASTER_PARAM_ModuleType} -notin @("dsccommunity") -and (-not (Test-Path "${PLASTER_PARAM_ModuleName}/${PLASTER_PARAM_ModuleName}/${PLASTER_PARAM_ModuleName}.psd1"))'
+        rootModule='$PLASTER_PARAM_ModuleName.psm1'
+        condition='${PLASTER_PARAM_ModuleType} -notin @("dsccommunity") -and (-not (Test-Path "${PLASTER_PARAM_ModuleName}/${PLASTER_PARAM_SourceDirectory}/${PLASTER_PARAM_ModuleName}.psd1"))'
     />
 
     <!--   EMPTY MODULE BUILDER MANIFEST (waiting for bug fix https://github.com/PoshCode/ModuleBuilder/issues/44) -->
@@ -344,11 +352,11 @@
           condition='${PLASTER_PARAM_ModuleType} -in @("dsccommunity","SimpleModule","CompleteModule","SharedDscConfig") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("Build")'
     />
 
-     <!-- <templateFile
+     <templateFile
         source='Sampler/Assets/module.template'
         destination='${PLASTER_PARAM_ModuleName}/${PLASTER_PARAM_SourceDirectory}/${PLASTER_PARAM_ModuleName}.psm1'
-        condition='-not (Test-Path "${PLASTER_PARAM_ModuleName}/${PLASTER_PARAM_SourceDirectory}/${PLASTER_PARAM_ModuleName}.psm1")'
-    />  -->
+        condition='${PLASTER_PARAM_ModuleType} -notin @("dsccommunity") -and (!(Test-Path "${PLASTER_PARAM_ModuleName}/${PLASTER_PARAM_SourceDirectory}/${PLASTER_PARAM_ModuleName}.psm1"))'
+    />
 
     <!-- LICENSE based on type of license MIT/Apache2/CC...-->
     <!--   MIT License -->
@@ -379,19 +387,19 @@
    <!-- CONTRIBUTING MD -->
    <file source='CONTRIBUTING.md'
           destination='${PLASTER_PARAM_ModuleName}/CONTRIBUTING.md'
-          condition='${PLASTER_PARAM_ModuleType} -in @("CompleteModule","CompleteModule_NoBuild","SimpleBuild") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("git")'
+          condition='${PLASTER_PARAM_ModuleType} -in @("dsccommunity","CompleteModule","CompleteModule_NoBuild") -or ${PLASTER_PARAM_Features} -Contains ("All")'
     />
 
    <!-- CODE OF CONDUCT MD -->
    <file source='CODE_OF_CONDUCT.md'
           destination='${PLASTER_PARAM_ModuleName}/CODE_OF_CONDUCT.md'
-          condition='${PLASTER_PARAM_ModuleType} -in @("dsccommunity","CompleteModule","CompleteModule_NoBuild","SimpleBuild") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("git")'
+          condition='${PLASTER_PARAM_ModuleType} -in @("dsccommunity","CompleteModule","CompleteModule_NoBuild") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("git")'
     />
 
    <!-- CHANGELOG MD -->
    <file source='Sampler/Assets/CHANGELOG.md.template'
           destination='${PLASTER_PARAM_ModuleName}/CHANGELOG.md'
-          condition='${PLASTER_PARAM_ModuleType} -in @("CompleteModule","CompleteModule_NoBuild","SimpleBuild") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("git")'
+          condition='${PLASTER_PARAM_ModuleType} -in @("CompleteModule","CompleteModule_NoBuild","SimpleModule") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("git")'
     />
 
    <!-- GITVERSION CONFIG YAML -->
@@ -403,7 +411,7 @@
    <!-- MARKDOWN LINT -->
    <file source='Sampler/Assets/markdownlint.json'
           destination='${PLASTER_PARAM_ModuleName}/.markdownlint.json'
-          condition='${PLASTER_PARAM_ModuleType} -in @("dsccommunity","CompleteModule","CompleteModule_NoBuild","SimpleBuild") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("vscode")'
+          condition='${PLASTER_PARAM_ModuleType} -in @("dsccommunity","CompleteModule") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("vscode")'
     />
 
    <!-- VSCODE SETTINGS -->
@@ -415,7 +423,7 @@
    <!-- GITHUB TEMPLATES -->
    <file source='Sampler/Assets/github'
           destination='${PLASTER_PARAM_ModuleName}/.github'
-          condition='${PLASTER_PARAM_ModuleType} -in @("CompleteModule","CompleteModule_NoBuild","SimpleBuild") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("github")'
+          condition='${PLASTER_PARAM_ModuleType} -in @("CompleteModule","CompleteModule_NoBuild") -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("github")'
     />
 
   </content>

--- a/tests/Unit/PlasterTemplate/PlasterTemplate.tests.ps1
+++ b/tests/Unit/PlasterTemplate/PlasterTemplate.tests.ps1
@@ -23,6 +23,7 @@ Describe 'Plaster Templates creates a complete Module scaffolding' {
             moduleName        = $ModuleName
             ModuleVersion     = '0.0.1'
             SourceDirectory   = 'Source'
+            CustomRepo        = 'Modules'
         }
         Invoke-plaster @PlasterParams
     }


### PR DESCRIPTION
- build.yaml, RequiredModules.psd1 and Resolve-Dependency.psd1 are now templated
assets with conditional content.
- HQRM tests to run only when using the dsccommunity module type.
- Updated simple module to not contain sample scripts & tests.
- supports setting CustomRepo to pull dependencies from a private gallery
 other than PSGallery.