### PR TITLE
[Resolve-Dependency.ps1] add -Force to all Save-Module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed task file from `Merge-CodeCoverageFiles.pester.build.ps1` to `JaCoCo.coverage.build.ps1`.
 - Move task _Convert_Pester_Coverage_ to task file `JaCoCo.coverage.build.ps1`.
 - Resolve-Dependency.ps1: fix MinimumPSDependVersion comparison.
+- Resolve-Dependency.ps1: add -Force to all Save-Module.
 
 ## [0.110.1] - 2021-04-08
 

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -290,11 +290,11 @@ try
 
     if ($PSBoundParameters.ContainsKey('MinimumPSDependVersion'))
     {
-        try 
+        try
         {
             $psDependModule = $psDependModule | Where-Object -FilterScript { $_.Version -ge $MinimumPSDependVersion }
         }
-        catch 
+        catch
         {
             throw ('There was a problem finding the minimum version of PSDepend. Error: {0}' -f $_)
         }
@@ -379,6 +379,7 @@ try
                 Name       = 'PowerShell-Yaml'
                 Repository = $Gallery
                 Path       = $PSDependTarget
+                Force      = $true
             }
 
             Save-Module @SaveModuleParam

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -335,6 +335,7 @@ try
                 Name       = 'PSDepend'
                 Repository = $Gallery
                 Path       = $PSDependTarget
+                Force      = $true
             }
 
             if ($MinimumPSDependVersion)
@@ -378,6 +379,7 @@ try
                 Name       = 'PowerShell-Yaml'
                 Repository = $Gallery
                 Path       = $PSDependTarget
+                Force      = $true
             }
 
             Save-Module @SaveModuleParam


### PR DESCRIPTION
## Pull Request (PR) description

Launched `Resolve-Dependency.ps1` and encountered the following error:

```powershell
PS C:\dev\fork\sampler> .\Resolve-Dependency.ps1
Save-Module : Cannot find the path 'C:\dev\fork\sampler\output\RequiredModules' because it does not exist.
At C:\dev\fork\sampler\Resolve-Dependency.ps1:384 char:13
+             Save-Module @SaveModuleParam
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Save-Module], InvalidOperationException
    + FullyQualifiedErrorId : PathNotFound,Save-Module
```

Searched repo for all `Save-Module` mentions to include the `-Force` switch.

### Fixed
- Resolve-Dependency.ps1: add -Force to all Save-Module.

## Task list

- [ ] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/274)
<!-- Reviewable:end -->
