### PR TITLE
No longer run Pester 5 tests twice when missing key `Path`

### DIFF
--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -873,7 +873,6 @@ Pester:
         # Use the default, search project path recursively for tests.
         $pesterParameters.Configuration.Run.Path = @(
             Join-Path -Path $ProjectPath -ChildPath 'tests'
-            Join-Path -Path $ProjectPath -ChildPath 'Tests'
         )
     }
     else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- When running test using Pester 5, and the build configuration (`build.yaml`)
+  do not specify the location of tests in the key `Path`, the pipeline will
+  no longer run the tests twice. Fixes [#337](https://github.com/gaelcolas/Sampler/issues/337)
+
 ## [0.112.1] - 2022-01-23
 
 ### Removed


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Fixed
- When running test using Pester 5, and the build configuration (`build.yaml`)
  do not specify the location of tests in the key `Path`, the pipeline will
  no longer run the tests twice. Fixes [#337](https://github.com/gaelcolas/Sampler/issues/337)

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/347)
<!-- Reviewable:end -->
