### PR TITLE
Fix task `Invoke_Pester_Tests_v5`

### DIFF
--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -803,16 +803,19 @@ Pester:
             $defaultCodeCoveragePaths = (Get-ChildItem -Path $moduleUnderTest.ModuleBase -Include @('*.psm1', '*.ps1') -Recurse).Where{
                 $result = $true
 
-                foreach ($excludePath in $ExcludeFromCodeCoverage)
+                if ($ExcludeFromCodeCoverage)
                 {
-                    if (-not (Split-Path -IsAbsolute $excludePath))
+                    foreach ($excludePath in $ExcludeFromCodeCoverage)
                     {
-                        $excludePath = Join-Path -Path $moduleUnderTest.ModuleBase -ChildPath $excludePath
-                    }
+                        if (-not (Split-Path -IsAbsolute $excludePath))
+                        {
+                            $excludePath = Join-Path -Path $moduleUnderTest.ModuleBase -ChildPath $excludePath
+                        }
 
-                    if ($_.FullName -match ([regex]::Escape($excludePath)))
-                    {
-                        $result = $false
+                        if ($_.FullName -match ([regex]::Escape($excludePath)))
+                        {
+                            $result = $false
+                        }
                     }
                 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- If the Pester build configuration key `ExcludeFromCodeCoverage` does
+  not specify a value, the task `Invoke_Pester_Tests_v5` no longer fails.
+
 ## [0.111.2] - 2021-05-21
 
 ### Fixed


### PR DESCRIPTION
# Pull Request


## Pull Request (PR) description

### Fixed
- If the Pester build configuration key `ExcludeFromCodeCoverage` does
  not specify a value, the task `Invoke_Pester_Tests_v5` no longer fails.

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/295)
<!-- Reviewable:end -->
