### PR TITLE
Does not export the helper function modules as tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the build task `Build-Module.ModuleBuilder`'s task variables.
 - When there are multiple module manifest found in the repository the build
   now fails with a a better error error message ([issue #155](https://github.com/gaelcolas/Sampler/issues/155)).
+- Now the the module does not export the helper function modules as tasks
+  aliases ([issue #161](https://github.com/gaelcolas/Sampler/issues/161)).
 
 ### Changed
 

--- a/Sampler/suffix.ps1
+++ b/Sampler/suffix.ps1
@@ -1,8 +1,8 @@
 # Inspired from https://github.com/nightroman/Invoke-Build/blob/64f3434e1daa806814852049771f4b7d3ec4d3a3/Tasks/Import/README.md#example-2-import-from-a-module-with-tasks
-Get-ChildItem (Join-Path -Path $PSScriptRoot -ChildPath 'tasks') | ForEach-Object {
-    $ModuleName = ([io.FileInfo]$MyInvocation.MyCommand.Name).BaseName
-    $taskFileAliasName = "$($_.BaseName).$ModuleName.ib.tasks"
-    Set-Alias -Name $taskFileAliasName -Value $_.FullName
-    Export-ModuleMember -Alias $taskFileAliasName
-
-}
+Get-ChildItem (Join-Path -Path $PSScriptRoot -ChildPath 'tasks\*') -Include '*.build.*' |
+    ForEach-Object {
+        $ModuleName = ([IO.FileInfo] $MyInvocation.MyCommand.Name).BaseName
+        $taskFileAliasName = "$($_.BaseName).$ModuleName.ib.tasks"
+        Set-Alias -Name $taskFileAliasName -Value $_.FullName
+        Export-ModuleMember -Alias $taskFileAliasName
+    }


### PR DESCRIPTION
# Pull Request

- Fixes #161 

## Pull Request (PR) description

### Fixed
- Now the the module does not export the helper function modules as tasks
  aliases (issue #161).

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/163)
<!-- Reviewable:end -->
