### PR TITLE
Adding task & Sample to build GuestConfig packages

### DIFF
--- a/.build/tasks/GuestConfig.build.ps1
+++ b/.build/tasks/GuestConfig.build.ps1
@@ -174,10 +174,10 @@ task build_guestconfiguration_packages {
 
         "`t`tZipped Guest Config Package: $($ZippedGCPackage.Path)"
 
-        #if we're running on Windows as admin, we can test the package
-        if (!$IsLinux -and [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
+        # If we're running on Windows as admin, we can test the package
+        if (-not $IsLinux -and [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
         {
-            # we ought to test the the package on a purposed-built vm (i.e. with TK)
+            # We ought to test the the package on a purposed-built vm (i.e. with TK)
             Test-GuestConfigurationPackage -Path $ZippedGCPackage.Path -Verbose
         }
         else

--- a/.build/tasks/GuestConfig.build.ps1
+++ b/.build/tasks/GuestConfig.build.ps1
@@ -1,0 +1,190 @@
+param
+(
+    [Parameter()]
+    [System.String]
+    $ProjectName = (property ProjectName ''),
+
+    [Parameter()]
+    [System.String]
+    $SourcePath = (property SourcePath ''),
+
+    [Parameter()]
+    [System.String]
+    $GCPackagesPath = (property GCPackagesPath 'GCPackages'),
+
+    [Parameter()]
+    [System.String]
+    $GCPoliciesPath = (property GCPoliciesPath 'GCPolicies'),
+
+    [Parameter()]
+    [System.String]
+    $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot "output")),
+
+    [Parameter()]
+    [System.String]
+    $BuiltModuleSubdirectory = (property BuiltModuleSubdirectory ''),
+
+    [Parameter()]
+    [System.String]
+    $BuildModuleOutput = (property BuildModuleOutput (Join-Path $OutputDirectory $BuiltModuleSubdirectory)),
+
+    [Parameter()]
+    [System.String]
+    $ReleaseNotesPath = (property ReleaseNotesPath (Join-Path $OutputDirectory 'ReleaseNotes.md')),
+
+    [Parameter()]
+    [System.String]
+    $ModuleVersion = (property ModuleVersion ''),
+
+    [Parameter()]
+    [System.Collections.Hashtable]
+    $BuildInfo = (property BuildInfo @{ })
+)
+
+# SYNOPSIS: Building the Azure Policy Guest Configuration Packages
+task build_guestconfiguration_packages {
+    if ([System.String]::IsNullOrEmpty($ProjectName))
+    {
+        $ProjectName = Get-ProjectName -BuildRoot $BuildRoot
+    }
+
+    if ([System.String]::IsNullOrEmpty($SourcePath))
+    {
+        $SourcePath = Get-SourcePath -BuildRoot $BuildRoot
+    }
+
+    if (-not (Split-Path -IsAbsolute $GCPackagesPath))
+    {
+        $GCPackagesPath = Join-Path -Path $SourcePath -ChildPath $GCPackagesPath
+    }
+
+    if (-not (Split-Path -IsAbsolute $GCPoliciesPath))
+    {
+        $GCPoliciesPath = Join-Path -Path $SourcePath -ChildPath $GCPoliciesPath
+    }
+
+    $moduleManifestPath = "$SourcePath/$ProjectName.psd1"
+
+    $getBuildVersionParameters = @{
+        ModuleManifestPath = $moduleManifestPath
+        ModuleVersion      = $ModuleVersion
+    }
+
+    <#
+        This will get the version from $ModuleVersion if is was set as a parameter
+        or as a property. If $ModuleVersion is $null or an empty string the version
+        will fetched from GitVersion if it is installed. If GitVersion is _not_
+        installed the version is fetched from the module manifest in SourcePath.
+    #>
+    $ModuleVersion = Get-BuildVersion @getBuildVersionParameters
+
+    "`tProject Name         = $ProjectName"
+    "`tModule Version       = $ModuleVersion"
+    "`tSource Path          = $SourcePath"
+    "`tOutput Directory     = $OutputDirectory"
+    "`tBuild Module Output  = $BuildModuleOutput"
+    "`tModule Manifest Path = $moduleManifestPath"
+    "`tGC Packages Path     = $GCPackagesPath"
+    "`t------------------------------------------------`r`n"
+
+    Get-ChildItem -Path $GCPackagesPath -Directory -ErrorAction SilentlyContinue | ForEach-Object -Process {
+        "`t`tPackaging Policy '$($_.Name)'"
+        $GCPackageName = $_.Name
+        $ConfigurationFile = Join-Path -Path $_.FullName -ChildPath "$GCPackageName.config.ps1"
+        $MOFFile = Join-Path -Path $_.FullName -ChildPath "$GCPackageName.mof"
+
+        if (-not (Test-Path -Path $ConfigurationFile) -and -not (Test-Path -Path $MOFFile))
+        {
+            throw "The configuration '$ConfigurationFile' could not be found. Cannot compile MOF for '$GCPackageName' policy Package"
+        }
+
+        if (Test-Path -Path $MOFFile)
+        {
+            "`t`tCreating GC Package from MOF file: '$MOFFile'"
+        }
+        else
+        {
+            "`t`tCreating GC Package from Configuration file: '$ConfigurationFile'"
+            try
+            {
+                $MOFFileAndErrors = &{
+                    . $ConfigurationFile
+                    &$GCPackageName -OutputPath (Join-Path -Path $OutputDirectory -ChildPath 'MOFs') -ErrorAction SilentlyContinue
+                } 2>&1
+
+                $CompilationErrors = @()
+                $MOFFile = $MOFFileAndErrors.Foreach{
+                    if ($_ -isnot [System.Management.Automation.ErrorRecord])
+                    {
+                        $_
+                    }
+                    else
+                    {
+                        $CompilationErrors += $_
+                    }
+                }
+            }
+            catch
+            {
+                throw "Compilation error. $($_.Exception.Message)"
+            }
+        }
+
+        $ZippedGCPackage = (
+            &{
+                $NewGCPackageParams = @{
+                    Configuration = $MOFFile
+                    Name          = $GCPackageName
+                    Path          = (Join-Path -Path $OutputDirectory -ChildPath 'GCPolicyPackages')
+                    Force         = $true
+                }
+
+                New-GuestConfigurationPackage @NewGCPackageParams
+            } 2>&1
+        ).Where{
+            if ($_ -isnot [System.Management.Automation.ErrorRecord])
+            {
+                # Filter out the Error records from New-GuestConfigurationPackage
+                $true
+            }
+            elseif ($_.Exception.Message -notmatch '^A second CIM class definition')
+            {
+                # Write non-terminating errors that are not "A second CIM class definition for .... was found..."
+                $false
+                Write-Error $_ -ErrorAction Continue
+            }
+            else
+            {
+                $false
+            }
+        }
+
+        "`t`tGuest Config Package creation in progress..."
+
+        if ($ModuleVersion)
+        {
+            $GCPackageWithVersionZipName = ('{0}_{1}.zip' -f $GCPackageName,$ModuleVersion)
+            $GCPackageOutputPath = (Join-Path -Path $OutputDirectory -ChildPath 'GCPolicyPackages')
+            $ZippedGCPackagePath = Move-Item -Path $ZippedGCPackage.Path -Destination (Join-Path -Path $GCPackageOutputPath -ChildPath $GCPackageWithVersionZipName) -PassThru
+            $ZippedGCPackage = @{
+                Name = $ZippedGCPackage.Name
+                Path = $ZippedGCPackagePath.FullName
+            }
+        }
+
+        "`t`tZipped Guest Config Package: $($ZippedGCPackage.Path)"
+
+        #if we're running on Windows as admin, we can test the package
+        if (!$IsLinux -and [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
+        {
+            # we ought to test the the package on a purposed-built vm (i.e. with TK)
+            Test-GuestConfigurationPackage -Path $ZippedGCPackage.Path -Verbose
+        }
+        else
+        {
+            Write-Warning -Message "Testing the Package will fail on Linux or if not running elevated on Windows. Skipping."
+        }
+    }
+}
+
+task gcpack clean,build,build_guestconfiguration_packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the build_guestconfiguration_packages task to create GuestConfig packages using the GuestConfiguration module.
+- Added GCPackage template so that you can use `Add-Sample -Sample GCPackage` to add a GC Package to your Sampler project.
+- Added the gcpack meta task to call clean, build, and build_guestconfiguration_packages for you.
+
 ## [0.109.2] - 2021-01-13
 
 ### Changed

--- a/Sampler/Public/Add-Sample.ps1
+++ b/Sampler/Public/Add-Sample.ps1
@@ -40,7 +40,7 @@ function Add-Sample
     (
         [Parameter()]
         # Add a sample component based on the Plaster templates embedded with this module.
-        [ValidateSet('Classes', 'ClassFolderResource', 'ClassResource', 'Composite', 'Enum', 'Examples', 'GithubConfig', 'HelperSubModules', 'MofResource', 'PrivateFunction', 'PublicCallPrivateFunctions', 'PublicFunction', 'VscodeConfig')]
+        [ValidateSet('Classes', 'ClassFolderResource', 'ClassResource', 'Composite', 'Enum', 'Examples', 'GithubConfig', 'GCPackage', 'HelperSubModules', 'MofResource', 'PrivateFunction', 'PublicCallPrivateFunctions', 'PublicFunction', 'VscodeConfig')]
         [string]
         $Sample,
 

--- a/Sampler/Templates/GCPackage/GCPackages/MyGuestConfigPackage/MyGuestConfigPackage.config.ps1.template
+++ b/Sampler/Templates/GCPackage/GCPackages/MyGuestConfigPackage/MyGuestConfigPackage.config.ps1.template
@@ -1,0 +1,9 @@
+configuration <%= $PLASTER_PARAM_GCPackageName %> {
+    Import-DscResource -ModuleName MyModule
+
+    MyResource MyModule {
+        Ensure = 'Present'
+        KeyProperty = 'key'
+        Property = 'Value'
+    }
+}

--- a/Sampler/Templates/GCPackage/plasterManifest.xml
+++ b/Sampler/Templates/GCPackage/plasterManifest.xml
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest
+  schemaVersion="1.0" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+  <metadata>
+    <name>GCPackages</name>
+    <id>e2e70839-6b8c-477f-a069-8ddcf693c6dc</id>
+    <version>0.0.1</version>
+    <title>Azure Policy Guest Configuration Package template</title>
+    <description>An Azure Policy Guest Configuration Package template to build your packages from DSC configurations, to be used by policies</description>
+    <author>Gael Colas</author>
+    <tags>GuestConfiguration, Azure, Policy, Arc, Sampler, Template, Build, Module</tags>
+  </metadata>
+  <parameters>
+    <parameter store="text"  name="GCPackageName" type="text" prompt="Name of your GuestConfiguration Package" />
+    <parameter store="text"  name="SourceDirectory" type="text" prompt="What is your source folder?" default="source" />
+  </parameters>
+    <!--
+      ${PLASTER_PARAM_SourceDirectory}
+      ${PLASTER_PARAM_GCPackageName}
+     -->
+  <content>
+    <!-- FOLDER SCAFFOLDING -->
+
+      <!--   SOURCE/GCPackages Folder -->
+      <file source=''
+            destination='${PLASTER_PARAM_SourceDirectory}/GCPackages'
+      />
+
+      <!--   SOURCE/GCPackages/MyGuestConfigPackage Folder -->
+      <file source=''
+            destination='${PLASTER_PARAM_SourceDirectory}/GCPackages/${PLASTER_PARAM_GCPackageName}'
+      />
+
+      <!--   tests/GCPackages/ Folder -->
+      <file source=''
+            destination='tests/GCPackages/'
+      />
+
+      <!--   tests/GCPackages/MyGuestConfigPackage Folder -->
+      <file source=''
+            destination='tests/GCPackages/${PLASTER_PARAM_GCPackageName}'
+      />
+
+      <!--   SOURCE/GCPackages/** files -->
+      <templateFile source='GCPackages/MyGuestConfigPackage/MyGuestConfigPackage.config.ps1.template'
+            destination='${PLASTER_PARAM_SourceDirectory}/GCPackages/${PLASTER_PARAM_GCPackageName}/${PLASTER_PARAM_GCPackageName}.config.ps1'
+      />
+
+      <!-- Add GuestConfiguration module as build dependency -->
+      <modify path='RequiredModules.psd1' condition='(Test-Path -Path "RequiredModules.psd1")'>
+            <replace condition="((Get-Content -Path RequiredModules.psd1 -Raw) -notmatch '\s*GuestConfiguration\s*=')">
+                  <original>}(\r|\r\n)*$</original>
+                  <substitute expand='true'>    GuestConfiguration =          'latest'`r`n}`r`n</substitute>
+            </replace>
+      </modify>
+
+  </content>
+</plasterManifest>

--- a/tests/Integration/PlasterTemplates/GCPackage/GCPackages.integration.Tests.ps1
+++ b/tests/Integration/PlasterTemplates/GCPackage/GCPackages.integration.Tests.ps1
@@ -1,0 +1,88 @@
+#region HEADER
+$script:projectPath = "$PSScriptRoot\..\..\..\.." | Convert-Path
+$script:projectName = (Get-ChildItem -Path "$script:projectPath\*\*.psd1" | Where-Object -FilterScript {
+        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+        $(try
+            {
+                Test-ModuleManifest -Path $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            })
+    }).BaseName
+
+$script:moduleName = Get-Module -Name $script:projectName -ListAvailable | Select-Object -First 1
+Remove-Module -Name $script:moduleName -Force -ErrorAction 'SilentlyContinue'
+
+$importedModule = Import-Module $script:moduleName -Force -PassThru -ErrorAction 'Stop'
+
+#endregion HEADER
+
+Import-Module -Name "$PSScriptRoot\..\..\IntegrationTestHelpers.psm1"
+
+Install-TreeCommand
+
+Describe 'DSC MOF based resource Plaster Template' {
+    Context 'When creating a new MOF DSC Resource' {
+        BeforeAll {
+            $mockGCPackageName  = 'myGCPackage'
+            $mockModuleRootPath = $TestDrive
+
+            $listOfExpectedFilesAndFolders = @(
+                # Folders (relative to module root)
+                'source'
+                'source/GCPackages'
+                'source/GCPackages/myGCPackage'
+                'tests'
+                'tests/GCPackages'
+                'tests/GCPackages/myGCPackage'
+
+                # Files (relative to module root)
+                'source/GCPackages/myGCPackage/myGCPackage.config.ps1'
+            )
+        }
+
+        It 'Should create a new module without throwing' {
+            $invokePlasterParameters = @{
+                TemplatePath      = Join-Path -Path $importedModule.ModuleBase -ChildPath 'Templates/GCPackage'
+                DestinationPath   = $testdrive
+                NoLogo            = $true
+                Force             = $true
+
+                # Template properties
+                GCPackageName     = $mockGCPackageName
+                SourceDirectory   = 'source'
+            }
+
+            { Invoke-Plaster @invokePlasterParameters } | Should -Not -Throw
+        }
+
+        It 'Should have the expected folder and file structure' {
+            $modulePaths = Get-ChildItem -Path $mockModuleRootPath -Recurse -Force
+
+            # Make the path relative to module root.
+            $relativeModulePaths = $modulePaths.FullName -replace [RegEx]::Escape($mockModuleRootPath)
+
+            # Change to slash when testing on Windows.
+            $relativeModulePaths = ($relativeModulePaths -replace '\\', '/').TrimStart('/')
+
+            # check files & folders discrepencies
+            $missingFilesOrFolders    = $listOfExpectedFilesAndFolders.Where{$_ -notin $relativeModulePaths}
+            $unexpectedFilesAndFolders  = $relativeModulePaths.Where{$_ -notin $listOfExpectedFilesAndFolders}
+            $TreeStructureIsOk = ($missingFilesOrFolders.count -eq 0 -and $unexpectedFilesAndFolders.count -eq 0)
+
+            # format the report to be used in because
+            $report = ":`r`n  Missing:`r`n`t$($missingFilesOrFolders -join "`r`n`t")`r`n  Unexpected:`r`n`t$($unexpectedFilesAndFolders -join "`r`n`t")`r`n."
+
+            # Check if tree structure failed. If so output the module directory tree.
+            if ( -not $TreeStructureIsOk)
+            {
+                $treeOutput = Get-DirectoryTree -Path $mockModuleRootPath
+                Write-Verbose -Message ($treeOutput | Out-String) -Verbose
+            }
+
+            $TreeStructureIsOk | Should -BeTrue -Because $report
+        }
+    }
+}

--- a/tests/Integration/PlasterTemplates/GCPackage/GCPackages.integration.Tests.ps1
+++ b/tests/Integration/PlasterTemplates/GCPackage/GCPackages.integration.Tests.ps1
@@ -67,16 +67,16 @@ Describe 'DSC MOF based resource Plaster Template' {
             # Change to slash when testing on Windows.
             $relativeModulePaths = ($relativeModulePaths -replace '\\', '/').TrimStart('/')
 
-            # check files & folders discrepencies
-            $missingFilesOrFolders    = $listOfExpectedFilesAndFolders.Where{$_ -notin $relativeModulePaths}
+            # Check files & folders discrepencies
+            $missingFilesOrFolders      = $listOfExpectedFilesAndFolders.Where{$_ -notin $relativeModulePaths}
             $unexpectedFilesAndFolders  = $relativeModulePaths.Where{$_ -notin $listOfExpectedFilesAndFolders}
-            $TreeStructureIsOk = ($missingFilesOrFolders.count -eq 0 -and $unexpectedFilesAndFolders.count -eq 0)
+            $TreeStructureIsOk          = ($missingFilesOrFolders.count -eq 0 -and $unexpectedFilesAndFolders.count -eq 0)
 
-            # format the report to be used in because
+            # Format the report to be used in because
             $report = ":`r`n  Missing:`r`n`t$($missingFilesOrFolders -join "`r`n`t")`r`n  Unexpected:`r`n`t$($unexpectedFilesAndFolders -join "`r`n`t")`r`n."
 
             # Check if tree structure failed. If so output the module directory tree.
-            if ( -not $TreeStructureIsOk)
+            if (-not $TreeStructureIsOk)
             {
                 $treeOutput = Get-DirectoryTree -Path $mockModuleRootPath
                 Write-Verbose -Message ($treeOutput | Out-String) -Verbose


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Added

- Added the build_guestconfiguration_packages task to create GuestConfig packages using the GuestConfiguration module.
- Added GCPackage template so that you can use `Add-Sample -Sample GCPackage` to add a GC Package to your Sampler project.
- Added the gcpack meta task to call clean, build, and build_guestconfiguration_packages for you.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/237)
<!-- Reviewable:end -->
