### PR TITLE
Link to testing guidelines from Contributing [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
 # Contributing
 
 Please check out common DSC Community [contributing guidelines](https://dsccommunity.org/guidelines/contributing).
+
+## Running the Tests
+
+If want to know how to run this module's tests you can look at the [Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines/#running-tests)


### PR DESCRIPTION
This change adds a link directly to instructions for how to run unit
and integration tests from the CONTRIBUTING.md file. Prior to this
those instructions were not very discoverable, leaving some contributors
to spend a lot of time figuring out how to get automated tests to run
on their local machines before pushing code up for automated testing.

Fixes #136

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/137)
<!-- Reviewable:end -->
