### PR TITLE
Change task Convert_Pester_Coverage to for Pester 5

### DIFF
--- a/.build/tasks/JaCoCo.coverage.build.ps1
+++ b/.build/tasks/JaCoCo.coverage.build.ps1
@@ -325,6 +325,10 @@ task Convert_Pester_Coverage {
         $pesterObject = Import-Clixml -Path $PesterResultObjectClixml
     }
 
+    <#
+        Evaluate Pester version to use the correct properties for hit and missed commands.
+        The property Version does not exist on the result object from Pester 4.
+    #>
     if ($pesterObject.Version)
     {
         # Pester 5
@@ -334,18 +338,12 @@ task Convert_Pester_Coverage {
         {
             throw 'When Pester 5 is used then to correctly support code coverage the minimum required version is v5.2.0.'
         }
-    }
-    else
-    {
-        # Pester 4
-        $pesterVersion = [System.Version] '4.0.0' # Set to anything other than 5.0.0 or higher
-    }
-
-    if ($pesterVersion -ge '5.2.0')
-    {
-        # Pester 5
-        $originalMissedCommands = $pesterObject.CodeCoverage.CommandsMissed
-        $originalHitCommands = $pesterObject.CodeCoverage.CommandsExecuted
+        else
+        {
+            # Pester 5
+            $originalMissedCommands = $pesterObject.CodeCoverage.CommandsMissed
+            $originalHitCommands = $pesterObject.CodeCoverage.CommandsExecuted
+        }
     }
     else
     {

--- a/.build/tasks/JaCoCo.coverage.build.ps1
+++ b/.build/tasks/JaCoCo.coverage.build.ps1
@@ -476,7 +476,7 @@ task Convert_Pester_Coverage {
 
     $targetXmlDocument = Update-JaCoCoStatistic -Document $targetXmlDocument
 
-    $sourcePathFolderName = (Split-Path -Path $SourcePath -Leaf) -replace '\\','/'
+    $sourcePathFolderName = Split-Path -Path $SourcePath -Leaf
 
     Write-Build -Color 'DarkGray' -Text ("`tUpdating path to include source folder '{0}' in the package element in the coverage file." -f $sourcePathFolderName)
 

--- a/.build/tasks/JaCoCo.coverage.build.ps1
+++ b/.build/tasks/JaCoCo.coverage.build.ps1
@@ -478,6 +478,8 @@ task Convert_Pester_Coverage {
 
     $targetXmlDocument = Update-JaCoCoStatistic -Document $targetXmlDocument
 
+    $sourcePathFolderName = (Split-Path -Path $SourcePath -Leaf) -replace '\\','/'
+
     Write-Build -Color 'DarkGray' -Text ("`tUpdating path to include source folder '{0}' in the package element in the coverage file." -f $sourcePathFolderName)
 
     Select-Xml -Xml $targetXmlDocument -XPath '//package' |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Task `Invoke_Pester_Tests_v5` will not run if Pester 4 is used in the pipeline.
 - The task _Convert\_Pester\_Coverage_ was changed to support converting
   Pester 5 code coverage.
+- The function `Get-CodeCoverageThreshold` was changed to support Pester 5
+  advanced build configuration.
+- The function `Get-SamplerCodeCoverageOutputFile` was changed to support Pester 5
+  advanced build configuration.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Invoke_Pester_Tests_v4` (previously `Invoke_Pester_Test`), and `Invoke_Pester_Tests_v5`.
   - Task `Invoke_Pester_Tests_v4` will not run if Pester 5 is used in the pipeline.
   - Task `Invoke_Pester_Tests_v5` will not run if Pester 4 is used in the pipeline.
+- The task _Convert\_Pester\_Coverage_ was changed to support converting
+  Pester 5 code coverage.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Now unit tests properly test the function in the built module, not the
   ones that the pipeline dot-sources into session to be able to dogfooding
   itself.
+- Fix so that _Convert\_Pester\_Coverage_ correctly replaces build version
+  with source folder in JaCoCo file.
 
 ## [0.110.1] - 2021-04-08
 

--- a/Sampler/Public/Get-CodeCoverageThreshold.ps1
+++ b/Sampler/Public/Get-CodeCoverageThreshold.ps1
@@ -39,11 +39,19 @@ function Get-CodeCoverageThreshold
         if ($BuildInfo.ContainsKey('Pester') -and $BuildInfo.Pester.ContainsKey('CodeCoverageThreshold'))
         {
             $codeCoverageThreshold = $BuildInfo.Pester.CodeCoverageThreshold
+
             Write-Debug -Message "Loaded Code Coverage Threshold from Config file: $codeCoverageThreshold %."
+        }
+        elseif ($BuildInfo.ContainsKey('Pester') -and $BuildInfo.Pester.ContainsKey('Configuration') -and $BuildInfo.Pester.Configuration.CodeCoverage.CoveragePercentTarget)
+        {
+            $codeCoverageThreshold = $BuildInfo.Pester.Configuration.CodeCoverage.CoveragePercentTarget
+
+            Write-Debug -Message "Loaded Code Coverage Threshold from Config file in Pester advanced configuration: $codeCoverageThreshold %."
         }
         else
         {
             $codeCoverageThreshold = 0
+
             Write-Debug -Message "No code coverage threshold value found (param nor config), using the default value."
         }
     }

--- a/Sampler/Public/Get-CodeCoverageThreshold.ps1
+++ b/Sampler/Public/Get-CodeCoverageThreshold.ps1
@@ -36,13 +36,13 @@ function Get-CodeCoverageThreshold
     # If no codeCoverageThreshold configured at runtime, look for BuildInfo settings.
     if ([String]::IsNullOrEmpty($RuntimeCodeCoverageThreshold))
     {
-        if ($BuildInfo.ContainsKey('Pester') -and $BuildInfo.Pester.ContainsKey('CodeCoverageThreshold'))
+        if ($BuildInfo -and $BuildInfo.ContainsKey('Pester') -and $BuildInfo.Pester.ContainsKey('CodeCoverageThreshold'))
         {
             $codeCoverageThreshold = $BuildInfo.Pester.CodeCoverageThreshold
 
             Write-Debug -Message "Loaded Code Coverage Threshold from Config file: $codeCoverageThreshold %."
         }
-        elseif ($BuildInfo.ContainsKey('Pester') -and $BuildInfo.Pester.ContainsKey('Configuration') -and $BuildInfo.Pester.Configuration.CodeCoverage.CoveragePercentTarget)
+        elseif ($BuildInfo -and $BuildInfo.ContainsKey('Pester') -and $BuildInfo.Pester.ContainsKey('Configuration') -and $BuildInfo.Pester.Configuration.CodeCoverage.CoveragePercentTarget)
         {
             $codeCoverageThreshold = $BuildInfo.Pester.Configuration.CodeCoverage.CoveragePercentTarget
 
@@ -58,6 +58,7 @@ function Get-CodeCoverageThreshold
     else
     {
         $codeCoverageThreshold = [int] $RuntimeCodeCoverageThreshold
+
         Write-Debug -Message "Loading CodeCoverage Threshold from Parameter ($codeCoverageThreshold %)."
     }
 

--- a/Sampler/Public/Get-SamplerCodeCoverageOutputFile.ps1
+++ b/Sampler/Public/Get-SamplerCodeCoverageOutputFile.ps1
@@ -32,11 +32,20 @@ function Get-SamplerCodeCoverageOutputFile
         $PesterOutputFolder
     )
 
+    $codeCoverageOutputFile = $null
+
     if ($BuildInfo.ContainsKey('Pester') -and $BuildInfo.Pester.ContainsKey('CodeCoverageOutputFile'))
     {
-        $codeCoverageOutputFile = $executioncontext.invokecommand.expandstring($BuildInfo.Pester.CodeCoverageOutputFile)
+        $codeCoverageOutputFile = $ExecutionContext.InvokeCommand.ExpandString($BuildInfo.Pester.CodeCoverageOutputFile)
+    }
+    elseif ($BuildInfo.ContainsKey('Pester') -and $BuildInfo.Pester.ContainsKey('Configuration') -and $BuildInfo.Pester.Configuration.CodeCoverage.OutputPath)
+    {
+        $codeCoverageOutputFile = $ExecutionContext.InvokeCommand.ExpandString($BuildInfo.Pester.Configuration.CodeCoverage.OutputPath)
+    }
 
-        if (-not (Split-Path -IsAbsolute $codeCoverageOutputFile))
+    if (-not [System.String]::IsNullOrEmpty($codeCoverageOutputFile))
+    {
+        if (-not (Split-Path -Path $codeCoverageOutputFile -IsAbsolute))
         {
             $codeCoverageOutputFile = Join-Path -Path $PesterOutputFolder -ChildPath $codeCoverageOutputFile
 
@@ -45,6 +54,7 @@ function Get-SamplerCodeCoverageOutputFile
     }
     else
     {
+        # Make sure to return the value as $null if it for some reason was set to an empty string.
         $codeCoverageOutputFile = $null
     }
 

--- a/tests/Unit/Public/Get-CodeCoverageThreshold.tests.ps1
+++ b/tests/Unit/Public/Get-CodeCoverageThreshold.tests.ps1
@@ -1,0 +1,112 @@
+$ProjectPath = "$PSScriptRoot\..\..\.." | Convert-Path
+$ProjectName = (
+    (Get-ChildItem -Path $ProjectPath\*\*.psd1).Where{
+        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+        $(
+            try
+            {
+                Test-ModuleManifest $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            }
+        )
+    }
+).BaseName
+
+Import-Module $ProjectName
+
+Describe 'Get-CodeCoverageThreshold' {
+    Context 'When passing an integer value for RuntimeCodeCoverageThreshold' {
+        It 'Should return the same value as passed' {
+            $result = Sampler\Get-CodeCoverageThreshold -RuntimeCodeCoverageThreshold 10
+
+            $result | Should -Be 10
+        }
+    }
+
+    Context 'When passing a string value for RuntimeCodeCoverageThreshold' {
+        It 'Should return the same value as passed' {
+            $result = Sampler\Get-CodeCoverageThreshold -RuntimeCodeCoverageThreshold '21'
+
+            $result | Should -Be 21
+        }
+    }
+
+    Context 'When RuntimeCodeCoverageThreshold is $null' {
+        Context 'When there is no build configuration value' {
+            It 'Should return 0' {
+                $result = Sampler\Get-CodeCoverageThreshold -RuntimeCodeCoverageThreshold $null
+
+                $result | Should -Be 0
+            }
+        }
+
+        Context 'When using deprecated Pester build configuration value' {
+            It 'Should return the configured value' {
+                $result = Sampler\Get-CodeCoverageThreshold -RuntimeCodeCoverageThreshold $null -BuildInfo @{
+                    Pester = @{
+                        CodeCoverageThreshold = 30
+                    }
+                }
+
+                $result | Should -Be 30
+            }
+        }
+
+        Context 'When using advanced Pester build configuration value' {
+            It 'Should return the configured value' {
+                $result = Sampler\Get-CodeCoverageThreshold -RuntimeCodeCoverageThreshold $null -BuildInfo @{
+                    Pester = @{
+                        Configuration = @{
+                            CodeCoverage = @{
+                                CoveragePercentTarget = 40
+                            }
+                        }
+                    }
+                }
+
+                $result | Should -Be 40
+            }
+        }
+    }
+
+    Context 'When RuntimeCodeCoverageThreshold is not passed' {
+        Context 'When there is no build configuration value' {
+            It 'Should return 0' {
+                $result = Sampler\Get-CodeCoverageThreshold
+
+                $result | Should -Be 0
+            }
+        }
+
+        Context 'When using deprecated Pester build configuration value' {
+            It 'Should return the configured value' {
+                $result = Sampler\Get-CodeCoverageThreshold -BuildInfo @{
+                    Pester = @{
+                        CodeCoverageThreshold = 30
+                    }
+                }
+
+                $result | Should -Be 30
+            }
+        }
+
+        Context 'When using advanced Pester build configuration value' {
+            It 'Should return the configured value' {
+                $result = Sampler\Get-CodeCoverageThreshold -BuildInfo @{
+                    Pester = @{
+                        Configuration = @{
+                            CodeCoverage = @{
+                                CoveragePercentTarget = 40
+                            }
+                        }
+                    }
+                }
+
+                $result | Should -Be 40
+            }
+        }
+    }
+}

--- a/tests/Unit/Public/Get-SamplerCodeCoverageOutputFile.tests.ps1
+++ b/tests/Unit/Public/Get-SamplerCodeCoverageOutputFile.tests.ps1
@@ -1,0 +1,96 @@
+$ProjectPath = "$PSScriptRoot\..\..\.." | Convert-Path
+$ProjectName = (
+    (Get-ChildItem -Path $ProjectPath\*\*.psd1).Where{
+        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+        $(
+            try
+            {
+                Test-ModuleManifest $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            }
+        )
+    }
+).BaseName
+
+Import-Module $ProjectName
+
+Describe 'Get-SamplerCodeCoverageOutputFile' {
+    Context 'When there is no build configuration value' {
+        It 'Should return $null' {
+            $result = Sampler\Get-SamplerCodeCoverageOutputFile -PesterOutputFolder $TestDrive -BuildInfo @{}
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'When using deprecated Pester build configuration value' {
+        BeforeAll {
+            $mockAbsolutePath = Join-Path -Path $TestDrive -ChildPath 'JaCoCo_coverage.xml'
+        }
+
+        Context 'When passing absolute path' {
+            It 'Should return the absolute path' {
+                $result = Sampler\Get-SamplerCodeCoverageOutputFile -PesterOutputFolder $TestDrive -BuildInfo @{
+                    Pester = @{
+                        CodeCoverageOutputFile = $mockAbsolutePath
+                    }
+                }
+
+                $result | Should -Be $mockAbsolutePath
+            }
+        }
+
+        Context 'When passing relative path' {
+            It 'Should return the configured value' {
+                $result = Sampler\Get-SamplerCodeCoverageOutputFile -PesterOutputFolder $TestDrive -BuildInfo @{
+                    Pester = @{
+                        CodeCoverageOutputFile = 'JaCoCo_coverage.xml'
+                    }
+                }
+
+                $result | Should -Be $mockAbsolutePath
+            }
+        }
+    }
+
+    Context 'When using advanced Pester build configuration value' {
+        BeforeAll {
+            $mockAbsolutePath = Join-Path -Path $TestDrive -ChildPath 'JaCoCo_coverage.xml'
+        }
+
+        Context 'When passing absolute path' {
+            It 'Should return the absolute path' {
+                $result = Sampler\Get-SamplerCodeCoverageOutputFile -PesterOutputFolder $TestDrive -BuildInfo @{
+                    Pester = @{
+                        Configuration = @{
+                            CodeCoverage = @{
+                                OutputPath = $mockAbsolutePath
+                            }
+                        }
+                    }
+                }
+
+                $result | Should -Be $mockAbsolutePath
+            }
+        }
+
+        Context 'When passing relative path' {
+            It 'Should return the configured value' {
+                $result = Sampler\Get-SamplerCodeCoverageOutputFile -PesterOutputFolder $TestDrive -BuildInfo @{
+                    Pester = @{
+                        Configuration = @{
+                            CodeCoverage = @{
+                                OutputPath = 'JaCoCo_coverage.xml'
+                            }
+                        }
+                    }
+                }
+
+                $result | Should -Be $mockAbsolutePath
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Changed
- The task _Convert\_Pester\_Coverage_ was changed to support converting
  Pester 5 code coverage.
- The task _Convert\_Pester\_Coverage_ was changed to support converting
  Pester 5 code coverage.
- The function `Get-CodeCoverageThreshold` was changed to support Pester 5
  advanced build configuration.
- The function `Get-SamplerCodeCoverageOutputFile` was changed to support Pester 5
  advanced build configuration.

### Fixed

- Fix so that _Convert\_Pester\_Coverage_ correctly replaces build version
  with source folder in JaCoCo file.

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/284)
<!-- Reviewable:end -->
