### PR TITLE
fixing pushing module using nuget push & packing module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added New-SampleModule command to invoke the template.
 - Added Add-Sample command to invoke component templates
 
+### Fixed
+
+- Fixed pack action & nuget push.
+
 ## [0.106.1] - 2020-08-30
 
 ### Fixed


### PR DESCRIPTION
Attempting to fix the task that pushes the nupkg using Nuget push.
hard to test but it's been failing recently as it looks like nuget command has been added to the AzDO image.

It seems to be a typo issue and also making sure the packing has the right release notes in the PSD1, as we can't "inject" like we do with `Publish-Module`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/194)
<!-- Reviewable:end -->
