### PR TITLE
Fixed issue with uncommenting release notes

### DIFF
--- a/.build/tasks/release.module.build.ps1
+++ b/.build/tasks/release.module.build.ps1
@@ -61,7 +61,8 @@ task Create_changelog_release_output {
     }
 
     $builtModuleManifest = Get-SamplerBuiltModuleManifest @GetBuiltModuleManifestParams
-
+    $builtModuleManifest = (Get-Item -Path $builtModuleManifest).FullName
+    
     "`tBuilt Module Manifest = '$builtModuleManifest'"
 
     $moduleVersion = Get-BuiltModuleVersion @GetBuiltModuleManifestParams

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue with uncommenting release notes in module manifest
+
 ## [0.109.9] - 2021-03-20
 
 ### Fixed


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Fixed
- Fixed issue with uncommenting release notes in module manifest

## Task list

- [X] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [X] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).