### PR TITLE
Issue #182 - add alternate trunk name support

### DIFF
--- a/.build/tasks/New-Release.GitHub.build.ps1
+++ b/.build/tasks/New-Release.GitHub.build.ps1
@@ -129,9 +129,9 @@ task Create_ChangeLog_GitHub_PR -if ($GitHubToken) {
     # git remote add origin https://github.com/gaelcolas/Sampler
     # git config gc.auto 0
     # git config --get-all http.https://github.com/gaelcolas/Sampler.extraheader
-    # git pull origin $MainGitBranch
+    # git @('pull', 'origin', $MainGitBranch)
     # # git fetch --force --tags --prune --progress --no-recurse-submodules origin
-    # # git checkout --progress --force (git rev-parse origin/$MainGitBranch)
+    # # git @('checkout', '--progress', '--force' (git @('rev-parse', "origin/$MainGitBranch")))
 
     foreach ($GitHubConfigKey in @('GitHubFilesToAdd', 'GitHubConfigUserName', 'GitHubConfigUserEmail', 'UpdateChangelogOnPrerelease'))
     {
@@ -144,9 +144,9 @@ task Create_ChangeLog_GitHub_PR -if ($GitHubToken) {
         }
     }
 
-    git pull origin $MainGitBranch --tag
+    git @('pull', 'origin', $MainGitBranch, '--tag')
     # Look at the tags on latest commit for origin/$MainGitBranch (assume we're on detached head)
-    $TagsAtCurrentPoint = git tag -l --points-at (git rev-parse origin/$MainGitBranch)
+    $TagsAtCurrentPoint = git @('tag', '-l', '--points-at', (git @('rev-parse', "origin/$MainGitBranch")))
     # Only Update changelog if last commit is a full release
     if ($UpdateChangelogOnPrerelease)
     {

--- a/.build/tasks/New-Release.GitHub.build.ps1
+++ b/.build/tasks/New-Release.GitHub.build.ps1
@@ -38,7 +38,10 @@ param(
     $BuildInfo = (property BuildInfo @{ }),
 
     [Parameter()]
-    $SkipPublish = (property SkipPublish '')
+    $SkipPublish = (property SkipPublish ''),
+
+    [Parameter()]
+    $MainGitBranch = (property MainGitBranch 'master')
 )
 
 Import-Module -Name "$PSScriptRoot/Common.Functions.psm1"
@@ -126,9 +129,9 @@ task Create_ChangeLog_GitHub_PR -if ($GitHubToken) {
     # git remote add origin https://github.com/gaelcolas/Sampler
     # git config gc.auto 0
     # git config --get-all http.https://github.com/gaelcolas/Sampler.extraheader
-    # git pull origin master
+    # git pull origin $MainGitBranch
     # # git fetch --force --tags --prune --progress --no-recurse-submodules origin
-    # # git checkout --progress --force (git rev-parse origin/master)
+    # # git checkout --progress --force (git rev-parse origin/$MainGitBranch)
 
     foreach ($GitHubConfigKey in @('GitHubFilesToAdd', 'GitHubConfigUserName', 'GitHubConfigUserEmail', 'UpdateChangelogOnPrerelease'))
     {
@@ -141,9 +144,9 @@ task Create_ChangeLog_GitHub_PR -if ($GitHubToken) {
         }
     }
 
-    git pull origin master --tag
-    # Look at the tags on latest commit for origin/master (assume we're on detached head)
-    $TagsAtCurrentPoint = git tag -l --points-at (git rev-parse origin/master)
+    git pull origin $MainGitBranch --tag
+    # Look at the tags on latest commit for origin/$MainGitBranch (assume we're on detached head)
+    $TagsAtCurrentPoint = git tag -l --points-at (git rev-parse origin/$MainGitBranch)
     # Only Update changelog if last commit is a full release
     if ($UpdateChangelogOnPrerelease)
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added integration tests for the Plaster templates
+- Added support to use an alternate name for the trunk branch in
+  `New-Release.GitHub.build.ps1` ([issue #182](https://github.com/gaelcolas/Sampler/issues/182)).
 
 ## [0.105.6] - 2020-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support to use an alternate name for the trunk branch in
   `New-Release.GitHub.build.ps1` ([issue #182](https://github.com/gaelcolas/Sampler/issues/182)).
 
+### Fixed
+
+- Fix `module.tests.ps1` to be able to run locally.
+
 ## [0.105.6] - 2020-06-01
 
 - Added fix to support Pester 4 parameters.

--- a/tests/QA/module.tests.ps1
+++ b/tests/QA/module.tests.ps1
@@ -23,7 +23,7 @@ $allModuleFunctions = &$mut {Get-Command -Module $args[0] -CommandType Function 
             # Get the list of changed files compared with master
             $HeadCommit = &git rev-parse HEAD
             $MasterCommit = &git rev-parse origin/master
-            $filesChanged = &git diff $MasterCommit...$HeadCommit --name-only
+            $filesChanged = &git @('diff', "$MasterCommit...$HeadCommit", '--name-only')
 
             if ($HeadCommit -ne $MasterCommit) { # if we're not testing same commit (i.e. master..master)
                 $filesChanged.Where{ (Split-Path $_ -Leaf) -match '^changelog' } | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
# Pull Request

This PR adds support for specifying an alternate name for the trunk branch. This is expected as a parameter passed in `MainGitBranch` and will default to `master` if not specified.

## Pull Request (PR) description

### Added
- Added support to use an alternate name for the trunk branch in
  `New-Release.GitHub.build.ps1` ([issue #182](https://github.com/gaelcolas/Sampler/issues/182)).

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/183)
<!-- Reviewable:end -->
