### PR TITLE
Fixe issue #299 and correct PR #306

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added support of `BuiltSubDirectoryDirectory` in build configuration files ([issue #299](https://github.com/gaelcolas/Sampler/issues/299)) .
+- Added support of `BuiltSubDirectoryDirectory` in build configuration files
+ ([issue #299](https://github.com/gaelcolas/Sampler/issues/299)).
+
+### Fixed
+
+- Removed `$BuiltModuleSubdirectory` definition in the `begin` bloc of `build.ps1`
+ template ([issue #299](https://github.com/gaelcolas/Sampler/issues/299)).
 
 ### Fixed
 

--- a/Sampler/Templates/Build/build.ps1
+++ b/Sampler/Templates/Build/build.ps1
@@ -440,30 +440,6 @@ Begin
             }
         }
 
-        if ($BuiltModuleSubdirectory)
-        {
-            if (-not (Split-Path -IsAbsolute -Path $BuiltModuleSubdirectory))
-            {
-                $BuildModuleOutput = Join-Path -Path $OutputDirectory -ChildPath $BuiltModuleSubdirectory
-            }
-            else
-            {
-                $BuildModuleOutput = $BuiltModuleSubdirectory
-            }
-        }
-        else
-        {
-            $BuildModuleOutput = $OutputDirectory
-        }
-
-        # Pre-pending $BuildModuleOutput folder to PSModulePath to resolve built module from this folder.
-        if ($powerShellModulePaths -notcontains $BuildModuleOutput)
-        {
-            Write-Host -Object "[pre-build] Pre-pending '$BuildModuleOutput' folder to PSModulePath" -ForegroundColor Green
-
-            $env:PSModulePath = $BuildModuleOutput + [System.IO.Path]::PathSeparator + $env:PSModulePath
-        }
-
         <#
             The variable $PSDependTarget will be used below when building the splatting
             variable before calling Resolve-Dependency.ps1, unless overridden in the

--- a/Sampler/scripts/Set-SamplerTaskVariable.ps1
+++ b/Sampler/scripts/Set-SamplerTaskVariable.ps1
@@ -82,13 +82,13 @@ $OutputDirectory = Get-SamplerAbsolutePath -Path $OutputDirectory -RelativeTo $B
 "`tOutput Directory           = '$OutputDirectory'"
 <#
     We check if the value is set in build.yaml.
-    1 . If it past to parameter, we use parameter,
+    1 . If it past to parameter, or defined in parameter property we use parameter,
     2 . If it set in build.yaml we use it
-    3 . Use default value
+    3 . If it set nowhere, we used an empty value
 #>
-if ($PSBoundParameters.ContainsKey('BuiltModuleSubdirectory'))
+if (-not [string]::IsNullOrEmpty($BuiltModuleSubDirectory))
 {
-    $BuiltModuleSubdirectory = Get-SamplerAbsolutePath -Path $BuiltModuleSubdirectory -RelativeTo $OutputDirectory
+    $BuiltModuleSubdirectory = Get-SamplerAbsolutePath -Path $BuiltModuleSubDirectory -RelativeTo $OutputDirectory
 }
 elseif ($BuildInfo.ContainsKey('BuiltModuleSubdirectory'))
 {
@@ -96,7 +96,7 @@ elseif ($BuildInfo.ContainsKey('BuiltModuleSubdirectory'))
     $BuildModuleOutput = $BuiltModuleSubdirectory
 }
 else {
-    $BuiltModuleSubdirectory = Get-SamplerAbsolutePath -Path $BuiltModuleSubdirectory -RelativeTo $OutputDirectory
+    $BuiltModuleSubdirectory = Get-SamplerAbsolutePath -Path '' -RelativeTo $OutputDirectory
 }
 
 "`tBuilt Module Subdirectory  = '$BuiltModuleSubdirectory'"

--- a/tests/Integration/Tasks/Set-SamplerTaskVariable.Tests.ps1
+++ b/tests/Integration/Tasks/Set-SamplerTaskVariable.Tests.ps1
@@ -29,6 +29,7 @@ Describe 'Set-SamplerTaskVariable' {
         $originalModuleVersionFolder = $ModuleVersionFolder
         $originalPreReleaseTag = $PreReleaseTag
         $originalBuiltModuleRootScriptPath = $BuiltModuleRootScriptPath
+        $originalBuildInfo = $BuildInfo
     }
 
     Context 'When calling the function with parameter AsNewBuild' {
@@ -65,6 +66,8 @@ Describe 'Set-SamplerTaskVariable' {
             $OutputDirectory = $originalOutputDirectory
             $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
             $ReleaseNotesPath = $originalReleaseNotesPath
+            $BuildInfo = $originalBuildInfo
+
         }
 
         It 'Should return the expected output' {
@@ -85,6 +88,82 @@ Describe 'Set-SamplerTaskVariable' {
             $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
             $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
         }
+
+        Context 'When BuiltSubModuleDirectory is set on parameter' {
+            BeforeAll {
+                $BuiltModuleSubdirectory = 'SubDir'
+            }
+
+            AfterAll {
+                $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
+            }
+
+            It 'Should return the expected output' {
+                $result = . Sampler\Set-SamplerTaskVariable -AsNewBuild
+
+                Write-Debug ($result | Out-String) -Verbose
+
+                $result | Should -Contain "`tProject Name               = 'MyProject'"
+                $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
+                $result | Should -Contain ("`tOutput Directory           = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output'))
+                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir'))
+                $result | Should -Contain ("`tModule Manifest Path (src) = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source/MyProject.psd1'))
+                $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
+                $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
+            }
+        }
+
+        Context 'When BuiltSubModuleDirectory is set in the build configuration file' {
+            BeforeAll {
+                $BuiltModuleSubdirectory = ''
+                $BuildInfo['BuiltModuleSubdirectory'] = 'SubDir'
+            }
+
+            AfterAll {
+                $BuildInfo = $originalBuildInfo
+                $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
+            }
+
+            It 'Should return the expected output' {
+                $result = . Sampler\Set-SamplerTaskVariable -AsNewBuild -Verbose
+
+                Write-Debug ($result | Out-String) -Verbose
+
+                $result | Should -Contain "`tProject Name               = 'MyProject'"
+                $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
+                $result | Should -Contain ("`tOutput Directory           = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output'))
+                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir'))
+                $result | Should -Contain ("`tModule Manifest Path (src) = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source/MyProject.psd1'))
+                $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
+                $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
+            }
+        }
+
+        Context 'When BuiltSubModuleDirectory is set in the build configuration file and on parameter' {
+            BeforeAll {
+                $BuiltModuleSubdirectory = 'SubDir'
+                $BuildInfo['BuiltModuleSubdirectory'] = 'SubDirFile'
+            }
+
+            AfterAll {
+                $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
+                $BuildInfo = $originalBuildInfo
+            }
+
+            It 'Should return the expected output' {
+                $result = . Sampler\Set-SamplerTaskVariable -AsNewBuild
+
+                Write-Debug ($result | Out-String) -Verbose
+
+                $result | Should -Contain "`tProject Name               = 'MyProject'"
+                $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
+                $result | Should -Contain ("`tOutput Directory           = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output'))
+                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir'))
+                $result | Should -Contain ("`tModule Manifest Path (src) = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source/MyProject.psd1'))
+                $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
+                $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
+            }
+        }
     }
 
     Context 'When calling the function without a parameter' {
@@ -95,6 +174,7 @@ Describe 'Set-SamplerTaskVariable' {
             # Remove parent scope's value.
             $ProjectName = $null
             $SourcePath = $null
+            $BuildInfo = @{}
 
             $OutputDirectory = 'output'
             $BuiltModuleSubdirectory = ''
@@ -191,6 +271,127 @@ Describe 'Set-SamplerTaskVariable' {
             $result | Should -Contain "`tModule Version Folder      = '1.0.0'"
             $result | Should -Contain "`tPre-release Tag            = 'preview'"
             $result | Should -Contain ("`tBuilt Module Root Script   = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\MyProject\1.0.0-preview\MyProject.psm1'))
+        }
+
+        Context 'When BuiltSubModuleDirectory is set on parameter' {
+            BeforeAll {
+                $BuiltModuleSubdirectory = 'SubDir'
+                $mockBuiltModuleManifest = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview/MyProject.psd1'
+                $mockBuiltModuleBase = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview'
+                $mockBuiltModuleRootScriptPath = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview/MyProject.psm1'
+            }
+
+            AfterAll {
+                $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
+            }
+
+            It 'Should return the expected output' {
+                <#
+                    Since Sampler adds its own alias in build.ps1 that does not point
+                    to the built module's Set-SamplerTaskVariable we must point
+                    out that the alias to test is the one in the module.
+                #>
+                $result = . Sampler\Set-SamplerTaskVariable
+
+                Write-Debug ($result | Out-String) -Verbose
+
+                $result | Should -Contain "`tProject Name               = 'MyProject'"
+                $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
+                $result | Should -Contain ("`tOutput Directory           = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output'))
+                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir'))
+                $result | Should -Contain ("`tModule Manifest Path (src) = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source/MyProject.psd1'))
+                $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
+                $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
+
+                $result | Should -Contain "`tVersioned Output Directory = 'True'"
+                $result | Should -Contain ("`tBuilt Module Manifest      = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview\MyProject.psd1'))
+                $result | Should -Contain ("`tBuilt Module Base          = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview'))
+                $result | Should -Contain "`tModule Version Folder      = '1.0.0'"
+                $result | Should -Contain "`tPre-release Tag            = 'preview'"
+                $result | Should -Contain ("`tBuilt Module Root Script   = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview\MyProject.psm1'))
+            }
+        }
+
+        Context 'When BuiltSubModuleDirectory is set in the build configuration file' {
+            BeforeAll {
+                $BuiltModuleSubdirectory = ''
+                $BuildInfo['BuiltModuleSubdirectory'] = 'SubDir'
+                $mockBuiltModuleManifest = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview/MyProject.psd1'
+                $mockBuiltModuleBase = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview'
+                $mockBuiltModuleRootScriptPath = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview/MyProject.psm1'
+            }
+
+            AfterAll {
+                $BuildInfo = $originalBuildInfo
+                $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
+            }
+
+            It 'Should return the expected output' {
+                <#
+                    Since Sampler adds its own alias in build.ps1 that does not point
+                    to the built module's Set-SamplerTaskVariable we must point
+                    out that the alias to test is the one in the module.
+                #>
+                $result = . Sampler\Set-SamplerTaskVariable -Verbose
+
+                Write-Debug ($result | Out-String) -Verbose
+
+                $result | Should -Contain "`tProject Name               = 'MyProject'"
+                $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
+                $result | Should -Contain ("`tOutput Directory           = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output'))
+                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir'))
+                $result | Should -Contain ("`tModule Manifest Path (src) = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source/MyProject.psd1'))
+                $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
+                $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
+
+                $result | Should -Contain "`tVersioned Output Directory = 'True'"
+                $result | Should -Contain ("`tBuilt Module Manifest      = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview\MyProject.psd1'))
+                $result | Should -Contain ("`tBuilt Module Base          = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview'))
+                $result | Should -Contain "`tModule Version Folder      = '1.0.0'"
+                $result | Should -Contain "`tPre-release Tag            = 'preview'"
+                $result | Should -Contain ("`tBuilt Module Root Script   = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview\MyProject.psm1'))
+            }
+        }
+
+        Context 'When BuiltSubModuleDirectory is set in the build configuration file and on parameter' {
+            BeforeAll {
+                $BuiltModuleSubdirectory = 'SubDir'
+                $BuildInfo['BuiltModuleSubdirectory'] = 'SubDirFile'
+                $mockBuiltModuleManifest = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview/MyProject.psd1'
+                $mockBuiltModuleBase = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview'
+                $mockBuiltModuleRootScriptPath = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview/MyProject.psm1'
+            }
+
+            AfterAll {
+                $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
+                $BuildInfo = $originalBuildInfo
+            }
+
+            It 'Should return the expected output with parameter priority' {
+                <#
+                    Since Sampler adds its own alias in build.ps1 that does not point
+                    to the built module's Set-SamplerTaskVariable we must point
+                    out that the alias to test is the one in the module.
+                #>
+                $result = . Sampler\Set-SamplerTaskVariable
+
+                Write-Debug ($result | Out-String) -Verbose
+
+                $result | Should -Contain "`tProject Name               = 'MyProject'"
+                $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
+                $result | Should -Contain ("`tOutput Directory           = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output'))
+                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir'))
+                $result | Should -Contain ("`tModule Manifest Path (src) = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source/MyProject.psd1'))
+                $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
+                $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
+
+                $result | Should -Contain "`tVersioned Output Directory = 'True'"
+                $result | Should -Contain ("`tBuilt Module Manifest      = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview\MyProject.psd1'))
+                $result | Should -Contain ("`tBuilt Module Base          = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview'))
+                $result | Should -Contain "`tModule Version Folder      = '1.0.0'"
+                $result | Should -Contain "`tPre-release Tag            = 'preview'"
+                $result | Should -Contain ("`tBuilt Module Root Script   = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview\MyProject.psm1'))
+            }
         }
     }
 

--- a/tests/Integration/Tasks/Set-SamplerTaskVariable.Tests.ps1
+++ b/tests/Integration/Tasks/Set-SamplerTaskVariable.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Set-SamplerTaskVariable' {
         $originalModuleVersionFolder = $ModuleVersionFolder
         $originalPreReleaseTag = $PreReleaseTag
         $originalBuiltModuleRootScriptPath = $BuiltModuleRootScriptPath
-        $originalBuildInfo = $BuildInfo
+        $originalBuildInfo = $BuildInfo.Clone()
     }
 
     Context 'When calling the function with parameter AsNewBuild' {
@@ -66,7 +66,7 @@ Describe 'Set-SamplerTaskVariable' {
             $OutputDirectory = $originalOutputDirectory
             $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
             $ReleaseNotesPath = $originalReleaseNotesPath
-            $BuildInfo = $originalBuildInfo
+            #$BuildInfo = $originalBuildInfo.Clone()
 
         }
 
@@ -91,7 +91,7 @@ Describe 'Set-SamplerTaskVariable' {
 
         Context 'When BuiltSubModuleDirectory is set on parameter' {
             BeforeAll {
-                $BuiltModuleSubdirectory = 'SubDir'
+                $BuiltModuleSubdirectory = 'SubDir1'
             }
 
             AfterAll {
@@ -106,7 +106,7 @@ Describe 'Set-SamplerTaskVariable' {
                 $result | Should -Contain "`tProject Name               = 'MyProject'"
                 $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
                 $result | Should -Contain ("`tOutput Directory           = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output'))
-                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir'))
+                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir1'))
                 $result | Should -Contain ("`tModule Manifest Path (src) = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source/MyProject.psd1'))
                 $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
                 $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
@@ -116,12 +116,12 @@ Describe 'Set-SamplerTaskVariable' {
         Context 'When BuiltSubModuleDirectory is set in the build configuration file' {
             BeforeAll {
                 $BuiltModuleSubdirectory = ''
-                $BuildInfo['BuiltModuleSubdirectory'] = 'SubDir'
+                $BuildInfo['BuiltModuleSubdirectory'] = 'SubDir2'
             }
 
             AfterAll {
-                $BuildInfo = $originalBuildInfo
                 $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
+                $BuildInfo['BuiltModuleSubdirectory'] = $originalBuildInfo['BuiltModuleSubdirectory']
             }
 
             It 'Should return the expected output' {
@@ -132,7 +132,7 @@ Describe 'Set-SamplerTaskVariable' {
                 $result | Should -Contain "`tProject Name               = 'MyProject'"
                 $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
                 $result | Should -Contain ("`tOutput Directory           = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output'))
-                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir'))
+                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir2'))
                 $result | Should -Contain ("`tModule Manifest Path (src) = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source/MyProject.psd1'))
                 $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
                 $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
@@ -141,13 +141,13 @@ Describe 'Set-SamplerTaskVariable' {
 
         Context 'When BuiltSubModuleDirectory is set in the build configuration file and on parameter' {
             BeforeAll {
-                $BuiltModuleSubdirectory = 'SubDir'
+                $BuiltModuleSubdirectory = 'SubDir3'
                 $BuildInfo['BuiltModuleSubdirectory'] = 'SubDirFile'
             }
 
             AfterAll {
                 $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
-                $BuildInfo = $originalBuildInfo
+                $BuildInfo['BuiltModuleSubdirectory'] = $originalBuildInfo['BuiltModuleSubdirectory']
             }
 
             It 'Should return the expected output' {
@@ -158,7 +158,7 @@ Describe 'Set-SamplerTaskVariable' {
                 $result | Should -Contain "`tProject Name               = 'MyProject'"
                 $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
                 $result | Should -Contain ("`tOutput Directory           = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output'))
-                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir'))
+                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir3'))
                 $result | Should -Contain ("`tModule Manifest Path (src) = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source/MyProject.psd1'))
                 $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
                 $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
@@ -174,7 +174,6 @@ Describe 'Set-SamplerTaskVariable' {
             # Remove parent scope's value.
             $ProjectName = $null
             $SourcePath = $null
-            $BuildInfo = @{}
 
             $OutputDirectory = 'output'
             $BuiltModuleSubdirectory = ''
@@ -245,6 +244,7 @@ Describe 'Set-SamplerTaskVariable' {
             $OutputDirectory = $originalOutputDirectory
             $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
             $ReleaseNotesPath = $originalReleaseNotesPath
+            $BuildInfo = $originalBuildInfo.Clone()
         }
 
         It 'Should return the expected output' {
@@ -275,10 +275,10 @@ Describe 'Set-SamplerTaskVariable' {
 
         Context 'When BuiltSubModuleDirectory is set on parameter' {
             BeforeAll {
-                $BuiltModuleSubdirectory = 'SubDir'
-                $mockBuiltModuleManifest = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview/MyProject.psd1'
-                $mockBuiltModuleBase = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview'
-                $mockBuiltModuleRootScriptPath = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview/MyProject.psm1'
+                $BuiltModuleSubdirectory = 'SubDir4'
+                $mockBuiltModuleManifest = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir4/MyProject/1.0.0-preview/MyProject.psd1'
+                $mockBuiltModuleBase = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir4/MyProject/1.0.0-preview'
+                $mockBuiltModuleRootScriptPath = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir4/MyProject/1.0.0-preview/MyProject.psm1'
             }
 
             AfterAll {
@@ -298,32 +298,32 @@ Describe 'Set-SamplerTaskVariable' {
                 $result | Should -Contain "`tProject Name               = 'MyProject'"
                 $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
                 $result | Should -Contain ("`tOutput Directory           = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output'))
-                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir'))
+                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir4'))
                 $result | Should -Contain ("`tModule Manifest Path (src) = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source/MyProject.psd1'))
                 $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
                 $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
 
                 $result | Should -Contain "`tVersioned Output Directory = 'True'"
-                $result | Should -Contain ("`tBuilt Module Manifest      = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview\MyProject.psd1'))
-                $result | Should -Contain ("`tBuilt Module Base          = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview'))
+                $result | Should -Contain ("`tBuilt Module Manifest      = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir4\MyProject\1.0.0-preview\MyProject.psd1'))
+                $result | Should -Contain ("`tBuilt Module Base          = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir4\MyProject\1.0.0-preview'))
                 $result | Should -Contain "`tModule Version Folder      = '1.0.0'"
                 $result | Should -Contain "`tPre-release Tag            = 'preview'"
-                $result | Should -Contain ("`tBuilt Module Root Script   = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview\MyProject.psm1'))
+                $result | Should -Contain ("`tBuilt Module Root Script   = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir4\MyProject\1.0.0-preview\MyProject.psm1'))
             }
         }
 
         Context 'When BuiltSubModuleDirectory is set in the build configuration file' {
             BeforeAll {
                 $BuiltModuleSubdirectory = ''
-                $BuildInfo['BuiltModuleSubdirectory'] = 'SubDir'
-                $mockBuiltModuleManifest = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview/MyProject.psd1'
-                $mockBuiltModuleBase = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview'
-                $mockBuiltModuleRootScriptPath = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview/MyProject.psm1'
+                $BuildInfo['BuiltModuleSubdirectory'] = 'SubDir5'
+                $mockBuiltModuleManifest = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir5/MyProject/1.0.0-preview/MyProject.psd1'
+                $mockBuiltModuleBase = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir5/MyProject/1.0.0-preview'
+                $mockBuiltModuleRootScriptPath = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir5/MyProject/1.0.0-preview/MyProject.psm1'
             }
 
             AfterAll {
-                $BuildInfo = $originalBuildInfo
                 $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
+                $BuildInfo['BuiltModuleSubdirectory'] = $originalBuildInfo['BuiltModuleSubdirectory']
             }
 
             It 'Should return the expected output' {
@@ -339,32 +339,32 @@ Describe 'Set-SamplerTaskVariable' {
                 $result | Should -Contain "`tProject Name               = 'MyProject'"
                 $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
                 $result | Should -Contain ("`tOutput Directory           = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output'))
-                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir'))
+                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir5'))
                 $result | Should -Contain ("`tModule Manifest Path (src) = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source/MyProject.psd1'))
                 $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
                 $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
 
                 $result | Should -Contain "`tVersioned Output Directory = 'True'"
-                $result | Should -Contain ("`tBuilt Module Manifest      = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview\MyProject.psd1'))
-                $result | Should -Contain ("`tBuilt Module Base          = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview'))
+                $result | Should -Contain ("`tBuilt Module Manifest      = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir5\MyProject\1.0.0-preview\MyProject.psd1'))
+                $result | Should -Contain ("`tBuilt Module Base          = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir5\MyProject\1.0.0-preview'))
                 $result | Should -Contain "`tModule Version Folder      = '1.0.0'"
                 $result | Should -Contain "`tPre-release Tag            = 'preview'"
-                $result | Should -Contain ("`tBuilt Module Root Script   = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview\MyProject.psm1'))
+                $result | Should -Contain ("`tBuilt Module Root Script   = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir5\MyProject\1.0.0-preview\MyProject.psm1'))
             }
         }
 
         Context 'When BuiltSubModuleDirectory is set in the build configuration file and on parameter' {
             BeforeAll {
-                $BuiltModuleSubdirectory = 'SubDir'
+                $BuiltModuleSubdirectory = 'SubDir6'
                 $BuildInfo['BuiltModuleSubdirectory'] = 'SubDirFile'
-                $mockBuiltModuleManifest = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview/MyProject.psd1'
-                $mockBuiltModuleBase = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview'
-                $mockBuiltModuleRootScriptPath = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir/MyProject/1.0.0-preview/MyProject.psm1'
+                $mockBuiltModuleManifest = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir6/MyProject/1.0.0-preview/MyProject.psd1'
+                $mockBuiltModuleBase = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir6/MyProject/1.0.0-preview'
+                $mockBuiltModuleRootScriptPath = Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir6/MyProject/1.0.0-preview/MyProject.psm1'
             }
 
             AfterAll {
                 $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
-                $BuildInfo = $originalBuildInfo
+                $BuildInfo['BuiltModuleSubdirectory'] = $originalBuildInfo['BuiltModuleSubdirectory']
             }
 
             It 'Should return the expected output with parameter priority' {
@@ -380,17 +380,17 @@ Describe 'Set-SamplerTaskVariable' {
                 $result | Should -Contain "`tProject Name               = 'MyProject'"
                 $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
                 $result | Should -Contain ("`tOutput Directory           = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output'))
-                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir'))
+                $result | Should -Contain ("`tBuilt Module Subdirectory  = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/SubDir6'))
                 $result | Should -Contain ("`tModule Manifest Path (src) = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source/MyProject.psd1'))
                 $result | Should -Contain "`tModule Version             = '1.0.0-preview'"
                 $result | Should -Contain ("`tRelease Notes path         = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/output/ReleaseNotes.md'))
 
                 $result | Should -Contain "`tVersioned Output Directory = 'True'"
-                $result | Should -Contain ("`tBuilt Module Manifest      = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview\MyProject.psd1'))
-                $result | Should -Contain ("`tBuilt Module Base          = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview'))
+                $result | Should -Contain ("`tBuilt Module Manifest      = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir6\MyProject\1.0.0-preview\MyProject.psd1'))
+                $result | Should -Contain ("`tBuilt Module Base          = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir6\MyProject\1.0.0-preview'))
                 $result | Should -Contain "`tModule Version Folder      = '1.0.0'"
                 $result | Should -Contain "`tPre-release Tag            = 'preview'"
-                $result | Should -Contain ("`tBuilt Module Root Script   = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir\MyProject\1.0.0-preview\MyProject.psm1'))
+                $result | Should -Contain ("`tBuilt Module Root Script   = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject\output\SubDir6\MyProject\1.0.0-preview\MyProject.psm1'))
             }
         }
     }
@@ -410,5 +410,9 @@ Describe 'Set-SamplerTaskVariable' {
         $ModuleVersionFolder | Should -Be $originalModuleVersionFolder
         $PreReleaseTag | Should -Be $originalPreReleaseTag
         $BuiltModuleRootScriptPath | Should -Be $originalBuiltModuleRootScriptPath
+        foreach ($buildKey in $BuildInfo.Keys)
+        {
+            $BuildInfo[$buildKey] | Should -Be $originalBuildInfo[$buildKey]
+        }
     }
 }

--- a/tests/Integration/Tasks/Set-SamplerTaskVariable.Tests.ps1
+++ b/tests/Integration/Tasks/Set-SamplerTaskVariable.Tests.ps1
@@ -66,8 +66,6 @@ Describe 'Set-SamplerTaskVariable' {
             $OutputDirectory = $originalOutputDirectory
             $BuiltModuleSubdirectory = $originalBuiltModuleSubdirectory
             $ReleaseNotesPath = $originalReleaseNotesPath
-            #$BuildInfo = $originalBuildInfo.Clone()
-
         }
 
         It 'Should return the expected output' {


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

Fixe issue #299 and correct PR #306. 

### Fixed

- Removed `$BuiltModuleSubdirectory` definition in the `begin` bloc of `build.ps1`
 template ([issue #299](https://github.com/gaelcolas/Sampler/issues/299)).

- Added pester tests for Set-SamplerTaskVariable.ps1.

## Task list


- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/310)
<!-- Reviewable:end -->
