### PR TITLE
Convert_Pester_Coverage: Fix task so it is skipped

### DIFF
--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -807,22 +807,20 @@ task Convert_Pester_Coverage {
     "`tCodeCoverageOutputFileEncoding = $CodeCoverageOutputFileEncoding"
     ""
 
+    if ($CodeCoverageThreshold -eq 0)
+    {
+        Write-Build -Color 'Green' -Text 'Coverage bypassed. Nothing to convert.'
+
+        return
+    }
+
     $PesterResultObjectClixml = Join-Path $PesterOutputFolder "PesterObject_$pesterOutputFileFileName"
 
     Write-Build -Color 'White' -Text "`tPester Output Object = $PesterResultObjectClixml"
 
     if (-not (Test-Path -Path $PesterResultObjectClixml))
     {
-        if ($CodeCoverageThreshold -eq 0)
-        {
-            Write-Build -Color 'Green' -Text 'Coverage bypassed. Nothing to convert.'
-
-            return
-        }
-        else
-        {
-            throw "No command were tested, nothing to convert."
-        }
+        throw "No command were tested, nothing to convert."
     }
     else
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix task _Convert_Pester_Coverage_ so it is skipped when `CodeCoverageThreshold`
+  is `0`.
+
 ## [0.110.0] - 2021-04-08
 
 ### Fixed


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Fixed
- Fix task _Convert_Pester_Coverage_ so it is skipped when `CodeCoverageThreshold`
  is `0`.

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/269)
<!-- Reviewable:end -->
