### PR TITLE
Removed NunitXml value of PesterOutputFormat parameter in DeployAll.PSDeploy.build.ps1 fix issue #292

### DIFF
--- a/.build/tasks/DeployAll.PSDeploy.build.ps1
+++ b/.build/tasks/DeployAll.PSDeploy.build.ps1
@@ -9,7 +9,7 @@ param (
 
     [Parameter()]
     [string]
-    $PesterOutputFormat = (property PesterOutputFormat 'NUnitXml'),
+    $PesterOutputFormat = (property PesterOutputFormat ''),
 
     [Parameter()]
     $DeploymentTags = (property DeploymentTags ''),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed `NunitXml` value of `PesterOutputFormat` parameter in `DeployAll.PSDeploy.build.ps1`
+ fix ([issue #292](https://github.com/gaelcolas/Sampler/issues/292)).
+
 ## [0.111.8] - 2021-08-08
 
 ### Changed


### PR DESCRIPTION
# Pull Request

Removed static value of Pester Output Format.

## Pull Request (PR) description

### Removed

- Removed `NunitXml` value of `PesterOutputFormat` parameter in `DeployAll.PSDeploy.build.ps1` fix ([issue #292](https://github.com/gaelcolas/Sampler/issues/292)).
## Task list


- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
