### PR TITLE
Pester_If_Code_Coverage_Under_Threshold: Correctly reports coverage percentage

### DIFF
--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -1005,8 +1005,8 @@ task Pester_If_Code_Coverage_Under_Threshold {
     {
         # Pester 5
 
-        # Convert to UInt32 so if CoveragePercent is $null it returns as 0.
-        $coverage = [System.UInt32] $pesterObject.CodeCoverage.CoveragePercent
+        # Convert to Decimal so if CoveragePercent is $null it returns as 0.
+        $coverage = [System.Decimal] $pesterObject.CodeCoverage.CoveragePercent
 
         if ($coverage -lt $CodeCoverageThreshold)
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed GitHub templates for the Sampler repository.
 - Fixed GitHub templates in the DSC Community Plaster template.
 
+### Fixed
+
+- Task `Pester_If_Code_Coverage_Under_Threshold`
+  - Now the code code coverage threshold is correctly reported using decimals.
+
 ## [0.111.6] - 2021-07-03
 
 ### Added


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Fixed
- Task `Pester_If_Code_Coverage_Under_Threshold`
  - Now the code code coverage threshold is correctly reported using decimals.

Fixes #302 

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/317)
<!-- Reviewable:end -->
