### PR TITLE
defaulting pipelines to build in a submodule of BuildModuleOutput

### DIFF
--- a/Sampler/Templates/Build/build.yaml.template
+++ b/Sampler/Templates/Build/build.yaml.template
@@ -7,11 +7,10 @@
 @"
 # Path to the Module Manifest to build (where path will be resolved from)
 # SourcePath: ./Sampler/Sampler.psd1
-# Output Directory where ModuleBuilder will build the Module, relative to module manifest
-# OutputDirectory: ../output/Sampler
 "@
     }
 %>
+BuiltModuleSubdirectory: module
 CopyPaths:
   - en-US
 <%
@@ -19,7 +18,7 @@ CopyPaths:
 "  - DSCResources"
     }
     else {
-"#  - DSCResources"
+"#  - DSCResources # Copy the DSCResources folder to the built module (not needed if using class based resources)."
     }
 %>
   # - Modules


### PR DESCRIPTION
Fixing default built submodule to be within a `module` subdir of `output` by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/379)
<!-- Reviewable:end -->
