### PR TITLE
Added warning messages to build tasks, while resolving project properties

### DIFF
--- a/.build/tasks/Build-Module.ModuleBuilder.build.ps1
+++ b/.build/tasks/Build-Module.ModuleBuilder.build.ps1
@@ -4,7 +4,7 @@ Param (
     [string]
     $ProjectName = (property ProjectName $(
             #Find the module manifest to deduce the Project Name
-            (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
+            (Get-ChildItem $BuildRoot\*\*.psd1 -Exclude 'build.psd1', 'analyzersettings.psd1' | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
                     $(try
                         {
@@ -21,7 +21,7 @@ Param (
 
     [Parameter()]
     [string]
-    $SourcePath = (property SourcePath ((Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
+    $SourcePath = (property SourcePath ((Get-ChildItem $BuildRoot\*\*.psd1 -Exclude 'build.psd1', 'analyzersettings.psd1' | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
                     $(try
                         {
@@ -259,7 +259,6 @@ Task Build_NestedModules_ModuleBuilder {
                             }
                             catch
                             {
-                                Write-Warning $_
                                 $false
                             })
                     }

--- a/.build/tasks/Build-Module.ModuleBuilder.build.ps1
+++ b/.build/tasks/Build-Module.ModuleBuilder.build.ps1
@@ -12,6 +12,7 @@ Param (
                         }
                         catch
                         {
+                            Write-Warning $_
                             $false
                         }) }
             ).BaseName
@@ -28,6 +29,7 @@ Param (
                         }
                         catch
                         {
+                            Write-Warning $_
                             $false
                         }) }
             ).Directory.FullName)
@@ -257,8 +259,10 @@ Task Build_NestedModules_ModuleBuilder {
                             }
                             catch
                             {
+                                Write-Warning $_
                                 $false
-                            }) }
+                            })
+                    }
             ).FullName -replace [Regex]::Escape($BuiltModuleBase), ".$([io.path]::DirectorySeparatorChar)"
 
 

--- a/.build/tasks/DeployAll.PSDeploy.build.ps1
+++ b/.build/tasks/DeployAll.PSDeploy.build.ps1
@@ -6,7 +6,7 @@ Param (
     [Parameter()]
     [string]
     $ProjectName = (property ProjectName $(
-            (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
+            (Get-ChildItem $BuildRoot\*\*.psd1 -Exclude 'build.psd1', 'analyzersettings.psd1' | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
                     $(try
                         {

--- a/.build/tasks/DeployAll.PSDeploy.build.ps1
+++ b/.build/tasks/DeployAll.PSDeploy.build.ps1
@@ -8,10 +8,13 @@ Param (
     $ProjectName = (property ProjectName $(
             (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-                    $(try {
+                    $(try
+                        {
                             Test-ModuleManifest $_.FullName -ErrorAction Stop
                         }
-                        catch {
+                        catch
+                        {
+                            Write-Warning $_
                             $false
                         }) }
             ).BaseName
@@ -24,17 +27,23 @@ Param (
 
     [Parameter()]
     [string]
-    $APPVEYOR_JOB_ID = $(try {
+    $APPVEYOR_JOB_ID = $(try
+        {
             property APPVEYOR_JOB_ID
         }
-        catch { ''
+        catch
+        {
+            ''
         }),
 
     [Parameter()]
-    $DeploymentTags = $(try {
+    $DeploymentTags = $(try
+        {
             property DeploymentTags
         }
-        catch { ''
+        catch
+        {
+            ''
         }),
 
     [Parameter()]
@@ -44,7 +53,8 @@ Param (
 # Synopsis: Deploy everything configured in PSDeploy
 task Deploy_with_PSDeploy {
 
-    if (![io.path]::IsPathRooted($BuildOutput)) {
+    if (![io.path]::IsPathRooted($BuildOutput))
+    {
         $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
     }
 
@@ -57,7 +67,8 @@ task Deploy_with_PSDeploy {
         Force = $true
     }
 
-    if ($DeploymentTags) {
+    if ($DeploymentTags)
+    {
         $null = $InvokePSDeployArgs.Add('Tags', $DeploymentTags)
     }
 

--- a/.build/tasks/DscResource.Test.build.ps1
+++ b/.build/tasks/DscResource.Test.build.ps1
@@ -14,10 +14,13 @@ Param (
     $ProjectName = (property ProjectName $(
             (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-                    $(try {
+                    $(try
+                        {
                             Test-ModuleManifest $_.FullName -ErrorAction Stop
                         }
-                        catch {
+                        catch
+                        {
+                            Write-Warning $_
                             $false
                         }) }
             ).BaseName
@@ -27,10 +30,12 @@ Param (
     [Parameter()]
     [string]
     $ModuleVersion = (property ModuleVersion $(
-            try {
+            try
+            {
                 (gitversion | ConvertFrom-Json -ErrorAction Stop).InformationalVersion
             }
-            catch {
+            catch
+            {
                 Write-Verbose "Error attempting to use GitVersion $($_)"
                 ''
             }
@@ -94,7 +99,7 @@ task Invoke_DscResource_tests {
     # Build.ps1 parameters should be top priority
     # BuildInfo values should come next
     # Otherwise we should set some defaults
-    Import-Module Pester,DscResource.Test -ErrorAction Stop
+    Import-Module Pester, DscResource.Test -ErrorAction Stop
     $DscTestCmd = Get-Command Invoke-DscResourceTest
     foreach ($ParamName in $DscTestCmd.Parameters.Keys)
     {
@@ -236,35 +241,44 @@ task Invoke_DscResource_tests {
 task Fail_Build_if_DscResource_Tests_failed {
     "Asserting that no test failed"
 
-    if (!(Split-Path -isAbsolute $OutputDirectory)) {
+    if (!(Split-Path -isAbsolute $OutputDirectory))
+    {
         $OutputDirectory = Join-Path -Path $ProjectPath -ChildPath $OutputDirectory
         Write-Build Yellow "Absolute path to Output Directory is $OutputDirectory"
     }
 
-    if (!(Split-Path -isAbsolute $DscTestOutputFolder)) {
+    if (!(Split-Path -isAbsolute $DscTestOutputFolder))
+    {
         $DscTestOutputFolder = Join-Path $OutputDirectory $DscTestOutputFolder
     }
 
-    $os = if ($isWindows -or $PSVersionTable.PSVersion.Major -le 5) {
+    $os = if ($isWindows -or $PSVersionTable.PSVersion.Major -le 5)
+    {
         'Windows'
     }
-    elseif ($isMacOS) {
+    elseif ($isMacOS)
+    {
         'MacOS'
     }
-    else {
+    else
+    {
         'Linux'
     }
 
-    if ([String]::IsNullOrEmpty($ModuleVersion)) {
+    if ([String]::IsNullOrEmpty($ModuleVersion))
+    {
         $ModuleInfo = Import-PowerShellDataFile "$OutputDirectory/$ProjectName/*/$ProjectName.psd1" -ErrorAction Stop
-        if ($PreReleaseTag = $ModuleInfo.PrivateData.PSData.Prerelease) {
+        if ($PreReleaseTag = $ModuleInfo.PrivateData.PSData.Prerelease)
+        {
             $ModuleVersion = $ModuleInfo.ModuleVersion + "-" + $PreReleaseTag
         }
-        else {
+        else
+        {
             $ModuleVersion = $ModuleInfo.ModuleVersion
         }
     }
-    else {
+    else
+    {
         $ModuleVersion, $BuildMetadata = $ModuleVersion -split '\+', 2
         $ModuleVersionFolder, $PreReleaseTag = $ModuleVersion -split '\-', 2
     }
@@ -275,10 +289,12 @@ task Fail_Build_if_DscResource_Tests_failed {
     Write-Build White "`tDscTest Output Object = $DscTestResultObjectClixml"
 
 
-    if (-Not (Test-Path $DscTestResultObjectClixml)) {
+    if (-Not (Test-Path $DscTestResultObjectClixml))
+    {
         Throw "No command were tested. $DscTestResultObjectClixml not found"
     }
-    else {
+    else
+    {
         $DscTestObject = Import-Clixml -Path $DscTestResultObjectClixml -ErrorAction Stop
         assert ($DscTestObject.FailedCount -eq 0) ('Failed {0} tests. Aborting Build' -f $DscTestObject.FailedCount)
     }
@@ -288,40 +304,50 @@ task Fail_Build_if_DscResource_Tests_failed {
 # Synopsis: Uploading Unit Test results to AppVeyor
 task Upload_DscResourceTest_Results_To_AppVeyor -If { (property BuildSystem 'unknown') -eq 'AppVeyor' } {
 
-    if (!(Split-Path -isAbsolute $OutputDirectory)) {
+    if (!(Split-Path -isAbsolute $OutputDirectory))
+    {
         $OutputDirectory = Join-Path -Path $ProjectPath -ChildPath $OutputDirectory
         Write-Build Yellow "Absolute path to Output Directory is $OutputDirectory"
     }
 
-    if (!(Split-Path -isAbsolute $DscTestOutputFolder)) {
+    if (!(Split-Path -isAbsolute $DscTestOutputFolder))
+    {
         $DscTestOutputFolder = Join-Path $OutputDirectory $DscTestOutputFolder
     }
 
-    if (!(Test-Path $DscTestOutputFolder)) {
+    if (!(Test-Path $DscTestOutputFolder))
+    {
         Write-Build Yellow "Creating folder $DscTestOutputFolder"
         $null = New-Item -ItemType Directory -force $DscTestOutputFolder -ErrorAction Stop
     }
 
-    $os = if ($isWindows -or $PSVersionTable.PSVersion.Major -le 5) {
+    $os = if ($isWindows -or $PSVersionTable.PSVersion.Major -le 5)
+    {
         'Windows'
     }
-    elseif ($isMacOS) {
+    elseif ($isMacOS)
+    {
         'MacOS'
     }
-    else {
+    else
+    {
         'Linux'
     }
 
-    if ([String]::IsNullOrEmpty($ModuleVersion)) {
+    if ([String]::IsNullOrEmpty($ModuleVersion))
+    {
         $ModuleInfo = Import-PowerShellDataFile "$OutputDirectory/$ProjectName/*/$ProjectName.psd1" -ErrorAction Stop
-        if ($PreReleaseTag = $ModuleInfo.PrivateData.PSData.Prerelease) {
+        if ($PreReleaseTag = $ModuleInfo.PrivateData.PSData.Prerelease)
+        {
             $ModuleVersion = $ModuleInfo.ModuleVersion + "-" + $PreReleaseTag
         }
-        else {
+        else
+        {
             $ModuleVersion = $ModuleInfo.ModuleVersion
         }
     }
-    else {
+    else
+    {
         $ModuleVersion, $BuildMetadata = $ModuleVersion -split '\+', 2
         $ModuleVersionFolder, $PreReleaseTag = $ModuleVersion -split '\-', 2
     }
@@ -331,7 +357,8 @@ task Upload_DscResourceTest_Results_To_AppVeyor -If { (property BuildSystem 'unk
     $DscTestOutputFullPath = Join-Path $DscTestOutputFolder "$($DscTestOutputFormat)_$DscTestOutputFileFileName"
 
     $TestResultFile = Get-Item $DscTestOutputFullPath -ErrorAction Ignore
-    if ($TestResultFile) {
+    if ($TestResultFile)
+    {
         Write-Build Green "  Uploading test results $TestResultFile to Appveyor"
         $TestResultFile | Add-TestResultToAppveyor
         Write-Build Green "  Upload Complete"

--- a/.build/tasks/DscResource.Test.build.ps1
+++ b/.build/tasks/DscResource.Test.build.ps1
@@ -12,7 +12,7 @@ Param (
     [Parameter()]
     [string]
     $ProjectName = (property ProjectName $(
-            (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
+            (Get-ChildItem $BuildRoot\*\*.psd1 -Exclude 'build.psd1', 'analyzersettings.psd1' | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
                     $(try
                         {

--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -12,7 +12,7 @@ Param (
     [Parameter()]
     [string]
     $ProjectName = (property ProjectName $(
-            (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
+            (Get-ChildItem $BuildRoot\*\*.psd1 -Exclude 'build.psd1', 'analyzersettings.psd1' | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
                     $(try
                         {

--- a/.build/tasks/New-Release.GitHub.build.ps1
+++ b/.build/tasks/New-Release.GitHub.build.ps1
@@ -15,7 +15,7 @@ param(
     [string]
     $ProjectName = (property ProjectName $(
             #Find the module manifest to deduce the Project Name
-            (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
+            (Get-ChildItem $BuildRoot\*\*.psd1 -Exclude 'build.psd1', 'analyzersettings.psd1' | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
                     $(try
                         {

--- a/.build/tasks/New-Release.GitHub.build.ps1
+++ b/.build/tasks/New-Release.GitHub.build.ps1
@@ -17,10 +17,13 @@ param(
             #Find the module manifest to deduce the Project Name
             (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-                    $(try {
+                    $(try
+                        {
                             Test-ModuleManifest $_.FullName -ErrorAction Stop
                         }
-                        catch {
+                        catch
+                        {
+                            Write-Warning $_
                             $false
                         }) }
             ).BaseName
@@ -30,10 +33,12 @@ param(
     [Parameter()]
     [string]
     $ModuleVersion = (property ModuleVersion $(
-            try {
+            try
+            {
                 (gitversion | ConvertFrom-Json -ErrorAction Stop).InformationalVersion
             }
-            catch {
+            catch
+            {
                 Write-Verbose "Error attempting to use GitVersion $($_)"
                 ''
             }
@@ -69,24 +74,30 @@ param(
 . $PSScriptRoot/GitHubRelease.functions.ps1
 
 task Publish_release_to_GitHub -if ($GitHubToken) {
-    if (!(Split-Path $OutputDirectory -IsAbsolute)) {
+    if (!(Split-Path $OutputDirectory -IsAbsolute))
+    {
         $OutputDirectory = Join-Path $BuildRoot $OutputDirectory
     }
 
-    if (!(Split-Path -isAbsolute $ReleaseNotesPath)) {
+    if (!(Split-Path -isAbsolute $ReleaseNotesPath))
+    {
         $ReleaseNotesPath = Join-Path $OutputDirectory $ReleaseNotesPath
     }
 
-    if ([String]::IsNullOrEmpty($ModuleVersion)) {
+    if ([String]::IsNullOrEmpty($ModuleVersion))
+    {
         $ModuleInfo = Import-PowerShellDataFile "$OutputDirectory/$ProjectName/*/$ProjectName.psd1" -ErrorAction Stop
-        if ($PreReleaseTag = $ModuleInfo.PrivateData.PSData.Prerelease) {
+        if ($PreReleaseTag = $ModuleInfo.PrivateData.PSData.Prerelease)
+        {
             $ModuleVersion = $ModuleInfo.ModuleVersion + "-" + $PreReleaseTag
         }
-        else {
+        else
+        {
             $ModuleVersion = $ModuleInfo.ModuleVersion
         }
     }
-    else {
+    else
+    {
         # Remove metadata from ModuleVersion
         $ModuleVersion, $BuildMetadata = $ModuleVersion -split '\+', 2
         # Remove Prerelease tag from ModuleVersionFolder
@@ -100,7 +111,8 @@ task Publish_release_to_GitHub -if ($GitHubToken) {
     Write-Build DarkGray "About to release $PackageToRelease v$ModuleVersion"
     $remoteURL = git remote get-url origin
 
-    if ($remoteURL -notMatch 'github') {
+    if ($remoteURL -notMatch 'github')
+    {
         Write-Build Yellow "Skipping Publish GitHub release to $RemoteURL"
         return
     }
@@ -109,11 +121,14 @@ task Publish_release_to_GitHub -if ($GitHubToken) {
     $Repo = GetHumanishRepositoryDetails -RemoteUrl $remoteURL
 
     # Retrieving ReleaseNotes or defaulting to Updated ChangeLog
-    if (Import-Module ChangelogManagement -ErrorAction SilentlyContinue -PassThru) {
+    if (Import-Module ChangelogManagement -ErrorAction SilentlyContinue -PassThru)
+    {
         $ReleaseNotes = (Get-ChangelogData -Path $ChangeLogPath).Unreleased.RawData -replace '\[unreleased\]', "[v$ModuleVersion]"
     }
-    else {
-        if (-not ($ReleaseNotes = (Get-Content -raw $ReleaseNotesPath -ErrorAction SilentlyContinue))) {
+    else
+    {
+        if (-not ($ReleaseNotes = (Get-Content -raw $ReleaseNotesPath -ErrorAction SilentlyContinue)))
+        {
             $ReleaseNotes = Get-Content -raw $ChangeLogPath -ErrorAction SilentlyContinue
         }
     }
@@ -133,7 +148,8 @@ task Publish_release_to_GitHub -if ($GitHubToken) {
         Description = $ReleaseNotes
         GitHubToken = $GitHubToken
     }
-    if (!$SkipPublish) {
+    if (!$SkipPublish)
+    {
         $APIResponse = Publish-GitHubRelease @releaseParams
     }
     Write-Build Green "Release Created. Follow the link -> $($APIResponse.html_url)"
@@ -149,8 +165,10 @@ task Create_ChangeLog_GitHub_PR -if ($GitHubToken) {
     # # git fetch --force --tags --prune --progress --no-recurse-submodules origin
     # # git checkout --progress --force (git rev-parse origin/master)
 
-    foreach ($GitHubConfigKey in @('GitHubFilesToAdd', 'GitHubConfigUserName', 'GitHubConfigUserEmail', 'UpdateChangelogOnPrerelease')) {
-        if ( -Not (Get-Variable -Name $GitHubConfigKey -ValueOnly -ErrorAction SilentlyContinue)) {
+    foreach ($GitHubConfigKey in @('GitHubFilesToAdd', 'GitHubConfigUserName', 'GitHubConfigUserEmail', 'UpdateChangelogOnPrerelease'))
+    {
+        if ( -Not (Get-Variable -Name $GitHubConfigKey -ValueOnly -ErrorAction SilentlyContinue))
+        {
             # Variable is not set in context, use $BuildInfo.GitHubConfig.<varName>
             $ConfigValue = $BuildInfo.GitHubConfig.($GitHubConfigKey)
             Set-Variable -Name $GitHubConfigKey -Value $ConfigValue
@@ -162,21 +180,25 @@ task Create_ChangeLog_GitHub_PR -if ($GitHubToken) {
     # Look at the tags on latest commit for origin/master (assume we're on detached head)
     $TagsAtCurrentPoint = git tag -l --points-at (git rev-parse origin/master)
     # Only Update changelog if last commit is a full release
-    if ($UpdateChangelogOnPrerelease) {
+    if ($UpdateChangelogOnPrerelease)
+    {
         $TagVersion = [string]($TagsAtCurrentPoint | Select-Object -First 1)
         Write-Build Green "Updating Changelog for PRE-Release $TagVersion"
     }
-    elseif ($TagVersion = [string]($TagsAtCurrentPoint.Where{ $_ -notMatch 'v.*\-' })) {
+    elseif ($TagVersion = [string]($TagsAtCurrentPoint.Where{ $_ -notMatch 'v.*\-' }))
+    {
         Write-Build Green "Updating the ChangeLog for release $TagVersion"
     }
-    else {
+    else
+    {
         Write-Build Yellow "No Release Tag found to update the ChangeLog from"
         return
     }
 
     $BranchName = "updateChangelogAfter$TagVersion"
     git checkout -B $BranchName
-    try {
+    try
+    {
         Write-Build DarkGray "Updating Changelog file"
         Update-Changelog -ReleaseVersion ($TagVersion -replace '^v') -LinkMode None -Path $ChangelogPath -ErrorAction SilentlyContinue
         git add $GitHubFilesToAdd
@@ -207,7 +229,8 @@ task Create_ChangeLog_GitHub_PR -if ($GitHubToken) {
         $Response = New-GitHubPullRequest @NewPullRequestParams
         Write-Build Green "`n --> PR #$($Response.number) opened: $($Response.url)"
     }
-    catch {
+    catch
+    {
         Write-Build Red "Error trying to create ChangeLog Pull Request. Ignoring.`r`n $_"
     }
 }

--- a/.build/tasks/generateHelp.PlatyPS.build.ps1
+++ b/.build/tasks/generateHelp.PlatyPS.build.ps1
@@ -6,7 +6,7 @@ Param (
     [Parameter()]
     [string]
     $ProjectName = (property ProjectName $(
-            (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
+            (Get-ChildItem $BuildRoot\*\*.psd1 -Exclude 'build.psd1', 'analyzersettings.psd1' | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
                     $(try
                         {
@@ -24,7 +24,7 @@ Param (
     [Parameter()]
     [string]
     $SourcePath = (property SourcePath $(
-            (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
+            (Get-ChildItem $BuildRoot\*\*.psd1 -Exclude 'build.psd1', 'analyzersettings.psd1' | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
                     $(try
                         {

--- a/.build/tasks/generateHelp.PlatyPS.build.ps1
+++ b/.build/tasks/generateHelp.PlatyPS.build.ps1
@@ -7,18 +7,36 @@ Param (
     [string]
     $ProjectName = (property ProjectName $(
             (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
-                ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-                $(try { Test-ModuleManifest $_.FullName -ErrorAction Stop }catch{$false}) }
+                    ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+                    $(try
+                        {
+                            Test-ModuleManifest $_.FullName -ErrorAction Stop
+                        }
+                        catch
+                        {
+                            Write-Warning $_
+                            $false
+                        }) }
             ).BaseName
         )
     ),
 
     [Parameter()]
     [string]
-    $SourcePath = (property SourcePath ((Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
+    $SourcePath = (property SourcePath $(
+            (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-                    $(try { Test-ModuleManifest $_.FullName -ErrorAction Stop }catch { $false }) }
-            ).Directory.FullName)
+                    $(try
+                        {
+                            Test-ModuleManifest $_.FullName -ErrorAction Stop
+                        }
+                        catch
+                        {
+                            Write-Warning $_
+                            $false
+                        }) }
+            ).Directory.FullName
+        )
     ),
 
     [Parameter()]
@@ -39,16 +57,18 @@ Param (
 
 )
 
-Task UpdateHelp{
+Task UpdateHelp {
     $LineSeparation
     "`t`t`t UPDATE HELP MARKDOWN FILE"
     $LineSeparation
 
-    if (!(Split-Path -IsAbsolute $BuildOutput)) {
+    if (!(Split-Path -IsAbsolute $BuildOutput))
+    {
         $BuildOutput = Join-Path -Path $ProjectPath.FullName -ChildPath $BuildOutput
     }
 
-    if (!(Split-Path -IsAbsolute $HelpFolder)) {
+    if (!(Split-Path -IsAbsolute $HelpFolder))
+    {
         $HelpFolder = Join-Path $SourcePath $HelpFolder
     }
 
@@ -63,11 +83,13 @@ Task GenerateMamlFromMd {
     "`t`t`t GENERATE MAML IN BUILD OUTPUT"
     $LineSeparation
 
-    if (!(Split-Path -IsAbsolute $BuildOutput)) {
+    if (!(Split-Path -IsAbsolute $BuildOutput))
+    {
         $BuildOutput = Join-Path -Path $ProjectPath.FullName -ChildPath $BuildOutput
     }
 
-    if (!(Split-Path -IsAbsolute $HelpFolder)) {
+    if (!(Split-Path -IsAbsolute $HelpFolder))
+    {
         $HelpFolder = Join-Path $SourcePath $HelpFolder
     }
 

--- a/.build/tasks/release.module.build.ps1
+++ b/.build/tasks/release.module.build.ps1
@@ -14,7 +14,7 @@ param(
     [string]
     $ProjectName = (property ProjectName $(
             #Find the module manifest to deduce the Project Name
-            (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
+            (Get-ChildItem $BuildRoot\*\*.psd1 -Exclude 'build.psd1', 'analyzersettings.psd1' | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
                     $(try
                         {
@@ -143,7 +143,6 @@ task Create_changelog_release_output {
                 }
                 catch
                 {
-                    Write-Warning $_
                     $false
                 }
             }
@@ -237,7 +236,6 @@ task package_module_nupkg {
             }
             catch
             {
-                Write-Warning $_
                 $false
             }
         }
@@ -306,7 +304,6 @@ task publish_module_to_gallery -if ((!(Get-Command nuget -ErrorAction SilentlyCo
             }
             catch
             {
-                Write-Warning $_
                 $false
             }
         }

--- a/.build/tasks/release.module.build.ps1
+++ b/.build/tasks/release.module.build.ps1
@@ -146,7 +146,7 @@ task Create_changelog_release_output {
                     $false
                 }
             }
-        if (-not $BuildModuleManifest)
+        if (-not $BuiltModuleManifest)
         {
             throw "No valid manifest found for project $ProjectName."
         }
@@ -240,7 +240,7 @@ task package_module_nupkg {
             }
         }
 
-    if (-not $BuildModuleManifest)
+    if (-not $BuiltModuleManifest)
     {
         throw "No valid manifest found for project $ProjectName."
     }
@@ -308,7 +308,7 @@ task publish_module_to_gallery -if ((!(Get-Command nuget -ErrorAction SilentlyCo
             }
         }
     # No need to test the manifest again here, because the pipeline tested all manifests via the where-clause already
-    if (-not $BuildModuleManifest)
+    if (-not $BuiltModuleManifest)
     {
         throw "No valid manifest found for project $ProjectName."
     }

--- a/.build/tasks/release.module.build.ps1
+++ b/.build/tasks/release.module.build.ps1
@@ -16,10 +16,13 @@ param(
             #Find the module manifest to deduce the Project Name
             (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
                     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-                    $(try {
+                    $(try
+                        {
                             Test-ModuleManifest $_.FullName -ErrorAction Stop
                         }
-                        catch {
+                        catch
+                        {
+                            Write-Warning $_
                             $false
                         }) }
             ).BaseName
@@ -29,10 +32,12 @@ param(
     [Parameter()]
     [string]
     $ModuleVersion = (property ModuleVersion $(
-            try {
+            try
+            {
                 (gitversion | ConvertFrom-Json -ErrorAction Stop).InformationalVersion
             }
-            catch {
+            catch
+            {
                 Write-Verbose "Error attempting to use GitVersion $($_)"
                 ''
             }
@@ -63,27 +68,33 @@ task Create_changelog_release_output {
     "  OutputDirectory  = $OutputDirectory"
     "  ReleaseNotesPath = $ReleaseNotesPath"
 
-    if (!(Split-Path -isAbsolute $OutputDirectory)) {
+    if (!(Split-Path -isAbsolute $OutputDirectory))
+    {
         $OutputDirectory = Join-Path $BuildRoot $OutputDirectory
     }
 
-    if (!(Split-Path -isAbsolute $ReleaseNotesPath)) {
+    if (!(Split-Path -isAbsolute $ReleaseNotesPath))
+    {
         $ReleaseNotesPath = Join-Path $OutputDirectory $ReleaseNotesPath
     }
 
     $ChangeLogOutputPath = Join-Path $OutputDirectory 'CHANGELOG.md'
     "  ChangeLogOutputPath = $ChangeLogOutputPath"
 
-    if ([String]::IsNullOrEmpty($ModuleVersion)) {
+    if ([String]::IsNullOrEmpty($ModuleVersion))
+    {
         $ModuleInfo = Import-PowerShellDataFile "$OutputDirectory/$ProjectName/*/$ProjectName.psd1" -ErrorAction Stop
-        if ($PreReleaseTag = $ModuleInfo.PrivateData.PSData.Prerelease) {
+        if ($PreReleaseTag = $ModuleInfo.PrivateData.PSData.Prerelease)
+        {
             $ModuleVersion = $ModuleInfo.ModuleVersion + "-" + $PreReleaseTag
         }
-        else {
+        else
+        {
             $ModuleVersion = $ModuleInfo.ModuleVersion
         }
     }
-    else {
+    else
+    {
         # Remove metadata from ModuleVersion
         $ModuleVersion, $BuildMetadata = $ModuleVersion -split '\+', 2
         # Remove Prerelease tag from ModuleVersionFolder
@@ -91,7 +102,8 @@ task Create_changelog_release_output {
     }
 
     # Parse the Changelog and extract unreleased
-    try {
+    try
+    {
         Import-Module ChangelogManagement -ErrorAction Stop
 
         # Update the source changelog file
@@ -100,37 +112,52 @@ task Create_changelog_release_output {
         # Create a ReleaseNotes from the Updated changelog
         ConvertFrom-Changelog -Path $ChangeLogOutputPath -Format Release -NoHeader -OutputPath $ReleaseNotesPath -ErrorAction Stop
     }
-    catch {
+    catch
+    {
         Write-Build Red "Error creating the Changelog Output and/or ReleaseNotes. $($_.Exception.Message)"
     }
 
-    if (-not ($ReleaseNotes = (Get-Content -raw $ReleaseNotesPath -ErrorAction SilentlyContinue))) {
+    if (-not ($ReleaseNotes = (Get-Content -raw $ReleaseNotesPath -ErrorAction SilentlyContinue)))
+    {
         $ReleaseNotes = Get-Content -raw $ChangeLogOutputPath -ErrorAction SilentlyContinue
     }
 
-    if ((Test-Path "$OutputDirectory/$ProjectName/*/$ProjectName.psd1" -ErrorAction SilentlyContinue) -and $ReleaseNotes) {
-        try {
+    if ((Test-Path "$OutputDirectory/$ProjectName/*/$ProjectName.psd1" -ErrorAction SilentlyContinue) -and $ReleaseNotes)
+    {
+        try
+        {
             Import-Module Configuration -ErrorAction Stop
         }
-        catch {
+        catch
+        {
             Write-Build Red "Issue importing Configuration module. $($_.Exception.Message)"
             return
         }
 
         # find Module manifest
         $BuiltModuleManifest = (Get-ChildItem (Join-Path $OutputDirectory $ProjectName) -Depth 2 -Filter "$ProjectName.psd1").FullName |
-            Where-Object { try {
+            Where-Object {
+                try
+                {
                     Test-ModuleManifest -ErrorAction Stop -Path $_
                 }
-                catch {
+                catch
+                {
+                    Write-Warning $_
                     $false
-                } }
+                }
+            }
+        if (-not $BuildModuleManifest)
+        {
+            throw "No valid manifest found for project $ProjectName."
+        }
         Write-Build DarkGray "Built Manifest $BuiltModuleManifest"
-        $null = Test-ModuleManifest $BuiltModuleManifest -ErrorAction Stop
+        # No need to test the manifest again here, because the pipeline tested all manifests via the where-clause already
 
         # Uncomment release notes (the default in Plaster/New-ModuleManifest)
         $ManifestString = Get-Content -raw $BuiltModuleManifest
-        if ( $ManifestString -match '#\sReleaseNotes\s?=') {
+        if ( $ManifestString -match '#\sReleaseNotes\s?=')
+        {
             $ManifestString = $ManifestString -replace '#\sReleaseNotes\s?=', '  ReleaseNotes ='
             $Utf8NoBomEncoding = [System.Text.UTF8Encoding]::new($False)
             [System.IO.File]::WriteAllLines($BuiltModuleManifest, $ManifestString, $Utf8NoBomEncoding)
@@ -148,16 +175,20 @@ task Create_changelog_release_output {
 }
 
 task publish_nupkg_to_gallery -if ((Get-Command nuget -ErrorAction SilentlyContinue) -and $GalleryApiToken) {
-    if ([String]::IsNullOrEmpty($ModuleVersion)) {
+    if ([String]::IsNullOrEmpty($ModuleVersion))
+    {
         $ModuleInfo = Import-PowerShellDataFile "$OutputDirectory/$ProjectName/*/$ProjectName.psd1" -ErrorAction Stop
-        if ($PreReleaseTag = $ModuleInfo.PrivateData.PSData.Prerelease) {
+        if ($PreReleaseTag = $ModuleInfo.PrivateData.PSData.Prerelease)
+        {
             $ModuleVersion = $ModuleInfo.ModuleVersion + "-" + $PreReleaseTag
         }
-        else {
+        else
+        {
             $ModuleVersion = $ModuleInfo.ModuleVersion
         }
     }
-    else {
+    else
+    {
         # Remove metadata from ModuleVersion
         $ModuleVersion, $BuildMetadata = $ModuleVersion -split '\+', 2
         # Remove Prerelease tag from ModuleVersionFolder
@@ -169,7 +200,8 @@ task publish_nupkg_to_gallery -if ((Get-Command nuget -ErrorAction SilentlyConti
     $ReleaseTag = "v$PSModuleVersion"
 
     Write-Build DarkGray "About to release $PackageToRelease"
-    if (!$SkipPublish) {
+    if (!$SkipPublish)
+    {
         $response = &nuget push $PackageToRelease -source $nugetPublishSource -ApiKey $GalleryApiToken
     }
     Write-Build Green "Response = " + $response
@@ -190,30 +222,44 @@ task package_module_nupkg {
     $null = Register-PSRepository @RepositoryParams
 
     # Cleaning up existing packaged module
-    if ($ModuleToRemove = Get-ChildItem (Join-Path $OutputDirectory "$ProjectName.*.nupkg")) {
+    if ($ModuleToRemove = Get-ChildItem (Join-Path $OutputDirectory "$ProjectName.*.nupkg"))
+    {
         Write-Build DarkGray "  Remove existing $ProjectName package"
         Remove-Item -force -Path $ModuleToRemove -ErrorAction Stop
     }
 
     # find Module manifest
     $BuiltModuleManifest = (Get-ChildItem (Join-Path $OutputDirectory $ProjectName) -Depth 2 -Filter "$ProjectName.psd1").FullName |
-        Where-Object { try {
+        Where-Object {
+            try
+            {
                 Test-ModuleManifest -ErrorAction Stop -Path $_
             }
-            catch {
+            catch
+            {
+                Write-Warning $_
                 $false
-            } }
+            }
+        }
+
+    if (-not $BuildModuleManifest)
+    {
+        throw "No valid manifest found for project $ProjectName."
+    }
     Write-Build DarkGray "  Built module's Manifest found at $BuiltModuleManifest"
 
     # load module manifest
     $ModuleInfo = Import-PowerShellDataFile -Path $BuiltModuleManifest
 
     # Publish dependencies (from environment) so we can publish the built module
-    foreach ($module in $ModuleInfo.RequiredModules) {
-        if (!([Microsoft.PowerShell.Commands.ModuleSpecification]$module | Find-Module -repository output -ErrorAction SilentlyContinue)) {
+    foreach ($module in $ModuleInfo.RequiredModules)
+    {
+        if (!([Microsoft.PowerShell.Commands.ModuleSpecification]$module | Find-Module -repository output -ErrorAction SilentlyContinue))
+        {
             # Replace the module by first (path & version) resolved in PSModulePath
             $module = Get-Module -ListAvailable -FullyQualifiedName $module | Select-Object -First 1
-            if ($Prerelease = $module.PrivateData.PSData.Prerelease) {
+            if ($Prerelease = $module.PrivateData.PSData.Prerelease)
+            {
                 $Prerelease = "-" + $Prerelease
             }
             Write-Build Yellow ("  Packaging Required Module {0} v{1}{2}" -f $Module.Name, $Module.Version.ToString(), $Prerelease)
@@ -235,32 +281,45 @@ task package_module_nupkg {
 }
 
 task publish_module_to_gallery -if ((!(Get-Command nuget -ErrorAction SilentlyContinue)) -and $GalleryApiToken) {
-    if (!(Split-Path $OutputDirectory -IsAbsolute)) {
+    if (!(Split-Path $OutputDirectory -IsAbsolute))
+    {
         $OutputDirectory = Join-Path $BuildRoot $OutputDirectory
     }
 
-    if (!(Split-Path -isAbsolute $ReleaseNotesPath)) {
+    if (!(Split-Path -isAbsolute $ReleaseNotesPath))
+    {
         $ReleaseNotesPath = Join-Path $OutputDirectory $ReleaseNotesPath
     }
 
     # Retrieving ReleaseNotes or defaulting to Updated ChangeLog
-    if (-not ($ReleaseNotes = (Get-Content -raw $ReleaseNotesPath -ErrorAction SilentlyContinue))) {
+    if (-not ($ReleaseNotes = (Get-Content -raw $ReleaseNotesPath -ErrorAction SilentlyContinue)))
+    {
         $ReleaseNotes = Get-Content -raw $ChangeLogPath -ErrorAction SilentlyContinue
     }
 
     # find Module manifest
     $BuiltModuleManifest = (Get-ChildItem (Join-Path $OutputDirectory $ProjectName) -Depth 2 -Filter "$ProjectName.psd1").FullName |
-        Where-Object { try {
+        Where-Object {
+            try
+            {
                 Test-ModuleManifest -ErrorAction Stop -Path $_
             }
-            catch {
+            catch
+            {
+                Write-Warning $_
                 $false
-            } }
-    $null = Test-ModuleManifest $BuiltModuleManifest -ErrorAction Stop
+            }
+        }
+    # No need to test the manifest again here, because the pipeline tested all manifests via the where-clause already
+    if (-not $BuildModuleManifest)
+    {
+        throw "No valid manifest found for project $ProjectName."
+    }
 
     # Uncomment release notes (the default in Plaster/New-ModuleManifest)
     $ManifestString = Get-Content -raw $BuiltModuleManifest
-    if ( $ManifestString -match '#\sReleaseNotes\s?=') {
+    if ( $ManifestString -match '#\sReleaseNotes\s?=')
+    {
         $ManifestString = $ManifestString -replace '#\sReleaseNotes\s?=', '  ReleaseNotes ='
         $Utf8NoBomEncoding = [System.Text.UTF8Encoding]::new($False)
         [System.IO.File]::WriteAllLines($BuiltModuleManifest, $ManifestString, $Utf8NoBomEncoding)
@@ -273,10 +332,12 @@ task publish_module_to_gallery -if ((!(Get-Command nuget -ErrorAction SilentlyCo
         ErrorAction  = 'Stop'
     }
 
-    try {
+    try
+    {
         Update-Manifest @UpdateReleaseNotesParams
     }
-    catch {
+    catch
+    {
         Write-Build Red "Error updating the Release notes to Module manifest. $($_.Exception.Message)"
     }
 
@@ -291,7 +352,8 @@ task publish_module_to_gallery -if ((!(Get-Command nuget -ErrorAction SilentlyCo
         ErrorAction  = 'Stop'
         releaseNotes = $ReleaseNotes
     }
-    if (!$SkipPublish) {
+    if (!$SkipPublish)
+    {
         Publish-Module @PublishModuleParams
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added warning messages to all build task if the task couldn't be imported because of an invalid PSD1 file
+
 ## [0.99.4] - 2020-01-22
 
 ### Changed


### PR DESCRIPTION
# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Prepend the title with the [DscResourceName] if your PR is specific to a DSC resource.
    Also prepend with [BREAKING CHANGE] if relevant.
    i.e. [BREAKING CHANGE][xFile] Add security descriptor property

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.
-->

## Pull Request (PR) description

This PR contains changes to all build task so that the user receives an appropriate error (warning) message, when the build tasks couldn't be loaded because calls to `Test-ModuleManifest`  are failing.

**Background:** I spend almost 4 hours of debugging why a module cant' be built with the Sampler infrastructure, because the error message `ERROR: Missing property 'Projectname'` constantly popped up.

![image](https://user-images.githubusercontent.com/14177833/73123077-0cbe7080-3f8c-11ea-9c68-c753c8e0dfdc.png)

Finally I discovered that I missed to add a couple of dependent modules to `RequiredModules.psd1` which let the  `Test-ModuleManifest` constantly fail on the module's `*.psd1` file, which will ultimately fail to evaluate the expression for the `ProjectName` property in the build tasks `param` specification. 

```Powershell
[Parameter()]
    [string]
    $ProjectName = (property ProjectName $(
            #Find the module manifest to deduce the Project Name
            (Get-ChildItem $BuildRoot\*\*.psd1 | Where-Object {
                    ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
                    $(try
                        {
                            Test-ModuleManifest $_.FullName -ErrorAction Stop
                        }
                        catch
                        {
                            $false
                        }) }
            ).BaseName
        )
    ),
```

As stated the PR changes the build tasks in a way that a meaningful error (warning) message is provided to the user:

![image](https://user-images.githubusercontent.com/14177833/73123208-cb2ec500-3f8d-11ea-926d-010f03ecbe32.png)

<!--
    Replace this comment block with a description of your PR to provide context.
    Please be describe the intent and link issue where the problem has been discussed.
    try to link the issue that it fixes by providing the verb and ref: [fix|close #18]

    After the description, please concisely list the changes as per keepachangelog.com
    This **should** duplicate what you've updated in the changelog file.

### Added
- for new features [closes #15]
### Changed
- for changes in existing functionality.
### Deprecated
- for soon-to-be removed features.
### Security
- in case of vulnerabilities.
### Fixed
- for any bug fixes. [fix #52]
### Removed
- for now removed features.
-->

### Changed
- implementation of all build task in `.build` directory

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [ ] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
