### PR TITLE
New task: Merge JaCoCo code coverage files

### DIFF
--- a/.build/tasks/Common.Functions.ps1
+++ b/.build/tasks/Common.Functions.ps1
@@ -209,3 +209,345 @@ function Get-CodeCoverageOutputFileEncoding
 
     return $codeCoverageOutputFileEncoding
 }
+
+function Merge-JaCoCoReports
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlDocument]
+        $OriginalDocument,
+
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlDocument]
+        $MergeDocument
+    )
+
+    foreach ($mPackage in $MergeDocument.report.package)
+    {
+        Write-Verbose "  Processing package: $($mPackage.Name)"
+        $oPackage = $OriginalDocument.report.package | Where-Object { $_.Name -eq $mPackage.Name }
+
+        foreach ($mSourcefile in $mPackage.sourcefile)
+        {
+            Write-Verbose "    Processing sourcefile: $($mSourcefile.Name)"
+            if ($null -ne $oPackage)
+            {
+                foreach ($mPackageLine in $mSourcefile.line)
+                {
+                    $oSourcefile = $oPackage.sourcefile | Where-Object { $_.name -eq $mSourcefile.name }
+                    $oPackageLine = $oSourcefile.line | Where-Object { $_.nr -eq $mPackageLine.nr }
+
+                    if ($null -eq $oPackageLine)
+                    {
+                        # Missed line in origin, covered in merge
+                        Write-Verbose "      Adding line: $($mPackageLine.nr)"
+                        $null = $oPackage.sourcefile.AppendChild($oPackage.sourcefile.OwnerDocument.ImportNode($mPackageLine, $true))
+                        continue
+                    }
+
+                    if (($oPackageLine.ci -eq 0) -and ($oPackageLine.mi -ne 0) -and `
+                        ($mPackageLine.ci -ne 0) -and ($mPackageLine.mi -eq 0))
+                    {
+                        # Missed line in origin, covered in merge
+                        Write-Verbose "      Updating missed line: $($mPackageLine.nr)"
+                        $oPackageLine.ci = $mPackageLine.ci
+                        $oPackageLine.mi = $mPackageLine.mi
+                        continue
+                    }
+
+                    if ($oPackageLine.ci -lt $mPackageLine.ci)
+                    {
+                        # Missed line in origin, covered in merge
+                        Write-Verbose "      Updating line: $($mPackageLine.nr)"
+                        $oPackageLine.ci = $mPackageLine.ci
+                        $oPackageLine.mi = $mPackageLine.mi
+                        continue
+                    }
+                }
+            }
+            else
+            {
+                # New package, does not exist in origin. Add package.
+                Write-Verbose "    Package '$($mPackage.Name)' does not exist in original file. Adding..."
+                foreach($xmlElement in $OriginalDocument.report)
+                {
+                    if ($xmlElement -is [System.Xml.XmlElement])
+                    {
+                        $null = $xmlElement.AppendChild($OriginalDocument.report.OwnerDocument.ImportNode($mPackage, $true))
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    return $OriginalDocument
+}
+
+function Update-JaCoCoStatistics
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlDocument]
+        $Document
+    )
+
+    Write-Verbose "Start updating statistics!"
+
+    $totalInstructionCovered = 0
+    $totalInstructionMissed = 0
+    $totalLineCovered = 0
+    $totalLineMissed = 0
+    $totalMethodCovered = 0
+    $totalMethodMissed = 0
+    $totalClassCovered = 0
+    $totalClassMissed = 0
+
+    foreach ($oPackage in $Document.report.package)
+    {
+        Write-Verbose "Processing package $($oPackage.name)"
+
+        $packageInstructionCovered = 0
+        $packageInstructionMissed = 0
+        $packageLineCovered = 0
+        $packageLineMissed = 0
+        $packageMethodCovered = 0
+        $packageMethodMissed = 0
+        $packageClassCovered = 0
+        $packageClassMissed = 0
+
+        foreach ($oPackageClass in $oPackage.class)
+        {
+            $classInstructionCovered = 0
+            $classInstructionMissed = 0
+            $classLineCovered = 0
+            $classLineMissed = 0
+            $classMethodCovered = 0
+            $classMethodMissed = 0
+
+            Write-Verbose "  Processing sourcefile $($oPackageClass.sourcefilename)"
+            $oPackageSourcefile = $oPackage.sourcefile | Where-Object -FilterScript { $_.Name -eq $oPackageClass.sourcefilename }
+
+            $oneMethodProcessed = $false
+            for ($i = 0; $i -lt ([array]($oPackageClass.method)).Count; $i++)
+            {
+                $methodInstructionCovered = 0
+                $methodInstructionMissed = 0
+                $methodLineCovered = 0
+                $methodLineMissed = 0
+                $methodCovered = 0
+                $methodMissed = 0
+
+                $currentMethod = [array]$oPackageClass.method
+                $start = $currentMethod[$i].line
+                if ($i -ne ($currentMethod.Count - 1))
+                {
+                    $end   = $currentMethod[$i+1].Line
+                    Write-Verbose "    Processing method: $($currentMethod[$i].Name)"
+                    [array]$coll = $oPackageSourcefile.line | Where-Object {
+                        [int]$_.nr -ge $start -and [int]$_.nr -lt $end
+                    }
+
+                    foreach ($line in $coll)
+                    {
+                        $methodInstructionCovered += $line.ci
+                        $methodInstructionMissed += $line.mi
+                    }
+                    [array]$cov = $coll | Where-Object -FilterScript { $_.ci -ne "0" }
+                    $methodLineCovered = $cov.Count
+                    [array]$mis = $coll | Where-Object -FilterScript { $_.ci -eq "0" }
+                    $methodLineMissed = $mis.Count
+                }
+                else
+                {
+                    Write-Verbose "    Processing method: $($currentMethod[$i].Name)"
+                    [array]$coll = $oPackageSourcefile.line | Where-Object {
+                        [int]$_.nr -ge $start
+                    }
+
+                    foreach ($line in $coll)
+                    {
+                        $methodInstructionCovered += $line.ci
+                        $methodInstructionMissed += $line.mi
+                    }
+
+                    [array]$cov = $coll | Where-Object -FilterScript { $_.ci -ne "0" }
+                    $methodLineCovered = $cov.Count
+                    [array]$mis = $coll | Where-Object -FilterScript { $_.ci -eq "0" }
+                    $methodLineMissed = $mis.Count
+                }
+
+                $classInstructionCovered += $methodInstructionCovered
+                $classInstructionMissed += $methodInstructionMissed
+                $classLineCovered += $methodLineCovered
+                $classLineMissed += $methodLineMissed
+                if ($methodInstructionCovered -ne 0)
+                {
+                    $methodCovered = 1
+                    $methodMissed = 0
+                    $classMethodCovered++
+                }
+                else
+                {
+                    $methodCovered = 0
+                    $methodMissed = 1
+                    $classMethodMissed++
+                }
+                if ($currentMethod[$i].Name -ne '<script>' -and $methodMissed -eq 0)
+                {
+                    $oneMethodProcessed = $true
+                }
+
+                # Update Method stats
+                $counterInstruction = $currentMethod[$i].counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+                $counterInstruction.covered = [string]$methodInstructionCovered
+                $counterInstruction.missed = [string]$methodInstructionMissed
+
+                $counterLine = $currentMethod[$i].counter | Where-Object { $_.type -eq 'LINE' }
+                $counterLine.covered = [string]$methodLineCovered
+                $counterLine.missed = [string]$methodLineMissed
+
+                $counterMethod = $currentMethod[$i].counter | Where-Object { $_.type -eq 'METHOD' }
+                $counterMethod.covered = [string]$methodCovered
+                $counterMethod.missed = [string]$methodMissed
+
+
+                Write-Verbose "      Method Instruction Covered : $methodInstructionCovered"
+                Write-Verbose "      Method Instruction Missed  : $methodInstructionMissed"
+                Write-Verbose "      Method Line Covered        : $methodLineCovered"
+                Write-Verbose "      Method Line Missed         : $methodLineMissed"
+                Write-Verbose "      Method Covered             : $methodCovered"
+                Write-Verbose "      Method Missed              : $methodMissed"
+            }
+
+            $packageInstructionCovered += $classInstructionCovered
+            $packageInstructionMissed += $classInstructionMissed
+            $packageLineCovered += $classLineCovered
+            $packageLineMissed += $classLineMissed
+            $packageMethodCovered += $classMethodCovered
+            $packageMethodMissed += $classMethodMissed
+            if ($oneMethodProcessed -eq $true)
+            {
+                $packageClassCovered++
+                $classClassCovered = 1
+                $classClassMissed = 0
+            }
+            else
+            {
+                $classClassCovered = 0
+                $classClassMissed = 1
+            }
+
+            # Update Class stats
+            $counterInstruction = $oPackageClass.counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+            $counterInstruction.covered = [string]$classInstructionCovered
+            $counterInstruction.missed = [string]$classInstructionMissed
+
+            $counterLine = $oPackageClass.counter | Where-Object { $_.type -eq 'LINE' }
+            $counterLine.covered = [string]$classLineCovered
+            $counterLine.missed = [string]$classLineMissed
+
+            $counterMethod = $oPackageClass.counter | Where-Object { $_.type -eq 'METHOD' }
+            $counterMethod.covered = [string]$classMethodCovered
+            $counterMethod.missed = [string]$classMethodMissed
+
+            $counterMethod = $oPackageClass.counter | Where-Object { $_.type -eq 'CLASS' }
+            $counterMethod.covered = [string]$classClassCovered
+            $counterMethod.missed = [string]$classClassMissed
+
+            # Update Sourcefile stats
+            $counterInstruction = $oPackageSourcefile.counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+            $counterInstruction.covered = [string]$classInstructionCovered
+            $counterInstruction.missed = [string]$classInstructionMissed
+
+            $counterLine = $oPackageSourcefile.counter | Where-Object { $_.type -eq 'LINE' }
+            $counterLine.covered = [string]$classLineCovered
+            $counterLine.missed = [string]$classLineMissed
+
+            $counterMethod = $oPackageSourcefile.counter | Where-Object { $_.type -eq 'METHOD' }
+            $counterMethod.covered = [string]$classMethodCovered
+            $counterMethod.missed = [string]$classMethodMissed
+
+            $counterMethod = $oPackageSourcefile.counter | Where-Object { $_.type -eq 'CLASS' }
+            $counterMethod.covered = [string]$classClassCovered
+            $counterMethod.missed = [string]$classClassMissed
+
+            Write-Verbose "      Class Instruction Covered  : $classInstructionCovered"
+            Write-Verbose "      Class Instruction Missed   : $classInstructionMissed"
+            Write-Verbose "      Class Line Covered         : $classLineCovered"
+            Write-Verbose "      Class Line Missed          : $classLineMissed"
+            Write-Verbose "      Class Method Covered       : $classMethodCovered"
+            Write-Verbose "      Class Method Missed        : $classMethodMissed"
+        }
+        $totalInstructionCovered += $packageInstructionCovered
+        $totalInstructionMissed += $packageInstructionMissed
+        $totalLineCovered += $packageLineCovered
+        $totalLineMissed += $packageLineMissed
+        $totalMethodCovered += $packageMethodCovered
+        $totalMethodMissed += $packageMethodMissed
+        $totalClassCovered += $packageClassCovered
+        $totalClassMissed += $packageClassMissed
+
+        # Update Package stats
+        $counterInstruction = $oPackage.counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+        $counterInstruction.covered = [string]$packageInstructionCovered
+        $counterInstruction.missed = [string]$packageInstructionMissed
+
+        $counterLine = $oPackage.counter | Where-Object { $_.type -eq 'LINE' }
+        $counterLine.covered = [string]$packageLineCovered
+        $counterLine.missed = [string]$packageLineMissed
+
+        $counterMethod = $oPackage.counter | Where-Object { $_.type -eq 'METHOD' }
+        $counterMethod.covered = [string]$packageMethodCovered
+        $counterMethod.missed = [string]$packageMethodMissed
+
+        $counterClass = $oPackage.counter | Where-Object { $_.type -eq 'CLASS' }
+        $counterClass.covered = [string]$packageClassCovered
+        $counterClass.missed = [string]$packageClassMissed
+
+        Write-Verbose "  Package Instruction Covered: $packageInstructionCovered"
+        Write-Verbose "  Package Instruction Missed : $packageInstructionMissed"
+        Write-Verbose "  Package Line Covered       : $packageLineCovered"
+        Write-Verbose "  Package Line Missed        : $packageLineMissed"
+        Write-Verbose "  Package Method Covered     : $packageMethodCovered"
+        Write-Verbose "  Package Method Missed      : $packageMethodMissed"
+        Write-Verbose "  Package Class Covered      : $packageClassCovered"
+        Write-Verbose "  Package Class Missed       : $packageClassMissed"
+    }
+
+    #Update Total stats
+    $counterInstruction = $Document.report.counter | Where-Object { $_.type -eq 'INSTRUCTION' }
+    $counterInstruction.covered = [string]$totalInstructionCovered
+    $counterInstruction.missed = [string]$totalInstructionMissed
+
+    $counterLine = $Document.report.counter | Where-Object { $_.type -eq 'LINE' }
+    $counterLine.covered = [string]$totalLineCovered
+    $counterLine.missed = [string]$totalLineMissed
+
+    $counterMethod = $Document.report.counter | Where-Object { $_.type -eq 'METHOD' }
+    $counterMethod.covered = [string]$totalMethodCovered
+    $counterMethod.missed = [string]$totalMethodMissed
+
+    $counterClass = $Document.report.counter | Where-Object { $_.type -eq 'CLASS' }
+    $counterClass.covered = [string]$totalClassCovered
+    $counterClass.missed = [string]$totalClassMissed
+
+    Write-Verbose "----------------------------------------"
+    Write-Verbose " Totals"
+    Write-Verbose "----------------------------------------"
+    Write-Verbose "  Total Instruction Covered : $totalInstructionCovered"
+    Write-Verbose "  Total Instruction Missed  : $totalInstructionMissed"
+    Write-Verbose "  Total Line Covered        : $totalLineCovered"
+    Write-Verbose "  Total Line Missed         : $totalLineMissed"
+    Write-Verbose "  Total Method Covered      : $totalMethodCovered"
+    Write-Verbose "  Total Method Missed       : $totalMethodMissed"
+    Write-Verbose "  Total Class Covered       : $totalClassCovered"
+    Write-Verbose "  Total Class Missed        : $totalClassMissed"
+    Write-Verbose "----------------------------------------"
+
+    Write-Verbose "Completed merging files and updating statistics!"
+
+    return $Document
+}

--- a/.build/tasks/Merge-CodeCoverageFiles.pester.build.ps1
+++ b/.build/tasks/Merge-CodeCoverageFiles.pester.build.ps1
@@ -63,8 +63,6 @@ task Merge_CodeCoverage_Files {
         $CodeCovOutputFile = $BuildInfo.Pester.CodeCoverageMergedOutputFile
     }
 
-Write-Build Yellow $CodeCovOutputFile
-
     $targetFile = Join-Path -Path $OutputDirectory -ChildPath $CodeCovOutputFile
 
     if (Test-Path -Path $targetFile)

--- a/.build/tasks/Merge-CodeCoverageFiles.pester.build.ps1
+++ b/.build/tasks/Merge-CodeCoverageFiles.pester.build.ps1
@@ -1,0 +1,141 @@
+Param (
+    # Project path
+    [Parameter()]
+    [string]
+    $ProjectPath = (property ProjectPath $BuildRoot),
+
+    [Parameter()]
+    # Base directory of all output (default to 'output')
+    [string]
+    $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot 'output')),
+
+    [Parameter()]
+    [string]
+    $ProjectName = (property ProjectName $(
+            (Get-ChildItem $BuildRoot\*\*.psd1 -Exclude 'build.psd1', 'analyzersettings.psd1' | Where-Object {
+                    ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+                    $(try
+                        {
+                            Test-ModuleManifest $_.FullName -ErrorAction Stop
+                        }
+                        catch
+                        {
+                            Write-Warning $_
+                            $false
+                        }) }
+            ).BaseName
+        )
+    ),
+
+    [Parameter()]
+    [string]
+    $ModuleVersion = (property ModuleVersion $(
+            try
+            {
+                (gitversion | ConvertFrom-Json -ErrorAction Stop).InformationalVersion
+            }
+            catch
+            {
+                Write-Verbose "Error attempting to use GitVersion $($_)"
+                ''
+            }
+        )),
+
+    # Build Configuration object
+    [Parameter()]
+    $BuildInfo = (property BuildInfo @{ })
+)
+
+. $PSScriptRoot/Common.Functions.ps1
+
+# Synopsis: Making sure the Module meets some quality standard (help, tests).
+task Merge_CodeCoverage_Files {
+    if (!(Split-Path -isAbsolute $OutputDirectory))
+    {
+        $OutputDirectory = Join-Path -Path $ProjectPath -ChildPath $OutputDirectory
+        Write-Build Yellow "Absolute path to Output Directory is $OutputDirectory"
+    }
+
+    $CodeCovOutputFile = "CodeCov_Merged.xml"
+    if ($BuildInfo.ContainsKey("Pester") -eq $true -and
+        $BuildInfo.Pester.ContainsKey("CodeCoverageMergedOutputFile") -eq $true)
+    {
+        $CodeCovOutputFile = $BuildInfo.Pester.CodeCoverageMergedOutputFile
+    }
+
+Write-Build Yellow $CodeCovOutputFile
+
+    $targetFile = Join-Path -Path $OutputDirectory -ChildPath $CodeCovOutputFile
+
+    if (Test-Path -Path $targetFile)
+    {
+        Write-Build Yellow "File $targetFile found, deleting file"
+        Remove-Item -Path $targetFile -Force
+    }
+
+    Write-Build White "Processing folder: $OutputDirectory"
+
+    $codecovFiles = Get-ChildItem -Path $OutputDirectory -Include 'codecov*.xml' -Recurse
+
+    if ($codecovFiles.Count -gt 1)
+    {
+        $firstFile = $codecovFiles | Select-Object -First 1
+        $otherFiles = $codecovFiles | Select-Object -Skip 1
+
+        Write-Build DarkGray "Started merging $($codecovFiles.Count) code coverage files!"
+        [xml]$targetDocument = Get-Content $firstFile.FullName
+
+        if (Validate-CodeCoverageFileFormat -CodeCovFile $targetDocument)
+        {
+            Write-Build DarkGray "Successfully imported $($firstFile.Name) as a baseline"
+
+            $merged = 0
+            foreach ($file in $otherFiles)
+            {
+                [xml]$mergeDocument = Get-Content $file.FullName
+                Write-Build DarkGray "Merging $($file.Name) into baseline"
+                if (Validate-CodeCoverageFileFormat -CodeCovFile $mergeDocument)
+                {
+                    $targetDocument = Merge-JaCoCoReports -OriginalDocument $targetDocument -MergeDocument $mergeDocument
+                    $merged++
+                }
+                else
+                {
+                    Write-Build DarkGray "The following code coverage file is not using the JaCoCo format: $($file.Name)"
+                }
+            }
+            Write-Build DarkGray "Merge completed: Successfully merged $merged files into the baseline"
+
+            $targetDocument = Update-JaCoCoStatistics -Document $targetDocument
+
+            $fullTargetFilePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($targetFile)
+            $targetDocument.Save($fullTargetFilePath)
+        }
+        else
+        {
+            throw "The following code coverage file is not using the JaCoCo format: $($firstFile.Name)"
+        }
+    }
+    else
+    {
+        throw "Found $($codecovFiles.Count) code coverage file. Need at least two files to merge."
+    }
+}
+
+function Validate-CodeCoverageFileFormat
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlDocument]
+        $CodeCovFile
+    )
+
+    $report = ($CodeCovFile.GetEnumerator() | Where-Object -FilterScript { $_.Name -eq "Report"})
+    if ($null -ne $report -and $report.OuterXml -like "*JACOCO*")
+    {
+        return $true
+    }
+
+    return $false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the functionality to merge multiple JaCoCo code coverage files into one file.
+
 ## [0.101.0] - 2020-02-10
 
 ### Changed

--- a/Sampler/Assets/build.yaml.template
+++ b/Sampler/Assets/build.yaml.template
@@ -69,6 +69,9 @@ BuildWorkflow:
   test:
     - Pester_Tests_Stop_On_Fail
     - Pester_if_Code_Coverage_Under_Threshold
+    # Use this task when you have multiple parallel tests, which produce multiple
+    # code coverage files and needs to get merged into one file.
+    #- Merge_CodeCoverage_Files
 <%
     if($PLASTER_PARAM_ModuleType -eq 'dsccommunity') {
 "    - hqrmtest"

--- a/Sampler/Assets/build.yaml.template
+++ b/Sampler/Assets/build.yaml.template
@@ -104,6 +104,7 @@ Pester: #Passthru, OutputFile, CodeCoverageOutputFile not supported
   CodeCoverageThreshold: 85 # Set to 0 to bypass
   # CodeCoverageOutputFile: JaCoCo_$OsShortName.xml
   # CodeCoverageOutputFileEncoding: ascii
+  # CodeCoverageMergedOutputFile: JaCoCo_Merged.xml
 <%
     if($PLASTER_PARAM_ModuleType -eq 'dsccommunity') {
 @"


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Added

- Added the functionality to merge multiple JaCoCo code coverage files into one file. [closes #127]

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/128)
<!-- Reviewable:end -->
