### PR TITLE
Fix release notes for published module

### DIFF
--- a/.build/tasks/release.module.build.ps1
+++ b/.build/tasks/release.module.build.ps1
@@ -247,6 +247,7 @@ task package_module_nupkg {
                 $PublishModuleParams['WhatIf'] = $True
             }
 
+            # Release notes will be used from module manifest
             Publish-Module -Repository output -ErrorAction SilentlyContinue -Path $module.ModuleBase
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no security.
 - Now supports getting module version from `dotnet-gitversion` if it is available.
 
+### Fixed
+
+- Task `package_module_nupkg` now correctly adds the release notes to the
+  Nuget package. Fixes [#373](https://github.com/gaelcolas/Sampler/issues/373)
+- Task `publish_module_to_gallery` now correctly adds the release notes to
+  the published module. Fixes [#373](https://github.com/gaelcolas/Sampler/issues/373)
+
 ## [0.114.0] - 2022-05-13
 
 ### Added


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Fixed
- Task `package_module_nupkg` now correctly adds the release notes to the
  Nuget package. Fixes [#373](https://github.com/gaelcolas/Sampler/issues/373)
- Task `publish_module_to_gallery` now correctly adds the release notes to
  the published module. Fixes [#373](https://github.com/gaelcolas/Sampler/issues/373)

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/374)
<!-- Reviewable:end -->
