### PR TITLE
Enhancement: Build config file will now be dynamically determined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-  `build.ps1` will now dynamically determine the build configuration if not specified via the `-BuildConfig` parameter
+
 ## [0.99.4] - 2020-01-22
 
 ### Changed

--- a/build.ps1
+++ b/build.ps1
@@ -18,7 +18,7 @@ param
     [validateScript(
         { Test-Path -Path $_ }
     )]
-    $BuildConfig = './build.yaml',
+    $BuildConfig,
 
     [Parameter()]
     # A Specific folder to build the artefact into.
@@ -222,6 +222,22 @@ process
 
 Begin
 {
+    # Find build config if not specified
+    if (-not $BuildConfig) {
+        $config = Get-ChildItem -Path "$PSScriptRoot\*" -Include 'build.y*ml', 'build.psd1', 'build.json*' -ErrorAction:Ignore
+        if (-not $config -or ($config -is [array] -and $config.Length -le 0)) {
+            throw "No build configuration found. Specify path via -BuildConfig"
+        }
+        elseif ($config -is [array]) {
+            if ($config.Length -gt 1) {
+                throw "More than one build configuration found. Specify which one to use via -BuildConfig"
+            }
+            $BuildConfig = $config[0]
+        }
+        else {
+            $BuildConfig = $config
+        }
+    }
     # Bootstrapping the environment before using Invoke-Build as task runner
 
     if ($MyInvocation.ScriptName -notLike '*Invoke-Build.ps1')


### PR DESCRIPTION
# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Prepend the title with the [DscResourceName] if your PR is specific to a DSC resource.
    Also prepend with [BREAKING CHANGE] if relevant.
    i.e. [BREAKING CHANGE][xFile] Add security descriptor property

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.
-->

## Pull Request (PR) description

<!--
    Replace this comment block with a description of your PR to provide context.
    Please be describe the intent and link issue where the problem has been discussed.
    try to link the issue that it fixes by providing the verb and ref: [fix|close #18]

    After the description, please concisely list the changes as per keepachangelog.com
    This **should** duplicate what you've updated in the changelog file.

The PR contains a change to `build.ps1` make the `-BuildConfig` really optional. If no file is specified via the `-BuildConfig` parameter the `build.ps1` will try to locate the build configuration dynamically by a filter (globbing) to `Get-Item`.  

### Added
- for new features [closes #15]
### Changed
- for changes in existing functionality.
### Deprecated
- for soon-to-be removed features.
### Security
- in case of vulnerabilities.
### Fixed
- for any bug fixes. [fix #52]
### Removed
- for now removed features.
-->

### Changed
- `build.ps1` will now dynamically determine the build configuration if not specified via the `-BuildConfig` parameter

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [ ] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
