### PR TITLE
testing ModuleBuilder 2.0.0-VersionedOutput Prerelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Testing ModuleBuilder v2.0.0-VersionedOutput.
+
 ## [0.108.0] - 2020-09-14
 
 ### Added

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -9,7 +9,16 @@
     PSScriptAnalyzer            = '1.19.0'
     Pester                      = '4.10.1'
     Plaster                     = 'latest'
-    ModuleBuilder               = 'latest'
+    ModuleBuilder               = @{
+        Name = 'ModuleBuilder'
+        DependencyType = 'PSGalleryModule'
+        Parameters = @{
+            AllowPrerelease = $true
+        }
+
+        Version = '2.0.0-VersionedOutput'
+    }
+
     MarkdownLinkCheck           = 'latest'
     ChangelogManagement         = 'latest'
     'DscResource.Test'          = 'latest'


### PR DESCRIPTION
@Jaykul this is a test of ModuleBuilder VersionedOutput.
Locally it worked fine (PS 7.0.3 & WPS on Windows), trying on Unbutu on AzDO now.
Needed 0 changes so I'm happy (if the build works).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/209)
<!-- Reviewable:end -->
