### PR TITLE
Don't fail when there's no project name 

### DIFF
--- a/.build/tasks/release.module.build.ps1
+++ b/.build/tasks/release.module.build.ps1
@@ -92,7 +92,7 @@ task Create_changelog_release_output {
         $ReleaseNotes = Get-Content -raw $ChangeLogOutputPath -ErrorAction SilentlyContinue
     }
 
-    if ((Test-Path -Path $builtModuleManifest -ErrorAction SilentlyContinue) -and $ReleaseNotes)
+    if ($ReleaseNotes -and -not [string]::IsNullOrEmpty($builtModuleManifest) -and (Test-Path -Path $builtModuleManifest -ErrorAction SilentlyContinue))
     {
         try
         {
@@ -132,9 +132,16 @@ task Create_changelog_release_output {
             Write-Build -Color Red "No Release notes found to insert."
         }
 
-        if (-not (Test-Path -Path $builtModuleManifest))
+        if ([string]::IsNullOrEmpty($builtModuleManifest) -or -not (Test-Path -Path $builtModuleManifest))
         {
-            Write-Build -Color Red "No valid manifest found for project $ProjectName. Cannot update the Release Notes."
+            if ([string]::IsNullOrEmpty($ProjectName))
+            {
+                Write-Build -Color DarkGray "No Project Name found so we assume you are not building a PowerShell Module."
+            }
+            else
+            {
+                Write-Build -Color Red "No valid manifest found for project '$ProjectName'. Cannot update the Release Notes."
+            }
         }
     }
 }

--- a/.build/tasks/release.module.build.ps1
+++ b/.build/tasks/release.module.build.ps1
@@ -136,7 +136,7 @@ task Create_changelog_release_output {
         {
             if ([string]::IsNullOrEmpty($ProjectName))
             {
-                Write-Build -Color DarkGray "No Project Name found so we assume you are not building a PowerShell Module."
+                Write-Build -Color DarkGray "No PowerShell module name found. We assume you are not building a PowerShell Module."
             }
             else
             {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Making sure the `Set-SamplerTaskVariable` does not fail when there's no Module manifest (i.e. when using Sampler for other reasons than building a module).
+
 ## [0.112.0] - 2021-09-23
 
 ### Removed
@@ -22,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Making sure the `Set-SamplerTaskVariable` does not fail when there's no Module manifest (i.e. when using Sampler for other reasons than building a module).
 - Merged both templates `dsccommunity` and `newDscCommunity` into the
   template `dsccommunity`.
 - All templates now defaults to using `main` as the default branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Making sure the `Set-SamplerTaskVariable` does not fail when there's no Module manifest (i.e. when using Sampler for other reasons than building a module).
 - Merged both templates `dsccommunity` and `newDscCommunity` into the
   template `dsccommunity`.
 - All templates now defaults to using `main` as the default branch.

--- a/Sampler/scripts/Set-SamplerTaskVariable.ps1
+++ b/Sampler/scripts/Set-SamplerTaskVariable.ps1
@@ -65,7 +65,7 @@ param
 
 if ([System.String]::IsNullOrEmpty($ProjectName))
 {
-    $ProjectName = Get-SamplerProjectName -BuildRoot $BuildRoot
+    $ProjectName = Get-SamplerProjectName -BuildRoot $BuildRoot -ErrorAction Ignore
 }
 
 "`tProject Name               = '$ProjectName'"
@@ -80,6 +80,11 @@ if ([System.String]::IsNullOrEmpty($SourcePath))
 $OutputDirectory = Get-SamplerAbsolutePath -Path $OutputDirectory -RelativeTo $BuildRoot
 
 "`tOutput Directory           = '$OutputDirectory'"
+
+$ReleaseNotesPath = Get-SamplerAbsolutePath -Path $ReleaseNotesPath -RelativeTo $OutputDirectory
+
+"`tRelease Notes path         = '$ReleaseNotesPath'"
+
 <#
     We check if the value is set in build.yaml.
     1 . If it past to parameter, or defined in parameter property we use parameter,
@@ -121,6 +126,10 @@ if ($AsNewBuild.IsPresent)
     $ModuleVersion = Get-BuildVersion @getBuildVersionParameters
 
     "`tModule Version             = '$ModuleVersion'"
+}
+elseif ([string]::IsNullOrEmpty($ProjectName))
+{
+    Write-Warning -Message "The ProjectName wasn't found. This might be because you are not build PowerShell module, in which case you can ignore this message."
 }
 else
 {
@@ -190,10 +199,6 @@ else
 
     "`tBuilt Module Root Script   = '$BuiltModuleRootScriptPath'"
 }
-
-$ReleaseNotesPath = Get-SamplerAbsolutePath -Path $ReleaseNotesPath -RelativeTo $OutputDirectory
-
-"`tRelease Notes path         = '$ReleaseNotesPath'"
 
 # Blank row in output.
 ""

--- a/Sampler/scripts/Set-SamplerTaskVariable.ps1
+++ b/Sampler/scripts/Set-SamplerTaskVariable.ps1
@@ -129,7 +129,7 @@ if ($AsNewBuild.IsPresent)
 }
 elseif ([string]::IsNullOrEmpty($ProjectName))
 {
-    Write-Warning -Message "The ProjectName wasn't found. This might be because you are not build PowerShell module, in which case you can ignore this message."
+    "No PowerShell module name found. This might be because you are not building a PowerShell module, in which case you can ignore this message."
 }
 else
 {


### PR DESCRIPTION

# Pull Request


## Pull Request (PR) description

### Changed

- Making sure the `Set-SamplerTaskVariable` does not fail when there's no Module manifest (i.e. when using Sampler for other reasons than building a module).

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/331)
<!-- Reviewable:end -->
