### PR TITLE
Added unit test for public command `Get-BuildVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new build task `Import_Pester` ([issue #223](https://github.com/gaelcolas/Sampler/issues/223)).
 - Added new build task `Invoke_Pester_Tests_v5` ([issue #223](https://github.com/gaelcolas/Sampler/issues/223)).
   - Task `Invoke_Pester_Tests_v5` will not run if Pester 4 is used in the pipeline.
+- Added unit test for public command `Get-BuildVersion`.
 
 ### Changed
 

--- a/tests/Unit/Public/Get-BuildVersion.tests.ps1
+++ b/tests/Unit/Public/Get-BuildVersion.tests.ps1
@@ -1,0 +1,230 @@
+$ProjectPath = "$PSScriptRoot\..\..\.." | Convert-Path
+$ProjectName = (
+    (Get-ChildItem -Path $ProjectPath\*\*.psd1).Where{
+        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+        $(
+            try
+            {
+                Test-ModuleManifest $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            }
+        )
+    }
+).BaseName
+
+Import-Module $ProjectName
+
+Describe 'Get-BuildVersion' {
+    Context 'When a value for parameter ModuleVersion is passed' {
+        Context 'When passing a module version' {
+            It 'Should return the correct module version' {
+                $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive -ModuleVersion '2.1.3'
+
+                $result | Should -Be '2.1.3'
+            }
+        }
+
+        Context 'When passing a preview module version' {
+            It 'Should return the correct module version' {
+                $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive -ModuleVersion '2.1.3-preview0023'
+
+                $result | Should -Be '2.1.3-preview0023'
+            }
+        }
+    }
+
+    Context 'When an empty string is passed as value for parameter ModuleVersion' {
+        Context 'When gitversion is not available' {
+            BeforeAll {
+                Mock -CommandName Get-Command -ModuleName $ProjectName
+            }
+
+            Context 'When passing a module version' {
+                BeforeAll {
+                    Mock -CommandName Import-PowerShellDataFile -MockWith {
+                        return @{
+                            ModuleVersion = '2.1.3'
+                            PrivateData = @{
+                                PSData = @{
+                                    Prerelease = ''
+                                }
+                            }
+                        }
+                    } -ModuleName $ProjectName
+                }
+
+                It 'Should return the correct module version' {
+                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive -ModuleVersion ''
+
+                    $result | Should -Be '2.1.3'
+                }
+            }
+
+            Context 'When passing a preview module version' {
+                BeforeAll {
+                    Mock -CommandName Import-PowerShellDataFile -MockWith {
+                        return @{
+                            ModuleVersion = '2.1.3'
+                            PrivateData = @{
+                                PSData = @{
+                                    Prerelease = 'preview0023'
+                                }
+                            }
+                        }
+                    } -ModuleName $ProjectName
+                }
+
+                It 'Should return the correct module version' {
+                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive -ModuleVersion ''
+
+                    $result | Should -Be '2.1.3-preview0023'
+                }
+            }
+        }
+
+        Context 'When gitversion is available' {
+            BeforeAll {
+                Mock -CommandName Get-Command -MockWith {
+                    return $true
+                } -ModuleName $ProjectName
+
+                # Stub for gitversion.exe so we can mock the result.
+                function gitversion
+                {
+                    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+                }
+            }
+
+            AfterAll {
+                Remove-Item -Path 'function:gitversion' -Force
+            }
+
+            Context 'When passing a module version' {
+                BeforeAll {
+                    Mock -CommandName gitversion -MockWith {
+                        return '{"NuGetVersionV2": "2.1.3"}'
+                    } -ModuleName $ProjectName
+                }
+
+                It 'Should return the correct module version' {
+                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive -ModuleVersion ''
+
+                    $result | Should -Be '2.1.3'
+                }
+            }
+
+            Context 'When passing a preview module version' {
+                BeforeAll {
+                    Mock -CommandName gitversion -MockWith {
+                        return '{"NuGetVersionV2": "2.1.3-preview0023"}'
+                    } -ModuleName $ProjectName
+                }
+
+                It 'Should return the correct module version' {
+                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive -ModuleVersion ''
+
+                    $result | Should -Be '2.1.3-preview0023'
+                }
+            }
+        }
+    }
+
+    Context 'When no value is passed for parameter ModuleVersion' {
+        Context 'When gitversion is not available' {
+            BeforeAll {
+                Mock -CommandName Get-Command -ModuleName $ProjectName
+            }
+
+            Context 'When passing a module version' {
+                BeforeAll {
+                    Mock -CommandName Import-PowerShellDataFile -MockWith {
+                        return @{
+                            ModuleVersion = '2.1.3'
+                            PrivateData = @{
+                                PSData = @{
+                                    Prerelease = ''
+                                }
+                            }
+                        }
+                    } -ModuleName $ProjectName
+                }
+
+                It 'Should return the correct module version' {
+                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive
+
+                    $result | Should -Be '2.1.3'
+                }
+            }
+
+            Context 'When passing a preview module version' {
+                BeforeAll {
+                    Mock -CommandName Import-PowerShellDataFile -MockWith {
+                        return @{
+                            ModuleVersion = '2.1.3'
+                            PrivateData = @{
+                                PSData = @{
+                                    Prerelease = 'preview0023'
+                                }
+                            }
+                        }
+                    } -ModuleName $ProjectName
+                }
+
+                It 'Should return the correct module version' {
+                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive
+
+                    $result | Should -Be '2.1.3-preview0023'
+                }
+            }
+        }
+
+        Context 'When gitversion is available' {
+            BeforeAll {
+                Mock -CommandName Get-Command -MockWith {
+                    return $true
+                } -ModuleName $ProjectName
+
+                # Stub for gitversion.exe so we can mock the result.
+                function gitversion
+                {
+                    throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+                }
+            }
+
+            AfterAll {
+                Remove-Item -Path 'function:gitversion' -Force
+            }
+
+            Context 'When passing a module version' {
+                BeforeAll {
+                    Mock -CommandName gitversion -MockWith {
+                        return '{"NuGetVersionV2": "2.1.3"}'
+                    } -ModuleName $ProjectName
+                }
+
+                It 'Should return the correct module version' {
+                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive
+
+                    $result | Should -Be '2.1.3'
+                }
+            }
+
+            Context 'When passing a preview module version' {
+                BeforeAll {
+                    Mock -CommandName gitversion -MockWith {
+                        return '{"NuGetVersionV2": "2.1.3-preview0023"}'
+                    } -ModuleName $ProjectName
+                }
+
+                It 'Should return the correct module version' {
+                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive
+
+                    $result | Should -Be '2.1.3-preview0023'
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Added
- Added unit test for public command `Get-BuildVersion`.

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/286)
<!-- Reviewable:end -->
