### PR TITLE
Fix duplicate run of task `Create_ChangeLog_GitHub_PR`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Template file `Build/RequiredModules.psd1` that was not used.
+
 ### Added
 
 - Added Pipeline to build chocolatey packages.
@@ -23,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed default source folder to source and not src.
 - Fixed failed loading when there's no project name (when calling `Set-SamplerTaskVariable`). Fixes [#331](https://github.com/gaelcolas/Sampler/issues/331).
 - Fixed `Get-SamplerAbsolutePath` returning the wrong path in PowerShell and ISE. Fixes [#341](https://github.com/gaelcolas/Sampler/issues/341).
+- The templates was using the task `Create_ChangeLog_GitHub_PR` in the meta task
+  publish that is also specifically run in a separate Azure Pipelines task. This
+  made the task to run twice.
 
 ### Changed
 

--- a/Sampler/Templates/Build/build.yaml.template
+++ b/Sampler/Templates/Build/build.yaml.template
@@ -157,7 +157,6 @@ BuildWorkflow:
 @"
     - Publish_Release_To_GitHub
     - Publish_GitHub_Wiki_Content
-    - Create_ChangeLog_GitHub_PR
 "@
     }
 %>
@@ -165,7 +164,6 @@ BuildWorkflow:
     if($PLASTER_PARAM_ModuleType -in @('SimpleModule') -or $PLASTER_PARAM_Features -Contains ('All') -or $PLASTER_PARAM_Features -Contains ('GitHub')) {
 @"
     - Publish_Release_To_GitHub
-    - Create_ChangeLog_GitHub_PR
 "@
     }
 %>

--- a/build.yaml
+++ b/build.yaml
@@ -120,7 +120,6 @@ BuildWorkflow:
     #- publish_nupkg_to_gallery  # Deploy using Nuget
     - publish_module_to_gallery # Deploy using cmdlet Publish-Module
     - Publish_release_to_GitHub
-    - Create_ChangeLog_GitHub_PR
 
 # Import ModuleBuilder tasks from a specific PowerShell module using the build
 # task's alias. Wildcard * can be used to specify all tasks that has a similar


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Fixed
- The templates was using the task `Create_ChangeLog_GitHub_PR` in the meta task
  publish that is also specifically run in a separate Azure Pipelines task. This
  made the task to run twice.

Fixes #339 

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [ ] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/340)
<!-- Reviewable:end -->
