### PR TITLE
Fix Azure coverage and merge coverage over pipeline jobs

### DIFF
--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -1086,7 +1086,20 @@ task Convert_Pester_Coverage {
 
             # The module version is what is expected to be in the XML.
             $sourceFilePath = ($jaCocoClass.Name -replace '^\.', $ModuleVersionFolder) -replace '\\','/'
-            $xmlClassName = $sourceFilePath -replace '\.ps1'
+
+            <#
+                Get class name if it exist, otherwise use function name. The first
+                object should in the array should give us the right information.
+            #>
+            $xmlClassName = if ([System.String]::IsNullOrEmpty($jaCocoClass.Group[0].Class))
+            {
+                $jaCocoClass.Group[0].Function
+            }
+            else
+            {
+                $jaCocoClass.Group[0].Class
+            }
+
             $sourceFileName = $sourceFilePath -replace [regex]::Escape('{0}/' -f $ModuleVersionFolder)
 
             Write-Debug -Message ("`tCreating XML output for JaCoCo class '{0}'." -f $classDisplayName)

--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -1093,7 +1093,6 @@ task Convert_Pester_Coverage {
             #>
             $xmlClassName = if ([System.String]::IsNullOrEmpty($jaCocoClass.Group[0].Class))
             {
-
                 if ([System.String]::IsNullOrEmpty($jaCocoClass.Group[0].Function))
                 {
                     '<script>'
@@ -1578,6 +1577,13 @@ task Convert_Pester_Coverage {
 
     $targetXmlDocument = Update-JaCoCoStatistic -Document $targetXmlDocument
 
+    Write-Build -Color 'DarkGray' -Text ("`tUpdating path to include source folder '{0}' in the package element in the coverage file." -f $sourcePathFolderName)
+
+    Select-Xml -Xml $xml -XPath '//package' |
+        ForEach-Object -Process {
+            $_.Node.name = $_.Node.name -replace '^\d+\.\d+\.\d+', $sourcePathFolderName
+        }
+
     Write-Build -Color 'DarkGray' -Text "`tWriting back updated code coverage file to '$CodeCoverageOutputFile'."
 
     $xmlSettings = New-Object -TypeName 'System.Xml.XmlWriterSettings'
@@ -1586,7 +1592,7 @@ task Convert_Pester_Coverage {
 
     $xmlWriter = [System.Xml.XmlWriter]::Create($CodeCoverageOutputFile, $xmlSettings)
 
-    $originalXml.Save($xmlWriter)
+    $targetXmlDocument.Save($xmlWriter)
 
     $xmlWriter.Close()
 

--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -1094,7 +1094,7 @@ task Convert_Pester_Coverage {
             $xmlClassName = if ([System.String]::IsNullOrEmpty($jaCocoClass.Group[0].Class))
             {
 
-                $functionName = if ([System.String]::IsNullOrEmpty($jaCocoClass.Group[0].Function))
+                if ([System.String]::IsNullOrEmpty($jaCocoClass.Group[0].Function))
                 {
                     '<script>'
                 }

--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -763,14 +763,15 @@ task Convert_Pester_Coverage {
     $PesterOutputFolder = Get-SamplerAbsolutePath -Path $PesterOutputFolder -RelativeTo $OutputDirectory
     "`tPester Output Folder     = '$PesterOutputFolder'"
 
-    if (-not (Split-Path -IsAbsolute $PesterOutputFolder))
-    {
-        $PesterOutputFolder = Join-Path -Path $OutputDirectory -ChildPath $PesterOutputFolder
-    }
-
     $osShortName = Get-OperatingSystemShortName
 
     $powerShellVersion = 'PSv.{0}' -f $PSVersionTable.PSVersion
+
+    $moduleFileName = '{0}.psm1' -f $ProjectName
+
+    "`tModule File Name         = '$moduleFileName'"
+
+    #### TODO: Split Script Task Variables here
 
     $getPesterOutputFileFileNameParameters = @{
         ProjectName       = $ProjectName
@@ -779,9 +780,7 @@ task Convert_Pester_Coverage {
         PowerShellVersion = $powerShellVersion
     }
 
-    $moduleFileName = '{0}.psm1' -f $ProjectName
-
-    "`tModule File Name         = '$moduleFileName'"
+    $pesterOutputFileFileName = Get-PesterOutputFileFileName @getPesterOutputFileFileNameParameters
 
     $getCodeCoverageOutputFile = @{
         BuildInfo          = $BuildInfo
@@ -808,11 +807,7 @@ task Convert_Pester_Coverage {
     "`tCodeCoverageOutputFileEncoding = $CodeCoverageOutputFileEncoding"
     ""
 
-    #### TODO: Split Script Task Variables here
-
-    $PesterOutputFileFileName = Get-PesterOutputFileFileName @getPesterOutputFileFileNameParameters
-
-    $PesterResultObjectClixml = Join-Path $PesterOutputFolder "PesterObject_$PesterOutputFileFileName"
+    $PesterResultObjectClixml = Join-Path $PesterOutputFolder "PesterObject_$pesterOutputFileFileName"
 
     Write-Build -Color 'White' -Text "`tPester Output Object = $PesterResultObjectClixml"
 
@@ -1492,7 +1487,7 @@ task Convert_Pester_Coverage {
         Write-Debug -Message ($StringWriter.ToString() | Out-String)
     }
 
-    $newCoverageFilePath = Join-Path -Path $PesterOutputFolder -ChildPath 'JaCoCo_source_coverage.xml'
+    $newCoverageFilePath = Join-Path -Path $PesterOutputFolder -ChildPath 'source_coverage.xml'
 
     Write-Build -Color 'DarkGray' -Text "`tWriting converted code coverage file to '$newCoverageFilePath'."
 
@@ -1522,7 +1517,7 @@ task Convert_Pester_Coverage {
 
     $originalXml.Load($CodeCoverageOutputFile)
 
-    $codeCoverageOutputBackupFile = $CodeCoverageOutputFile -replace '\.xml', '.bak.xml'
+    $codeCoverageOutputBackupFile = $CodeCoverageOutputFile -replace '\.xml', '.xml.bak'
     $newCoverageFilePath = Join-Path -Path $PesterOutputFolder -ChildPath $codeCoverageOutputBackupFile
 
     Write-Build -Color 'DarkGray' -Text "`tWriting a backup of original code coverage file to '$codeCoverageOutputBackupFile'."

--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -1093,7 +1093,15 @@ task Convert_Pester_Coverage {
             #>
             $xmlClassName = if ([System.String]::IsNullOrEmpty($jaCocoClass.Group[0].Class))
             {
-                $jaCocoClass.Group[0].Function
+
+                $functionName = if ([System.String]::IsNullOrEmpty($jaCocoClass.Group[0].Function))
+                {
+                    '<script>'
+                }
+                else
+                {
+                    $jaCocoClass.Group[0].Function
+                }
             }
             else
             {

--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -1579,7 +1579,7 @@ task Convert_Pester_Coverage {
 
     Write-Build -Color 'DarkGray' -Text ("`tUpdating path to include source folder '{0}' in the package element in the coverage file." -f $sourcePathFolderName)
 
-    Select-Xml -Xml $xml -XPath '//package' |
+    Select-Xml -Xml $targetXmlDocument -XPath '//package' |
         ForEach-Object -Process {
             $_.Node.name = $_.Node.name -replace '^\d+\.\d+\.\d+', $sourcePathFolderName
         }

--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -1030,12 +1030,7 @@ task Convert_Pester_Coverage {
     # This is what the user expects to see.
     $packageDisplayName = $sourcePathFolderName
 
-    <#
-        The module version is what is expected to be in the XML.
-
-        E.g. Codecov.io config converts this back to 'source' (or whatever
-        is configured in 'codecov.yml').
-    #>
+    # The module version is what is expected to be in the XML.
     $xmlPackageName = $ModuleVersionFolder
 
     Write-Debug -Message ('Creating XML output for JaCoCo package ''{0}''.' -f $packageDisplayName)

--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -1005,19 +1005,19 @@ task Convert_Pester_Coverage {
         Covered = 0
     }
 
-    $commandsGroupedOnParentFolder = $allCommands | Group-Object -Property {
-        $parentFolder = Split-Path -Path $_.SourceFile -Parent
+    # $commandsGroupedOnParentFolder = $allCommands | Group-Object -Property {
+    #     $parentFolder = Split-Path -Path $_.SourceFile -Parent
 
-        # TODO: We should just create one package element here instead of looping
-        if ($parentFolder -ne $ModuleVersionFolder)
-        {
-            # If we on a child folder, move up to next parent folder.
-            $parentFolder = Split-Path $parentFolder -Parent
-        }
-    }
+    #     # TODO: We should just create one package element here instead of looping
+    #     if ($parentFolder -ne $ModuleVersionFolder)
+    #     {
+    #         # If we on a child folder, move up to next parent folder.
+    #         $parentFolder = Split-Path $parentFolder -Parent
+    #     }
+    # }
 
-    foreach ($jaCocoPackage in $commandsGroupedOnParentFolder)
-    {
+    # foreach ($jaCocoPackage in $commandsGroupedOnParentFolder)
+    # {
         $packageCounterInstruction = @{
             Missed  = 0
             Covered = 0
@@ -1041,7 +1041,7 @@ task Convert_Pester_Coverage {
         $allSourceFileElements = @()
 
         # This is what the user expects to see.
-        $packageDisplayName = ($jaCoCoPackage.Name -replace '^\.', $sourcePathFolderName) -replace '\\','/'
+        $packageDisplayName = $sourcePathFolderName
 
         <#
             The module version is what is expected to be in the XML.
@@ -1049,7 +1049,7 @@ task Convert_Pester_Coverage {
             E.g. Codecov.io config converts this back to 'source' (or whatever
             is configured in 'codecov.yml').
         #>
-        $xmlPackageName = ($jaCoCoPackage.Name -replace '^\.', $ModuleVersionFolder) -replace '\\','/'
+        $xmlPackageName = $ModuleVersionFolder
 
         Write-Debug -Message ('Creating XML output for JaCoCo package ''{0}''.' -f $packageDisplayName)
 
@@ -1063,7 +1063,7 @@ task Convert_Pester_Coverage {
         $xmlElementPackage = $coverageXml.CreateElement('package')
         $xmlElementPackage.SetAttribute('name', $xmlPackageName)
 
-        $commandsGroupedOnSourceFile = $jaCoCoPackage.Group | Group-Object -Property 'SourceFile'
+        $commandsGroupedOnSourceFile = $allCommands | Group-Object -Property 'SourceFile'
 
         foreach ($jaCocoClass in $commandsGroupedOnSourceFile)
         {
@@ -1442,7 +1442,7 @@ task Convert_Pester_Coverage {
         $xmlElementPackage.AppendChild($xmlElementCounter_PackageClass) | Out-Null
 
         $xmlElementReport.AppendChild($xmlElementPackage) | Out-Null
-    } # end package loop
+    #} # end package loop
 
     # Add counters at the report level.
     $xmlElementCounter_ReportInstruction = $coverageXml.CreateElement('counter')

--- a/.build/tasks/Merge-CodeCoverageFiles.pester.build.ps1
+++ b/.build/tasks/Merge-CodeCoverageFiles.pester.build.ps1
@@ -157,7 +157,7 @@ task Merge_CodeCoverage_Files {
             $codecovFiles = Get-ChildItem -Path $PesterOutputFolder -Include $CodeCoverageFilePattern -Recurse
         }
 
-        "`tMerging Code Coverage Files     = {0}" -f ($codecovFiles.FullName -join ',')
+        "`tMerging Code Coverage Files     = '{0}'" -f ($codecovFiles.FullName -join ', ')
         ""
 
         if (Test-Path -Path $CodeCoverageMergedOutputFile)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for code coverage when using ModuleBuilder pattern for building module.
 - `Update-JaCoCoStatistic`
   - Added unit test.
+- Pipeline updated to support merging code coverage between operating
+  system pipeline jobs.
 
 ### Fixed
 
@@ -31,6 +33,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed so that statistics are updated correctly for the 'CLASS' counter.
 - Fixed codecov.yml to parse version number in paths correctly.
 - Fix uploading to Azure Code Coverage.
+- _Merge_CodeCoverage_Files_
+  - Fixed so the file that is outputted is in UTF-8 (without BOM) to support 
+    Codecov.io.
+  - The task now only searches for the file pattern inside the `./output/testResults`
+    folder.
+  - The merge process is not attempted if `CodeCoverageThreshold` is set to 
+    `0`.
+  - Updated so that build.yaml now have a key `CodeCoverage` which have to
+    settings `CodeCoverageMergedOutputFile` and `CodeCoverageFilePattern`.
+- _Convert_Pester_Coverage_
+  - The backup file now have the extension `.bak` (instead of `.bak.xml`)
+    so that is not mistakenly used by a task _Merge_CodeCoverage_Files_.
+  - Some code cleanup.
 
 ## [0.109.10] - 2021-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Update-JaCoCoStatistic`
   - Fixed so that statistics are updated correctly for the 'CLASS' counter.
 - Fixed codecov.yml to parse version number in paths correctly.
+- Fix uploading to Azure Code Coverage.
 
 ## [0.109.10] - 2021-03-24
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,7 +262,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/;$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Private/;$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Public/'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/'
           - script: |
               bash <(curl -s https://codecov.io/bash) -f "./$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml"
             displayName: 'Upload to Codecov.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -218,10 +218,10 @@ stages:
       - job: Code_Coverage
         displayName: 'Publish Code Coverage'
         dependsOn:
-          - test_windows_core
-          - test_windows_ps
           - test_macos
           - test_linux
+          # - test_windows_core
+          # - test_windows_ps
         pool:
           vmImage: 'ubuntu 16.04'
         timeoutInMinutes: 0
@@ -239,7 +239,6 @@ stages:
               artifactName: $(buildArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
           - download: 'current'
-            patterns: 'CodeCoverage*'
             displayName: 'Download All Test Artifacts'
           - task: PowerShell@2
             name: merge

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,7 +217,11 @@ stages:
 
       - job: Code_Coverage
         displayName: 'Publish Code Coverage'
-        dependsOn: test_windows_core
+        dependsOn:
+          - test_windows_core
+          - test_windows_ps
+          - test_macos
+          - test_linux
         pool:
           vmImage: 'ubuntu 16.04'
         timeoutInMinutes: 0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -238,8 +238,30 @@ stages:
               buildType: 'current'
               artifactName: $(buildArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
-          - download: 'current'
-            displayName: 'Download All Test Artifacts'
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact macOS'
+            inputs:
+              buildType: 'current'
+              artifactName: 'CodeCoverageMacOS'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact Linux'
+            inputs:
+              buildType: 'current'
+              artifactName: 'CodeCoverageLinux'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+          # - task: DownloadPipelineArtifact@2
+          #   displayName: 'Download Test Artifact Windows (PS 5.1)'
+          #   inputs:
+          #     buildType: 'current'
+          #     artifactName: 'CodeCoverageWinPS51'
+          #     targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+          # - task: DownloadPipelineArtifact@2
+          #   displayName: 'Download Test Artifact Windows (PS7)'
+          #   inputs:
+          #     buildType: 'current'
+          #     artifactName: 'CodeCoverageWinPS'
+          #     targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
           - task: PowerShell@2
             name: merge
             displayName: 'Merge Code Coverage files'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -175,33 +175,33 @@ stages:
           #     summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
           #     pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
 
-      # - job: test_macos
-      #   displayName: 'macOS'
-      #   timeoutInMinutes: 0
-      #   pool:
-      #     vmImage: 'macos-latest'
-      #   steps:
-      #     - task: DownloadPipelineArtifact@2
-      #       displayName: 'Download Pipeline Artifact'
-      #       inputs:
-      #         buildType: 'current'
-      #         artifactName: 'output'
-      #         targetPath: '$(Build.SourcesDirectory)/output'
+      - job: test_macos
+        displayName: 'macOS'
+        timeoutInMinutes: 0
+        pool:
+          vmImage: 'macos-latest'
+        steps:
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Pipeline Artifact'
+            inputs:
+              buildType: 'current'
+              artifactName: 'output'
+              targetPath: '$(Build.SourcesDirectory)/output'
 
-      #     - powershell: |
-      #         $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-      #         echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-      #         echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-      #       name: dscBuildVariable
-      #       displayName: 'Set Environment Variables'
+          - powershell: |
+              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
+              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
+              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
+            name: dscBuildVariable
+            displayName: 'Set Environment Variables'
 
-      #     - task: PowerShell@2
-      #       name: test
-      #       displayName: 'Run Tests'
-      #       inputs:
-      #         filePath: './build.ps1'
-      #         arguments: '-tasks test'
-      #         pwsh: true
+          - task: PowerShell@2
+            name: test
+            displayName: 'Run Tests'
+            inputs:
+              filePath: './build.ps1'
+              arguments: '-tasks test'
+              pwsh: true
 
           - task: PublishTestResults@2
             displayName: 'Publish Test Results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ stages:
             displayName: 'Publish Test Artifact'
             inputs:
               targetPath: '$(buildFolderName)/$(testResultFolderName)/'
-              artifactName: 'CodeCoverage_Linux'
+              artifactName: 'CodeCoverageLinux'
               parallel: true
 
       - job: test_windows_core
@@ -239,25 +239,25 @@ stages:
             inputs:
               buildType: 'current'
               artifactName: 'CodeCoverageMacOS'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_macOS'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Test Artifact Linux'
             inputs:
               buildType: 'current'
               artifactName: 'CodeCoverageLinux'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_Linux'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Test Artifact Windows (PS 5.1)'
             inputs:
               buildType: 'current'
               artifactName: 'CodeCoverageWinPS51'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_WinPS51'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Test Artifact Windows (PS7)'
             inputs:
               buildType: 'current'
               artifactName: 'CodeCoverageWinPS'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_WinPS'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
           - task: PowerShell@2
             name: merge
             displayName: 'Merge Code Coverage files'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,10 +262,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
-              pathToSources:
-                - '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
-                - '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)\Public'
-                - '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)\Private'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/'
           - script: |
               bash <(curl -s https://codecov.io/bash) -f "./$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml"
             displayName: 'Upload to Codecov.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,7 +262,10 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
+              pathToSources:
+                - '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
+                - '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)\Public'
+                - '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)\Private'
           - script: |
               bash <(curl -s https://codecov.io/bash) -f "./$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml"
             displayName: 'Upload to Codecov.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -238,25 +238,25 @@ stages:
             displayName: 'Download Test Artifact macOS'
             inputs:
               buildType: 'current'
-              artifactName: CodeCoverage_macOS
+              artifactName: 'CodeCoverage_macOS'
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_macOS'
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Test Artifact Linux'
             inputs:
               buildType: 'current'
-              artifactName: CodeCoverage_Linux
+              artifactName: 'CodeCoverage_Linux'
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_Linux'
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Test Artifact Windows (PS 5.1)'
             inputs:
               buildType: 'current'
-              artifactName: CodeCoverage_WinPS51
+              artifactName: 'CodeCoverage_WinPS51'
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_WinPS51'
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Test Artifact Windows (PS7)'
             inputs:
               buildType: 'current'
-              artifactName: CodeCoverage_WinPS
+              artifactName: 'CodeCoverage_WinPS'
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_WinPS'
           - task: PowerShell@2
             name: merge
@@ -267,7 +267,6 @@ stages:
               pwsh: true
           - task: PublishCodeCoverageResults@1
             displayName: 'Publish Azure Code Coverage'
-            condition: succeededOrFailed()
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
@@ -275,7 +274,6 @@ stages:
           - script: |
               bash <(curl -s https://codecov.io/bash) -f "./$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml"
             displayName: 'Upload to Codecov.io'
-            condition: succeededOrFailed()
 
   - stage: Deploy
     dependsOn: Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -218,9 +218,9 @@ stages:
       - job: Code_Coverage
         displayName: 'Publish Code Coverage'
         dependsOn:
-          - test_macos
+          #- test_macos
           - test_linux
-          # - test_windows_core
+          - test_windows_core
           # - test_windows_ps
         pool:
           vmImage: 'ubuntu 16.04'
@@ -239,17 +239,23 @@ stages:
               artifactName: $(buildArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
           - task: DownloadPipelineArtifact@2
-            displayName: 'Download Test Artifact macOS'
+            displayName: 'Download All Test Artifacts'
             inputs:
               buildType: 'current'
-              artifactName: 'CodeCoverageMacOS'
+              patterns: 'CodeCoverage*'
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Test Artifact Linux'
-            inputs:
-              buildType: 'current'
-              artifactName: 'CodeCoverageLinux'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+          # - task: DownloadPipelineArtifact@2
+          #   displayName: 'Download Test Artifact macOS'
+          #   inputs:
+          #     buildType: 'current'
+          #     artifactName: 'CodeCoverageMacOS'
+          #     targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+          # - task: DownloadPipelineArtifact@2
+          #   displayName: 'Download Test Artifact Linux'
+          #   inputs:
+          #     buildType: 'current'
+          #     artifactName: 'CodeCoverageLinux'
+          #     targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
           # - task: DownloadPipelineArtifact@2
           #   displayName: 'Download Test Artifact Windows (PS 5.1)'
           #   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,13 +87,12 @@ stages:
               testResultsFiles: 'output/testResults/NUnit*.xml'
               testRunTitle: 'Linux'
 
-          # - task: PublishCodeCoverageResults@1
-          #   displayName: 'Publish Code Coverage'
-          #   condition: succeededOrFailed()
-          #   inputs:
-          #     codeCoverageTool: 'JaCoCo'
-          #     summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
-          #     pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish Test Artifact'
+            inputs:
+              targetPath: '$(buildFolderName)/$(testResultFolderName)/'
+              artifactName: 'CodeCoverage_Linux'
+              parallel: true
 
       - job: test_windows_core
         displayName: 'Windows (PowerShell Core)'
@@ -128,7 +127,7 @@ stages:
             displayName: 'Publish Test Artifact'
             inputs:
               targetPath: '$(buildFolderName)/$(testResultFolderName)/'
-              artifactName: $(testArtifactName)
+              artifactName: 'CodeCoverage_WinPS7'
               parallel: true
 
       - job: test_windows_ps
@@ -167,13 +166,12 @@ stages:
               testResultsFiles: 'output/testResults/NUnit*.xml'
               testRunTitle: 'Windows Server Core (Windows PowerShell)'
 
-          # - task: PublishCodeCoverageResults@1
-          #   displayName: 'Publish Code Coverage'
-          #   condition: succeededOrFailed()
-          #   inputs:
-          #     codeCoverageTool: 'JaCoCo'
-          #     summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
-          #     pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish Test Artifact'
+            inputs:
+              targetPath: '$(buildFolderName)/$(testResultFolderName)/'
+              artifactName: 'CodeCoverage_WinPS51'
+              parallel: true
 
       - job: test_macos
         displayName: 'macOS'
@@ -211,13 +209,12 @@ stages:
               testResultsFiles: 'output/testResults/NUnit*.xml'
               testRunTitle: 'MacOS'
 
-          # - task: PublishCodeCoverageResults@1
-          #   displayName: 'Publish Code Coverage'
-          #   condition: succeededOrFailed()
-          #   inputs:
-          #     codeCoverageTool: 'JaCoCo'
-          #     summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
-          #     pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish Test Artifact'
+            inputs:
+              targetPath: '$(buildFolderName)/$(testResultFolderName)/'
+              artifactName: 'CodeCoverage_macOS'
+              parallel: true
 
       - job: Code_Coverage
         displayName: 'Publish Code Coverage'
@@ -239,11 +236,36 @@ stages:
               artifactName: $(buildArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
           - task: DownloadPipelineArtifact@2
-            displayName: 'Download Test Artifact'
+            displayName: 'Download Test Artifact macOS'
             inputs:
               buildType: 'current'
-              artifactName: $(testArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+              artifactName: CodeCoverage_macOS
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_macOS'
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact Linux'
+            inputs:
+              buildType: 'current'
+              artifactName: CodeCoverage_Linux
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_Linux'
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact Windows (PS 5.1)'
+            inputs:
+              buildType: 'current'
+              artifactName: CodeCoverage_WinPS51
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_WinPS51'
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact Windows (PS7)'
+            inputs:
+              buildType: 'current'
+              artifactName: CodeCoverage_WinPS
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_WinPS'
+          - task: PowerShell@2
+            name: merge
+            displayName: 'Merge Code Coverage files'
+            inputs:
+              filePath: './build.ps1'
+              arguments: '-tasks merge'
+              pwsh: true
           - task: PublishCodeCoverageResults@1
             displayName: 'Publish Azure Code Coverage'
             condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,13 +87,13 @@ stages:
               testResultsFiles: 'output/testResults/NUnit*.xml'
               testRunTitle: 'Linux'
 
-          - task: PublishCodeCoverageResults@1
-            displayName: 'Publish Code Coverage'
-            condition: succeededOrFailed()
-            inputs:
-              codeCoverageTool: 'JaCoCo'
-              summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
+          # - task: PublishCodeCoverageResults@1
+          #   displayName: 'Publish Code Coverage'
+          #   condition: succeededOrFailed()
+          #   inputs:
+          #     codeCoverageTool: 'JaCoCo'
+          #     summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
+          #     pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
 
       - job: test_windows_core
         displayName: 'Windows (PowerShell Core)'
@@ -167,13 +167,13 @@ stages:
               testResultsFiles: 'output/testResults/NUnit*.xml'
               testRunTitle: 'Windows Server Core (Windows PowerShell)'
 
-          - task: PublishCodeCoverageResults@1
-            displayName: 'Publish Code Coverage'
-            condition: succeededOrFailed()
-            inputs:
-              codeCoverageTool: 'JaCoCo'
-              summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
+          # - task: PublishCodeCoverageResults@1
+          #   displayName: 'Publish Code Coverage'
+          #   condition: succeededOrFailed()
+          #   inputs:
+          #     codeCoverageTool: 'JaCoCo'
+          #     summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
+          #     pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
 
       - job: test_macos
         displayName: 'macOS'
@@ -211,13 +211,13 @@ stages:
               testResultsFiles: 'output/testResults/NUnit*.xml'
               testRunTitle: 'MacOS'
 
-          - task: PublishCodeCoverageResults@1
-            displayName: 'Publish Code Coverage'
-            condition: succeededOrFailed()
-            inputs:
-              codeCoverageTool: 'JaCoCo'
-              summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
+          # - task: PublishCodeCoverageResults@1
+          #   displayName: 'Publish Code Coverage'
+          #   condition: succeededOrFailed()
+          #   inputs:
+          #     codeCoverageTool: 'JaCoCo'
+          #     summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
+          #     pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
 
       - job: Code_Coverage
         displayName: 'Publish Code Coverage'
@@ -244,6 +244,18 @@ stages:
               buildType: 'current'
               artifactName: $(testArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+          - pwsh: |
+              # Add code to change version
+              $path = Resolve-Path -Path '.\testResults\JaCoCo_coverage.xml'
+              [xml] $xml = Get-Content -Path $path
+              Select-Xml -Xml $xml -XPath '//package' | ForEach-Object -Process { $_.Node.name = $_.Node.name -replace '^\d+\.\d+\.\d+','Sampler' }
+              Select-Xml -Xml $xml -XPath '//class' | ForEach-Object -Process { $_.Node.name = $_.Node.name -replace '^\d+\.\d+\.\d+','Sampler' }
+              $xmlSettings = New-Object -TypeName 'System.Xml.XmlWriterSettings'
+              $xmlSettings.Indent = $true
+              $xmlSettings.Encoding = [System.Text.Encoding]::Ascii
+              $xmlWriter = [System.Xml.XmlWriter]::Create($path, $xmlSettings)
+              $xml.Save($xmlWriter)
+              $xmlWriter.Close()
           - task: PublishCodeCoverageResults@1
             displayName: 'Publish Azure Code Coverage'
             condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,7 +93,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Sampler'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
 
       - job: test_windows_core
         displayName: 'Windows (PowerShell Core)'
@@ -173,7 +173,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Sampler'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
 
       - job: test_macos
         displayName: 'macOS'
@@ -217,7 +217,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Sampler'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
 
       - job: Code_Coverage
         displayName: 'Publish Code Coverage'
@@ -250,7 +250,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Sampler'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
           - script: |
               bash <(curl -s https://codecov.io/bash) -f "./$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml"
             displayName: 'Upload to Codecov.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -200,7 +200,7 @@ stages:
           - test_macos
           - test_linux
           - test_windows_core
-           - test_windows_ps
+          - test_windows_ps
         pool:
           vmImage: 'ubuntu 16.04'
         timeoutInMinutes: 0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,13 +64,6 @@ stages:
               artifactName: 'output'
               targetPath: '$(Build.SourcesDirectory)/output'
 
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: dscBuildVariable
-            displayName: 'Set Environment Variables'
-
           - task: PowerShell@2
             name: test
             displayName: 'Run Tests'
@@ -142,13 +135,6 @@ stages:
               artifactName: 'output'
               targetPath: '$(Build.SourcesDirectory)/output'
 
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: dscBuildVariable
-            displayName: 'Set Environment Variables'
-
           - task: PowerShell@2
             name: test
             displayName: 'Run Tests'
@@ -185,13 +171,6 @@ stages:
               artifactName: 'output'
               targetPath: '$(Build.SourcesDirectory)/output'
 
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: dscBuildVariable
-            displayName: 'Set Environment Variables'
-
           - task: PowerShell@2
             name: test
             displayName: 'Run Tests'
@@ -218,10 +197,10 @@ stages:
       - job: Code_Coverage
         displayName: 'Publish Code Coverage'
         dependsOn:
-          #- test_macos
+          - test_macos
           - test_linux
           - test_windows_core
-          # - test_windows_ps
+           - test_windows_ps
         pool:
           vmImage: 'ubuntu 16.04'
         timeoutInMinutes: 0
@@ -239,35 +218,29 @@ stages:
               artifactName: $(buildArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
           - task: DownloadPipelineArtifact@2
-            displayName: 'Download All Test Artifacts'
+            displayName: 'Download Test Artifact macOS'
             inputs:
               buildType: 'current'
-              patterns: 'CodeCoverage*'
+              artifactName: 'CodeCoverageMacOS'
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
-          # - task: DownloadPipelineArtifact@2
-          #   displayName: 'Download Test Artifact macOS'
-          #   inputs:
-          #     buildType: 'current'
-          #     artifactName: 'CodeCoverageMacOS'
-          #     targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
-          # - task: DownloadPipelineArtifact@2
-          #   displayName: 'Download Test Artifact Linux'
-          #   inputs:
-          #     buildType: 'current'
-          #     artifactName: 'CodeCoverageLinux'
-          #     targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
-          # - task: DownloadPipelineArtifact@2
-          #   displayName: 'Download Test Artifact Windows (PS 5.1)'
-          #   inputs:
-          #     buildType: 'current'
-          #     artifactName: 'CodeCoverageWinPS51'
-          #     targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
-          # - task: DownloadPipelineArtifact@2
-          #   displayName: 'Download Test Artifact Windows (PS7)'
-          #   inputs:
-          #     buildType: 'current'
-          #     artifactName: 'CodeCoverageWinPS'
-          #     targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact Linux'
+            inputs:
+              buildType: 'current'
+              artifactName: 'CodeCoverageLinux'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact Windows (PS 5.1)'
+            inputs:
+              buildType: 'current'
+              artifactName: 'CodeCoverageWinPS51'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact Windows (PS7)'
+            inputs:
+              buildType: 'current'
+              artifactName: 'CodeCoverageWinPS'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
           - task: PowerShell@2
             name: merge
             displayName: 'Merge Code Coverage files'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -234,30 +234,9 @@ stages:
               buildType: 'current'
               artifactName: $(buildArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Test Artifact macOS'
-            inputs:
-              buildType: 'current'
-              artifactName: 'CodeCoverageMacOS'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Test Artifact Linux'
-            inputs:
-              buildType: 'current'
-              artifactName: 'CodeCoverageLinux'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Test Artifact Windows (PS 5.1)'
-            inputs:
-              buildType: 'current'
-              artifactName: 'CodeCoverageWinPS51'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Test Artifact Windows (PS7)'
-            inputs:
-              buildType: 'current'
-              artifactName: 'CodeCoverageWinPS'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+          - download: 'current'
+            patterns: 'CodeCoverage*'
+            displayName: 'Download All Test Artifacts'
           - task: PowerShell@2
             name: merge
             displayName: 'Merge Code Coverage files'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,7 +126,7 @@ stages:
             displayName: 'Publish Test Artifact'
             inputs:
               targetPath: '$(buildFolderName)/$(testResultFolderName)/'
-              artifactName: 'CodeCoverage_WinPS7'
+              artifactName: 'CodeCoverageWinPS7'
               parallel: true
 
       - job: test_windows_ps
@@ -169,7 +169,7 @@ stages:
             displayName: 'Publish Test Artifact'
             inputs:
               targetPath: '$(buildFolderName)/$(testResultFolderName)/'
-              artifactName: 'CodeCoverage_WinPS51'
+              artifactName: 'CodeCoverageWinPS51'
               parallel: true
 
       - job: test_macos
@@ -212,7 +212,7 @@ stages:
             displayName: 'Publish Test Artifact'
             inputs:
               targetPath: '$(buildFolderName)/$(testResultFolderName)/'
-              artifactName: 'CodeCoverage_macOS'
+              artifactName: 'CodeCoverageMacOS'
               parallel: true
 
       - job: Code_Coverage
@@ -238,25 +238,25 @@ stages:
             displayName: 'Download Test Artifact macOS'
             inputs:
               buildType: 'current'
-              artifactName: 'CodeCoverage_macOS'
+              artifactName: 'CodeCoverageMacOS'
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_macOS'
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Test Artifact Linux'
             inputs:
               buildType: 'current'
-              artifactName: 'CodeCoverage_Linux'
+              artifactName: 'CodeCoverageLinux'
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_Linux'
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Test Artifact Windows (PS 5.1)'
             inputs:
               buildType: 'current'
-              artifactName: 'CodeCoverage_WinPS51'
+              artifactName: 'CodeCoverageWinPS51'
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_WinPS51'
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Test Artifact Windows (PS7)'
             inputs:
               buildType: 'current'
-              artifactName: 'CodeCoverage_WinPS'
+              artifactName: 'CodeCoverageWinPS'
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverage_WinPS'
           - task: PowerShell@2
             name: merge

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,7 +239,7 @@ stages:
             displayName: 'Download Test Artifact Windows (PS7)'
             inputs:
               buildType: 'current'
-              artifactName: 'CodeCoverageWinPS'
+              artifactName: 'CodeCoverageWinPS7'
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
           - task: PowerShell@2
             name: merge

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,7 +262,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Private/'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/;$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Private/;$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Public/'
           - script: |
               bash <(curl -s https://codecov.io/bash) -f "./$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml"
             displayName: 'Upload to Codecov.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,7 +262,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
-              pathToSources: '$(System.DefaultWorkingDirectory)/Sampler/'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Private/'
           - script: |
               bash <(curl -s https://codecov.io/bash) -f "./$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml"
             displayName: 'Upload to Codecov.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,7 +262,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Sampler/Private/'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Private/'
           - script: |
               bash <(curl -s https://codecov.io/bash) -f "./$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml"
             displayName: 'Upload to Codecov.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,7 +262,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/'
+              pathToSources: '$(System.DefaultWorkingDirectory)/Sampler/'
           - script: |
               bash <(curl -s https://codecov.io/bash) -f "./$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml"
             displayName: 'Upload to Codecov.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -175,33 +175,33 @@ stages:
           #     summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
           #     pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)'
 
-      - job: test_macos
-        displayName: 'macOS'
-        timeoutInMinutes: 0
-        pool:
-          vmImage: 'macos-latest'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: 'output'
-              targetPath: '$(Build.SourcesDirectory)/output'
+      # - job: test_macos
+      #   displayName: 'macOS'
+      #   timeoutInMinutes: 0
+      #   pool:
+      #     vmImage: 'macos-latest'
+      #   steps:
+      #     - task: DownloadPipelineArtifact@2
+      #       displayName: 'Download Pipeline Artifact'
+      #       inputs:
+      #         buildType: 'current'
+      #         artifactName: 'output'
+      #         targetPath: '$(Build.SourcesDirectory)/output'
 
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: dscBuildVariable
-            displayName: 'Set Environment Variables'
+      #     - powershell: |
+      #         $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
+      #         echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
+      #         echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
+      #       name: dscBuildVariable
+      #       displayName: 'Set Environment Variables'
 
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Tests'
-            inputs:
-              filePath: './build.ps1'
-              arguments: '-tasks test'
-              pwsh: true
+      #     - task: PowerShell@2
+      #       name: test
+      #       displayName: 'Run Tests'
+      #       inputs:
+      #         filePath: './build.ps1'
+      #         arguments: '-tasks test'
+      #         pwsh: true
 
           - task: PublishTestResults@2
             displayName: 'Publish Test Results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,6 @@ variables:
   buildFolderName: output
   buildArtifactName: output
   testResultFolderName: testResults
-  testArtifactName: testResults
 
 stages:
   - stage: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -244,18 +244,6 @@ stages:
               buildType: 'current'
               artifactName: $(testArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
-          - pwsh: |
-              # Add code to change version
-              $path = Resolve-Path -Path '.\output\testResults\JaCoCo_coverage.xml'
-              [xml] $xml = Get-Content -Path $path
-              Select-Xml -Xml $xml -XPath '//package' | ForEach-Object -Process { $_.Node.name = $_.Node.name -replace '^\d+\.\d+\.\d+','Sampler' }
-              Select-Xml -Xml $xml -XPath '//class' | ForEach-Object -Process { $_.Node.name = $_.Node.name -replace '^\d+\.\d+\.\d+','Sampler' }
-              $xmlSettings = New-Object -TypeName 'System.Xml.XmlWriterSettings'
-              $xmlSettings.Indent = $true
-              $xmlSettings.Encoding = [System.Text.Encoding]::Ascii
-              $xmlWriter = [System.Xml.XmlWriter]::Create($path, $xmlSettings)
-              $xml.Save($xmlWriter)
-              $xmlWriter.Close()
           - task: PublishCodeCoverageResults@1
             displayName: 'Publish Azure Code Coverage'
             condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,7 +262,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Private/'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Sampler/Private/'
           - script: |
               bash <(curl -s https://codecov.io/bash) -f "./$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml"
             displayName: 'Upload to Codecov.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,7 +93,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/output/$(dscBuildVariable.RepositoryName)'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Sampler'
 
       - job: test_windows_core
         displayName: 'Windows (PowerShell Core)'
@@ -173,7 +173,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/output/$(dscBuildVariable.RepositoryName)'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Sampler'
 
       - job: test_macos
         displayName: 'macOS'
@@ -217,7 +217,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: 'output/testResults/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/output/$(dscBuildVariable.RepositoryName)'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Sampler'
 
       - job: Code_Coverage
         displayName: 'Publish Code Coverage'
@@ -250,7 +250,7 @@ stages:
             inputs:
               codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(buildFolderName)/$(dscBuildVariable.RepositoryName)'
+              pathToSources: '$(Build.SourcesDirectory)/$(dscBuildVariable.RepositoryName)/Sampler'
           - script: |
               bash <(curl -s https://codecov.io/bash) -f "./$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml"
             displayName: 'Upload to Codecov.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -246,7 +246,7 @@ stages:
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
           - pwsh: |
               # Add code to change version
-              $path = Resolve-Path -Path '.\testResults\JaCoCo_coverage.xml'
+              $path = Resolve-Path -Path '.\output\testResults\JaCoCo_coverage.xml'
               [xml] $xml = Get-Content -Path $path
               Select-Xml -Xml $xml -XPath '//package' | ForEach-Object -Process { $_.Node.name = $_.Node.name -replace '^\d+\.\d+\.\d+','Sampler' }
               Select-Xml -Xml $xml -XPath '//class' | ForEach-Object -Process { $_.Node.name = $_.Node.name -replace '^\d+\.\d+\.\d+','Sampler' }

--- a/build.yaml
+++ b/build.yaml
@@ -57,8 +57,16 @@ Pester:
   ExcludeTag:
   Tag:
   CodeCoverageThreshold: 10 # Set to 0 to bypass
-  CodeCoverageOutputFile: JaCoCo_coverage.xml
+  # Set to specific filename to override the default filename.
+  # CodeCoverageOutputFile: JaCoCo_coverage.xml
   CodeCoverageOutputFileEncoding: ascii
+
+CodeCoverage:
+  # Filename of the file that will be outputted by the task Merge_CodeCoverage_Files.
+  CodeCoverageMergedOutputFile: JaCoCo_coverage.xml
+  # File pattern used to search for files under the ./output/testResults folder
+  # by task Merge_CodeCoverage_Files.
+  CodeCoverageFilePattern: Codecov*.xml
 
 DscTest:
   ExcludeTag:
@@ -103,6 +111,9 @@ BuildWorkflow:
     - Convert_Pester_Coverage
     - Pester_if_Code_Coverage_Under_Threshold
     - hqrmtest
+
+  merge:
+    - Merge_CodeCoverage_Files
 
   publish:
     #- publish_nupkg_to_gallery  # Deploy using Nuget

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,6 +23,3 @@ coverage:
         # and let codecov.io set the goal for the code changed in the patch.
         target: auto
         threshold: 5
-
-fixes:
-  - '^\d+\.\d+\.\d+::Sampler'  # move path "X.Y.Z" => "source"


### PR DESCRIPTION
# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Prepend the title with the [DscResourceName] if your PR is specific to a DSC resource.
    Also prepend with [BREAKING CHANGE] if relevant.
    i.e. [BREAKING CHANGE][xFile] Add security descriptor property

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.
-->

## Pull Request (PR) description

### Added
- Pipeline updated to support merging code coverage between operating
  system pipeline jobs.
### Fixed
- Fix uploading to Azure Code Coverage.
- _Merge_CodeCoverage_Files_
  - Fixed so the file that is outputted is in UTF-8 (without BOM) to support 
    Codecov.io.
  - The task now only searches for the file pattern inside the `./output/testResults`
    folder.
  - The merge process is not attempted if `CodeCoverageThreshold` is set to 
    `0`.
  - Updated so that build.yaml now have a key `CodeCoverage` which have to
    settings `CodeCoverageMergedOutputFile` and `CodeCoverageFilePattern`.
- _Convert_Pester_Coverage_
  - The backup file now have the extension `.bak` (instead of `.bak.xml`)
    so that is not mistakenly used by a task _Merge_CodeCoverage_Files_.
  - Some code cleanup.

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/267)
<!-- Reviewable:end -->
