### PR TITLE
fixing builtmoduleSubdirectory issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `$BuiltModuleSubdirectory` definition in the `begin` bloc of `build.ps1`
  template ([issue #299](https://github.com/gaelcolas/Sampler/issues/299)).
+- Replaced `$ModudulePath` with `$BuiltModuleBase` for the `release.module.build.ps1` task file.
 
 ## [0.111.5] - 2021-06-25
 


### PR DESCRIPTION
Building a module with a `$BuiltModuleSubdirectory` was failing on the `pack` task because it was not updated to use $BuiltModuleBase (that derives from `$builtmodulesubdirectory`).

/cc @NicolasBn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/313)
<!-- Reviewable:end -->
