### PR TITLE
Fixed explicit parameter value in 'build.ps1' while calling 'Resolve-Dependency.ps1'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed explicit parameter value in `build.ps1` while calling `.\Resolve-Dependency.ps1`
 - When running test using Pester 5, and the build configuration (`build.yaml`)
   do not specify the location of tests in the key `Path`, the pipeline will
   no longer run the tests twice. Fixes [#337](https://github.com/gaelcolas/Sampler/issues/337)

--- a/Sampler/Templates/Build/build.ps1
+++ b/Sampler/Templates/Build/build.ps1
@@ -466,7 +466,7 @@ Begin
             # The parameter has been explicitly used for calling the .build.ps1
             if ($MyInvocation.BoundParameters.ContainsKey($cmdParameter))
             {
-                $paramValue = $MyInvocation.BoundParameters.ContainsKey($cmdParameter)
+                $paramValue = $MyInvocation.BoundParameters.Item($cmdParameter)
 
                 Write-Debug " adding  $cmdParameter :: $paramValue [from user-provided parameters to Build.ps1]"
 

--- a/build.ps1
+++ b/build.ps1
@@ -467,7 +467,7 @@ begin
             # The parameter has been explicitly used for calling the .build.ps1
             if ($MyInvocation.BoundParameters.ContainsKey($cmdParameter))
             {
-                $paramValue = $MyInvocation.BoundParameters.ContainsKey($cmdParameter)
+                $paramValue = $MyInvocation.BoundParameters.Item($cmdParameter)
 
                 Write-Debug " adding  $cmdParameter :: $paramValue [from user-provided parameters to Build.ps1]"
 


### PR DESCRIPTION
### Fixed
- explicit parameter value in 'build.ps1' while calling 'Resolve-Dependency.ps1'

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/352)
<!-- Reviewable:end -->
