### PR TITLE
Fix logic for different parameter name for Pester4

### DIFF
--- a/.build/tasks/DscResource.Test.build.ps1
+++ b/.build/tasks/DscResource.Test.build.ps1
@@ -115,7 +115,7 @@ task Invoke_DscResource_Tests {
     {
         if (($paramName -eq 'ExcludeTagFilter' -or $paramName -eq 'TagFilter') -and -not $isPester5)
         {
-            $paramName = ($paramName -split 'Filter')[0]
+            $paramName = $paramName -replace 'Filter'
         }
 
         $taskParamName = "DscTest$paramName"

--- a/.build/tasks/DscResource.Test.build.ps1
+++ b/.build/tasks/DscResource.Test.build.ps1
@@ -149,7 +149,7 @@ task Invoke_DscResource_Tests {
     "`tProject Path      = $ProjectPath"
     "`tProject Name      = $ProjectName"
     "`tTest Scripts      = $($DscTestScript -join ', ')"
-    "`tTags              = $($DscTestTagFilter -join ', ')"
+    "`tTags              = $($DscTestTag -join ', ')"
     "`tExclude Tags      = $($DscTestExcludeTag -join ', ')"
     "`tModuleVersion     = $ModuleVersion"
     "`tBuildModuleOutput = $BuildModuleOutput"

--- a/.build/tasks/DscResource.Test.build.ps1
+++ b/.build/tasks/DscResource.Test.build.ps1
@@ -113,6 +113,11 @@ task Invoke_DscResource_Tests {
     #>
     foreach ($paramName in $dscTestCmd.Parameters.Keys)
     {
+        if (($paramName -eq 'ExcludeTagFilter' -or $paramName -eq 'TagFilter') -and -not $isPester5)
+        {
+            $paramName = ($paramName -Split 'Filter')[0]
+        }
+
         $taskParamName = "DscTest$paramName"
 
         $DscTestBuildConfig = $BuildInfo.DscTest
@@ -144,7 +149,7 @@ task Invoke_DscResource_Tests {
     "`tProject Path      = $ProjectPath"
     "`tProject Name      = $ProjectName"
     "`tTest Scripts      = $($DscTestScript -join ', ')"
-    "`tTags              = $($DscTestTag -join ', ')"
+    "`tTags              = $($DscTestTagFilter -join ', ')"
     "`tExclude Tags      = $($DscTestExcludeTag -join ', ')"
     "`tModuleVersion     = $ModuleVersion"
     "`tBuildModuleOutput = $BuildModuleOutput"

--- a/.build/tasks/DscResource.Test.build.ps1
+++ b/.build/tasks/DscResource.Test.build.ps1
@@ -115,7 +115,7 @@ task Invoke_DscResource_Tests {
     {
         if (($paramName -eq 'ExcludeTagFilter' -or $paramName -eq 'TagFilter') -and -not $isPester5)
         {
-            $paramName = ($paramName -Split 'Filter')[0]
+            $paramName = ($paramName -split 'Filter')[0]
         }
 
         $taskParamName = "DscTest$paramName"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix for Pester 5.0.1 making sure only to use the `Simple` ParameterSet.
 - Fix typo in `DscResource.Test` task.
 - Updated style in `generateHelp.PlatyPS` task.
+- Added fix to support Pester 4 parameters.
 
 ## [0.105.4] - 2020-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added fix to support Pester 4 parameters.
+
 ## [0.105.5] - 2020-05-29
 
 ### Fixed
@@ -14,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix for Pester 5.0.1 making sure only to use the `Simple` ParameterSet.
 - Fix typo in `DscResource.Test` task.
 - Updated style in `generateHelp.PlatyPS` task.
-- Added fix to support Pester 4 parameters.
 
 ## [0.105.4] - 2020-05-29
 


### PR DESCRIPTION
# Pull Request
    TITLE: Add check to change parameter name based on Pester Version

## Pull Request (PR) description
   With updates to support Pester 5 it was not picking up exceptions for Pester4.

### Fixed
- CI/CD was not picking up skipped rules for HQRM tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/178)
<!-- Reviewable:end -->
