### PR TITLE
Allow all public functions to be exported from generated PSD1 file per default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added pester tests for `Set-SamplerVariableTask.ps1`.
 
+### Changed
+
+- Changed Plaster Template (`Sampler/Templates/Sampler/plasterManifest.xml`), so
+  that all functions will be exported by default, which in turn correlates with
+  the template code in `Sampler/Sampler.psm1`, which uses
+  `Export-ModuleMember` to export all functions loaded from the
+  `Public` (sub-)folder.
+
 ### Fixed
 
 - Removed `$BuiltModuleSubdirectory` definition in the `begin` bloc of `build.ps1`

--- a/Sampler/Templates/Sampler/plasterManifest.xml
+++ b/Sampler/Templates/Sampler/plasterManifest.xml
@@ -452,14 +452,6 @@
 
     <modify path='${PLASTER_PARAM_ModuleName}/${PLASTER_PARAM_SourceDirectory}/${PLASTER_PARAM_ModuleName}.psd1'
         condition='(Test-Path "${PLASTER_PARAM_ModuleName}/${PLASTER_PARAM_SourceDirectory}/${PLASTER_PARAM_ModuleName}.psd1")'>
-            <replace condition="$PLASTER_FileContent -notmatch '^FunctionsToExport\s*\=\s*'''">
-                  <original>(?mi)^FunctionsToExport\s*=\s*'\*'(.*)</original>
-                  <substitute>FunctionsToExport = ''$1</substitute>
-            </replace>
-    </modify>
-
-    <modify path='${PLASTER_PARAM_ModuleName}/${PLASTER_PARAM_SourceDirectory}/${PLASTER_PARAM_ModuleName}.psd1'
-        condition='(Test-Path "${PLASTER_PARAM_ModuleName}/${PLASTER_PARAM_SourceDirectory}/${PLASTER_PARAM_ModuleName}.psd1")'>
             <replace condition="$PLASTER_FileContent -notmatch '\n\s*Prerelease\s\=\s'">
                   <original><![CDATA[(?mi)^(?<psdata>(?<newline>\s*)PSData \= @\{\r\n)(?<end>.*)]]></original>
                   <substitute>${psdata}${newline}    Prerelease = ''${end}</substitute>


### PR DESCRIPTION
# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Prepend the title with the [DscResourceName] if your PR is specific to a DSC resource.
    Also prepend with [BREAKING CHANGE] if relevant.
    i.e. [BREAKING CHANGE][xFile] Add security descriptor property

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.
-->

## Pull Request (PR) description

<!--
    Replace this comment block with a description of your PR to provide context.
    Please be describe the intent and link issue where the problem has been discussed.
    try to link the issue that it fixes by providing the verb and ref: [fix|close #18]

    After the description, please concisely list the changes as per keepachangelog.com
    This **should** duplicate what you've updated in the changelog file.
-->

### Added
None
### Changed
- Changed Plaster Template (`Sampler/Templates/Sampler/plasterManifest.xml`), so
  that all functions will be exported by default, which in turn correlates with
  the template code in `Sampler/Sampler.psm1`, which uses
  `Export-ModuleMember` to export all functions loaded from the
  `Public` (sub-)folder.
### Deprecated
None
### Security
None
### Fixed
None
### Removed
None

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/312)
<!-- Reviewable:end -->
