### PR TITLE
Fix test result filename in task `Invoke_Pester_Tests_v5`

### DIFF
--- a/.build/tasks/Invoke-Pester.pester.build.ps1
+++ b/.build/tasks/Invoke-Pester.pester.build.ps1
@@ -467,8 +467,6 @@ task Invoke_Pester_Tests_v5 {
 
     $pesterOutputFileFileName = Get-PesterOutputFileFileName @getPesterOutputFileFileNameParameters
 
-    $pesterOutputFullPath = Get-SamplerAbsolutePath -Path "$($PesterOutputFormat)_$pesterOutputFileFileName" -RelativeTo $PesterOutputFolder
-
     #region Handle deprecated Pester build configuration
 
     if ($BuildInfo.Pester -and -not $BuildInfo.Pester.Configuration)
@@ -644,7 +642,7 @@ Pester:
 
     $defaultPesterParameters.Configuration.TestResult.Enabled = $true
     $defaultPesterParameters.Configuration.TestResult.OutputFormat = 'NUnitXml'
-    $defaultPesterParameters.Configuration.TestResult.OutputPath = $pesterOutputFullPath
+    $defaultPesterParameters.Configuration.TestResult.OutputPath = Get-SamplerAbsolutePath -Path "NUnitXml_$pesterOutputFileFileName" -RelativeTo $PesterOutputFolder
     $defaultPesterParameters.Configuration.TestResult.OutputEncoding = 'UTF8'
     $defaultPesterParameters.Configuration.TestResult.TestSuiteName = $ProjectName
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The task `Invoke_Pester_Tests_v5` generated a unexpected filename for the
+  test results, compared to the Pester 4 task. Fixes [#355](https://github.com/gaelcolas/Sampler/issues/355)
+
 ## [0.112.2] - 2022-03-20
 
 ### Fixed


### PR DESCRIPTION
# Pull Request


## Pull Request (PR) description

### Fixed
- The task `Invoke_Pester_Tests_v5` generated a unexpected filename for the
  test results, compared to the Pester 4 task. Fixes [#355](https://github.com/gaelcolas/Sampler/issues/355)

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/356)
<!-- Reviewable:end -->
