### PR TITLE
Fixed GuestConfiguration build task on MOF file name equal to 'localhost.mof'

### DIFF
--- a/.build/tasks/GuestConfig.build.ps1
+++ b/.build/tasks/GuestConfig.build.ps1
@@ -100,7 +100,8 @@ task build_guestconfiguration_packages {
                     }
                 }
 
-               Write-Build White "`t Compiled '$MOFFile'."
+                $MOFFile = [string]($MOFFile[0]) # ensure it's a single string
+                Write-Build White "`t Compiled '$MOFFile'."
 
                 if ((Split-Path -Leaf -Path $MOFFile -ErrorAction 'SilentlyContinue') -eq 'localhost.mof')
                 {
@@ -114,7 +115,6 @@ task build_guestconfiguration_packages {
             {
                 throw "Compilation error. $($_.Exception.Message)"
             }
-            $MOFFile = [string]($MOFFile[0]) # ensure it's a single string
         }
 
         if (Test-Path -Path $newPackageParamsFile)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed GuestConfiguration build task on MOF file name equal to `localhost.mof`
 - Fixed explicit parameter value in `build.ps1` while calling `.\Resolve-Dependency.ps1`
 - When running test using Pester 5, and the build configuration (`build.yaml`)
   do not specify the location of tests in the key `Path`, the pipeline will


### PR DESCRIPTION
### Fixed
- GuestConfiguration build task on MOF file name equal to 'localhost.mof'

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/353)
<!-- Reviewable:end -->
