### PR TITLE
fixing issue for Manifest only no builtmoduleRootScriptPath

### DIFF
--- a/.build/tasks/Build-Module.ModuleBuilder.build.ps1
+++ b/.build/tasks/Build-Module.ModuleBuilder.build.ps1
@@ -447,8 +447,11 @@ Task Build_DscResourcesToExport_ModuleBuilder {
     $builtModuleManifest = (Get-Item -Path $builtModuleManifest).FullName
     "`tBuilt Module Manifest    = '$builtModuleManifest'"
 
-    $builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest
-    $builtModuleRootScriptPath = (Get-Item -Path $builtModuleRootScriptPath).FullName
+    if ($builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest)
+    {
+        $builtModuleRootScriptPath = (Get-Item -Path $builtModuleRootScriptPath -ErrorAction SilentlyContinue).FullName
+    }
+
     "`tBuilt ModuleRoot script  = '$builtModuleRootScriptPath'"
 
     $builtDscResourcesFolder = Get-SamplerAbsolutePath -Path 'DSCResources' -RelativeTo $builtModuleBase

--- a/.build/tasks/DscResource.Test.build.ps1
+++ b/.build/tasks/DscResource.Test.build.ps1
@@ -81,7 +81,11 @@ task Invoke_DscResource_Tests {
     $builtModuleManifest = Get-SamplerBuiltModuleManifest @GetBuiltModuleManifestParams
     "`tBuilt Module Manifest    = '$builtModuleManifest'"
 
-    $builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest
+    if ($builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest)
+    {
+        $builtModuleRootScriptPath = (Get-Item -Path $builtModuleRootScriptPath -ErrorAction SilentlyContinue).FullName
+    }
+
     "`tBuilt ModuleRoot script  = '$builtModuleRootScriptPath'"
 
     $builtDscResourcesFolder = Get-SamplerAbsolutePath -Path 'DSCResources' -RelativeTo $builtModuleBase
@@ -320,7 +324,11 @@ task Fail_Build_If_DscResource_Tests_Failed {
     $builtModuleManifest = Get-SamplerBuiltModuleManifest @GetBuiltModuleManifestParams
     "`tBuilt Module Manifest    = '$builtModuleManifest'"
 
-    $builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest
+    if ($builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest)
+    {
+        $builtModuleRootScriptPath = (Get-Item -Path $builtModuleRootScriptPath -ErrorAction SilentlyContinue).FullName
+    }
+
     "`tBuilt ModuleRoot script  = '$builtModuleRootScriptPath'"
 
     $builtDscResourcesFolder = Get-SamplerAbsolutePath -Path 'DSCResources' -RelativeTo $builtModuleBase
@@ -399,7 +407,11 @@ task Upload_DscResourceTest_Results_To_AppVeyor -If { (property BuildSystem 'unk
     $builtModuleManifest = Get-SamplerBuiltModuleManifest @GetBuiltModuleManifestParams
     "`tBuilt Module Manifest    = '$builtModuleManifest'"
 
-    $builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest
+    if ($builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest)
+    {
+        $builtModuleRootScriptPath = (Get-Item -Path $builtModuleRootScriptPath -ErrorAction SilentlyContinue).FullName
+    }
+
     "`tBuilt ModuleRoot script  = '$builtModuleRootScriptPath'"
 
     $builtDscResourcesFolder = Get-SamplerAbsolutePath -Path 'DSCResources' -RelativeTo $builtModuleBase

--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -93,7 +93,11 @@ task Invoke_Pester_Tests {
     $builtModuleManifest = Get-SamplerBuiltModuleManifest @GetBuiltModuleManifestParams
     "`tBuilt Module Manifest    = '$builtModuleManifest'"
 
-    $builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest
+    if ($builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest)
+    {
+        $builtModuleRootScriptPath = (Get-Item -Path $builtModuleRootScriptPath -ErrorAction SilentlyContinue).FullName
+    }
+
     "`tBuilt ModuleRoot script  = '$builtModuleRootScriptPath'"
 
     $builtDscResourcesFolder = Get-SamplerAbsolutePath -Path 'DSCResources' -RelativeTo $builtModuleBase
@@ -489,7 +493,11 @@ task Fail_Build_If_Pester_Tests_Failed {
     $builtModuleManifest = Get-SamplerBuiltModuleManifest @GetBuiltModuleManifestParams
     "`tBuilt Module Manifest    = '$builtModuleManifest'"
 
-    $builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest
+    if ($builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest)
+    {
+        $builtModuleRootScriptPath = (Get-Item -Path $builtModuleRootScriptPath -ErrorAction SilentlyContinue).FullName
+    }
+
     "`tBuilt ModuleRoot script  = '$builtModuleRootScriptPath'"
 
     $builtDscResourcesFolder = Get-SamplerAbsolutePath -Path 'DSCResources' -RelativeTo $builtModuleBase
@@ -585,7 +593,11 @@ task Pester_If_Code_Coverage_Under_Threshold {
     $builtModuleManifest = Get-SamplerBuiltModuleManifest @GetBuiltModuleManifestParams
     "`tBuilt Module Manifest    = '$builtModuleManifest'"
 
-    $builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest
+    if ($builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest)
+    {
+        $builtModuleRootScriptPath = (Get-Item -Path $builtModuleRootScriptPath -ErrorAction SilentlyContinue).FullName
+    }
+
     "`tBuilt ModuleRoot script  = '$builtModuleRootScriptPath'"
 
     $builtDscResourcesFolder = Get-SamplerAbsolutePath -Path 'DSCResources' -RelativeTo $builtModuleBase
@@ -720,7 +732,11 @@ task Upload_Test_Results_To_AppVeyor -If { (property BuildSystem 'unknown') -eq 
     $builtModuleManifest = Get-SamplerBuiltModuleManifest @GetBuiltModuleManifestParams
     "`tBuilt Module Manifest    = '$builtModuleManifest'"
 
-    $builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest
+    if ($builtModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $builtModuleManifest)
+    {
+        $builtModuleRootScriptPath = (Get-Item -Path $builtModuleRootScriptPath -ErrorAction SilentlyContinue).FullName
+    }
+
     "`tBuilt ModuleRoot script  = '$builtModuleRootScriptPath'"
 
     $builtDscResourcesFolder = Get-SamplerAbsolutePath -Path 'DSCResources' -RelativeTo $builtModuleBase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Error when the Module has no RootModule script (manifest only with DSC resources).
+
 ## [0.109.6] - 2021-03-18
 
 ### Fixed


### PR DESCRIPTION
as per SharePointDsc, the tasks fails when there's no RootModule in the Module manifest.
```
    Built Module Base        = '/home/vsts/work/1/s/output/SharePointDsc/4.6.0'
	Built Module Manifest    = '/home/vsts/work/1/s/output/SharePointDsc/4.6.0/SharePointDsc.psd1'
ERROR: Cannot bind argument to parameter 'Path' because it is null.
At /home/vsts/work/1/s/output/RequiredModules/Sampler/0.109.6/tasks/Build-Module.ModuleBuilder.build.ps1:451 char:50
+ … leRootScriptPath = (Get-Item -Path $builtModuleRootScriptPath).FullNa …
+                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~
At /home/vsts/work/1/s/output/RequiredModules/Sampler/0.109.6/tasks/Build-Module.ModuleBuilder.build.ps1:402 char:1
+ Task Build_DscResourcesToExport_ModuleBuilder {
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
At /home/vsts/work/1/s/output/RequiredModules/Sampler/0.109.6/tasks/Build-Module.ModuleBuilder.build.ps1:545 char:1
+ Task Build_Module_ModuleBuilder Build_ModuleOutput_ModuleBuilder
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/252)
<!-- Reviewable:end -->
