### PR TITLE
Fix bug introduced with PR #383

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Some unnecessary code was removed from the script `Set-SamplerTaskVariable`
-  since the functions `Get-SamplerBuiltModuleManifest`, `Get-SamplerBuiltModuleBase`,
-  and `Get-SamplerModuleRootPath` already handle returning the absolute path.
-  It also simplified mocking the functions for the unit tests.
 - Task `copy_paths_to_choco_staging`
   - Now handle property `Exclude` and `Force` correctly.
 
@@ -35,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed one unused line of code.
   - Moved one line of code so that code coverage threshold value
     will output correctly in some circumstances.
+- `Set-SamplerTaskVariable`
+  - Reverted code that was removed in pull request #383. The code is
+    necessary because how the commands `Get-BuiltModuleVersion`,
+    `Get-SamplerBuiltModuleManifest`, `Get-SamplerBuiltModuleBase`, and 
+    `Get-SamplerModuleRootPath` are currently built. The code that was
+    reverted handles resolving the wildcard (`*`) in the returned paths
+    from the mentioned commands.
 
 ## [0.115.0] - 2022-06-09
 

--- a/Sampler/scripts/Set-SamplerTaskVariable.ps1
+++ b/Sampler/scripts/Set-SamplerTaskVariable.ps1
@@ -176,10 +176,21 @@ else
 
     $BuiltModuleManifest = Get-SamplerBuiltModuleManifest @GetBuiltModuleManifestParams
 
+    # Resolve path to replace '*' with version number.
+    if ($BuiltModuleManifest)
+    {
+        $BuiltModuleManifest = (Get-Item -Path $BuiltModuleManifest -ErrorAction 'SilentlyContinue').FullName
+    }
+
     "`tBuilt Module Manifest      = '$BuiltModuleManifest'"
 
     $BuiltModuleBase = Get-SamplerBuiltModuleBase @GetBuiltModuleManifestParams
 
+    # Resolve path to replace '*' with version number.
+    if ($BuiltModuleBase)
+    {
+        $BuiltModuleBase = (Get-Item -Path $BuiltModuleBase -ErrorAction 'SilentlyContinue').FullName
+    }
 
     "`tBuilt Module Base          = '$BuiltModuleBase'"
 
@@ -199,6 +210,12 @@ else
     if ($BuiltModuleManifest)
     {
         $BuiltModuleRootScriptPath = Get-SamplerModuleRootPath -ModuleManifestPath $BuiltModuleManifest
+
+        # Resolve path to replace '*' with version number.
+        if ($BuiltModuleRootScriptPath)
+        {
+            $BuiltModuleRootScriptPath = (Get-Item -Path $BuiltModuleRootScriptPath -ErrorAction 'SilentlyContinue').FullName
+        }
     }
 
     "`tBuilt Module Root Script   = '$BuiltModuleRootScriptPath'"

--- a/tests/Unit/TestHelpers/MockSetSamplerTaskVariable.ps1
+++ b/tests/Unit/TestHelpers/MockSetSamplerTaskVariable.ps1
@@ -54,67 +54,103 @@ Mock -CommandName Get-SamplerAbsolutePath -ParameterFilter {
     )
 }
 
-$script:mockGetSamplerBuiltModuleManifestReturnValue = Join-Path -Path $TestDrive -ChildPath 'output' |
-    Join-Path -ChildPath 'builtModule' |
-    Join-Path -ChildPath 'MyModule' |
-    Join-Path -ChildPath '2.0.0' |
-    Join-Path -ChildPath 'MyModule.psd1'
+$script:mockGetSamplerBuiltModuleManifestReturnValue =
 
 Mock -CommandName Get-SamplerBuiltModuleManifest -MockWith {
-    return $script:mockGetSamplerBuiltModuleManifestReturnValue
+    return (
+        Join-Path -Path $TestDrive -ChildPath 'output' |
+            Join-Path -ChildPath 'builtModule' |
+            Join-Path -ChildPath 'MyModule' |
+            Join-Path -ChildPath '2.0.0' |
+            Join-Path -ChildPath 'MyModule.psd1'
+    )
 }
 
 # This is called after the mock of Get-SamplerBuiltModuleManifest
 Mock -CommandName Get-Item -MockWith {
     return @{
-        FullName = $script:mockGetSamplerBuiltModuleManifestReturnValue
+        FullName = (
+            Join-Path -Path $TestDrive -ChildPath 'output' |
+                Join-Path -ChildPath 'builtModule' |
+                Join-Path -ChildPath 'MyModule' |
+                Join-Path -ChildPath '2.0.0' |
+                Join-Path -ChildPath 'MyModule.psd1'
+        )
     }
 } -ParameterFilter {
     # Must be the same path that the mock for Get-SamplerBuiltModuleManifest returns.
-    $Path -contains $script:mockGetSamplerBuiltModuleManifestReturnValue
+    $Path -contains (
+        Join-Path -Path $TestDrive -ChildPath 'output' |
+            Join-Path -ChildPath 'builtModule' |
+            Join-Path -ChildPath 'MyModule' |
+            Join-Path -ChildPath '2.0.0' |
+            Join-Path -ChildPath 'MyModule.psd1'
+    )
 }
 
-$script:mockGetSamplerBuiltModuleBaseReturnValue = Join-Path -Path $TestDrive -ChildPath 'output' |
-    Join-Path -ChildPath 'builtModule' |
-    Join-Path -ChildPath 'MyModule' |
-    Join-Path -ChildPath '2.0.0'
-
 Mock -CommandName Get-SamplerBuiltModuleBase -MockWith {
-    return $script:mockGetSamplerBuiltModuleBaseReturnValue
+    return (
+        Join-Path -Path $TestDrive -ChildPath 'output' |
+            Join-Path -ChildPath 'builtModule' |
+            Join-Path -ChildPath 'MyModule' |
+            Join-Path -ChildPath '2.0.0'
+    )
 }
 
 # This is called after the mock of Get-SamplerBuiltModuleBase
 Mock -CommandName Get-Item -MockWith {
     @{
-        FullName = $script:mockGetSamplerBuiltModuleBaseReturnValue
+        FullName = (
+            Join-Path -Path $TestDrive -ChildPath 'output' |
+                Join-Path -ChildPath 'builtModule' |
+                Join-Path -ChildPath 'MyModule' |
+                Join-Path -ChildPath '2.0.0'
+        )
     }
 } -ParameterFilter {
     # Must be the same path that the mock for Get-SamplerBuiltModuleManifest returns.
-    $Path -contains $script:mockGetSamplerBuiltModuleBaseReturnValue
+    $Path -contains (
+        Join-Path -Path $TestDrive -ChildPath 'output' |
+            Join-Path -ChildPath 'builtModule' |
+            Join-Path -ChildPath 'MyModule' |
+            Join-Path -ChildPath '2.0.0'
+    )
 }
 
 Mock -CommandName Get-BuiltModuleVersion -MockWith {
     return '2.0.0'
 }
 
-$script:mockGetSamplerModuleRootPathReturnValue = Join-Path -Path $TestDrive -ChildPath 'output' |
-    Join-Path -ChildPath 'builtModule' |
-    Join-Path -ChildPath 'MyModule' |
-    Join-Path -ChildPath '2.0.0' |
-    Join-Path -ChildPath 'MyModule.psm1'
-
 Mock -CommandName Get-SamplerModuleRootPath -MockWith {
-    return $script:mockGetSamplerModuleRootPathReturnValue
+    return (
+        Join-Path -Path $TestDrive -ChildPath 'output' |
+            Join-Path -ChildPath 'builtModule' |
+            Join-Path -ChildPath 'MyModule' |
+            Join-Path -ChildPath '2.0.0' |
+            Join-Path -ChildPath 'MyModule.psm1'
+    )
 }
 
 # This is called after the mock of Get-SamplerModuleRootPath
 Mock -CommandName Get-Item -MockWith {
     @{
-        FullName = $script:mockGetSamplerModuleRootPathReturnValue
+        FullName = (
+            Join-Path -Path $TestDrive -ChildPath 'output' |
+                Join-Path -ChildPath 'builtModule' |
+                Join-Path -ChildPath 'MyModule' |
+                Join-Path -ChildPath '2.0.0' |
+                Join-Path -ChildPath 'MyModule.psm1'
+        )
     }
 } -ParameterFilter {
     # Must be the same path that the mock for Get-SamplerBuiltModuleManifest returns.
-    $Path -contains $script:mockGetSamplerModuleRootPathReturnValue
+    $Path -contains (
+        Join-Path -Path $TestDrive -ChildPath 'output' |
+            Join-Path -ChildPath 'builtModule' |
+            Join-Path -ChildPath 'MyModule' |
+            Join-Path -ChildPath '2.0.0' |
+            Join-Path -ChildPath 'MyModule.psm1'
+    )
 }
 
 # This is only used when calling Set-SamplerTaskVariable with parameter -AsNewBuild

--- a/tests/Unit/TestHelpers/MockSetSamplerTaskVariable.ps1
+++ b/tests/Unit/TestHelpers/MockSetSamplerTaskVariable.ps1
@@ -54,37 +54,67 @@ Mock -CommandName Get-SamplerAbsolutePath -ParameterFilter {
     )
 }
 
+$script:mockGetSamplerBuiltModuleManifestReturnValue = Join-Path -Path $TestDrive -ChildPath 'output' |
+    Join-Path -ChildPath 'builtModule' |
+    Join-Path -ChildPath 'MyModule' |
+    Join-Path -ChildPath '2.0.0' |
+    Join-Path -ChildPath 'MyModule.psd1'
+
 Mock -CommandName Get-SamplerBuiltModuleManifest -MockWith {
-    return (
-        Join-Path -Path $TestDrive -ChildPath 'output' |
-            Join-Path -ChildPath 'builtModule' |
-            Join-Path -ChildPath 'MyModule' |
-            Join-Path -ChildPath '2.0.0' |
-            Join-Path -ChildPath 'MyModule.psd1'
-    )
+    return $script:mockGetSamplerBuiltModuleManifestReturnValue
 }
 
+# This is called after the mock of Get-SamplerBuiltModuleManifest
+Mock -CommandName Get-Item -MockWith {
+    return @{
+        FullName = $script:mockGetSamplerBuiltModuleManifestReturnValue
+    }
+} -ParameterFilter {
+    # Must be the same path that the mock for Get-SamplerBuiltModuleManifest returns.
+    $Path -contains $script:mockGetSamplerBuiltModuleManifestReturnValue
+}
+
+$script:mockGetSamplerBuiltModuleBaseReturnValue = Join-Path -Path $TestDrive -ChildPath 'output' |
+    Join-Path -ChildPath 'builtModule' |
+    Join-Path -ChildPath 'MyModule' |
+    Join-Path -ChildPath '2.0.0'
+
 Mock -CommandName Get-SamplerBuiltModuleBase -MockWith {
-    return (
-        Join-Path -Path $TestDrive -ChildPath 'output' |
-            Join-Path -ChildPath 'builtModule' |
-            Join-Path -ChildPath 'MyModule' |
-            Join-Path -ChildPath '2.0.0'
-    )
+    return $script:mockGetSamplerBuiltModuleBaseReturnValue
+}
+
+# This is called after the mock of Get-SamplerBuiltModuleBase
+Mock -CommandName Get-Item -MockWith {
+    @{
+        FullName = $script:mockGetSamplerBuiltModuleBaseReturnValue
+    }
+} -ParameterFilter {
+    # Must be the same path that the mock for Get-SamplerBuiltModuleManifest returns.
+    $Path -contains $script:mockGetSamplerBuiltModuleBaseReturnValue
 }
 
 Mock -CommandName Get-BuiltModuleVersion -MockWith {
     return '2.0.0'
 }
 
+$script:mockGetSamplerModuleRootPathReturnValue = Join-Path -Path $TestDrive -ChildPath 'output' |
+    Join-Path -ChildPath 'builtModule' |
+    Join-Path -ChildPath 'MyModule' |
+    Join-Path -ChildPath '2.0.0' |
+    Join-Path -ChildPath 'MyModule.psm1'
+
 Mock -CommandName Get-SamplerModuleRootPath -MockWith {
-    return (
-        Join-Path -Path $TestDrive -ChildPath 'output' |
-            Join-Path -ChildPath 'builtModule' |
-            Join-Path -ChildPath 'MyModule' |
-            Join-Path -ChildPath '2.0.0' |
-            Join-Path -ChildPath 'MyModule.psm1'
-    )
+    return $script:mockGetSamplerModuleRootPathReturnValue
+}
+
+# This is called after the mock of Get-SamplerModuleRootPath
+Mock -CommandName Get-Item -MockWith {
+    @{
+        FullName = $script:mockGetSamplerModuleRootPathReturnValue
+    }
+} -ParameterFilter {
+    # Must be the same path that the mock for Get-SamplerBuiltModuleManifest returns.
+    $Path -contains $script:mockGetSamplerModuleRootPathReturnValue
 }
 
 # This is only used when calling Set-SamplerTaskVariable with parameter -AsNewBuild

--- a/tests/Unit/tasks/Build-Module.ModuleBuilder.build.Tests.ps1
+++ b/tests/Unit/tasks/Build-Module.ModuleBuilder.build.Tests.ps1
@@ -362,62 +362,66 @@ Describe 'Build_NestedModules_ModuleBuilder' {
                     }
                 }
 
-                # Context 'When copied nested module just contain a module script file' {
-                #     BeforeAll {
-                #         $BuildInfo.NestedModule = @{
-                #             'DscResource.Common' = @{
-                #                 CopyOnly = $true
-                #                 AddToManifest = $true
-                #                 Exclude = 'PSGetModuleInfo.xml'
-                #             }
-                #         }
+                Context 'When copied nested module just contain a module script file' {
+                    BeforeAll {
+                        $BuildInfo.NestedModule = @{
+                            'DscResource.Common' = @{
+                                CopyOnly = $true
+                                AddToManifest = $true
+                                Exclude = 'PSGetModuleInfo.xml'
+                            }
+                        }
 
-                #         Mock -CommandName Get-SamplerModuleInfo -MockWith {
-                #             return @{
-                #                 NestedModules = @()
-                #             }
-                #         } -RemoveParameterValidation 'ModuleManifestPath'
+                        Mock -CommandName Get-SamplerModuleInfo -MockWith {
+                            return @{
+                                NestedModules = @()
+                            }
+                        } -RemoveParameterValidation 'ModuleManifestPath'
 
-                #         Mock -CommandName Copy-Item
+                        Mock -CommandName Copy-Item
 
-                #         Mock -CommandName Get-ChildItem -ParameterFilter {
-                #             $Include -contains '*.psd1'
-                #         }
+                        Mock -CommandName Get-ChildItem -ParameterFilter {
+                            $Include -contains '*.psd1'
+                        }
 
-                #         Mock -CommandName Get-ChildItem -ParameterFilter {
-                #             $Include -contains '*.psm1'
-                #         } -MockWith {
-                #             return @{
-                #                 Directory = @{
-                #                     Name = 'DscResource.Common'
-                #                 }
-                #                 BaseName = 'DscResource.Common'
-                #                 # Need to use DirectorySeparatorChar to make the mocked path correctly cross-plattform.
-                #                 FullName = "$BuiltModuleBase{0}Modules{0}DscResource.Common{0}DscResource.Common.psm1" -f $([System.IO.Path]::DirectorySeparatorChar)
-                #             }
-                #         }
+                        Mock -CommandName Get-ChildItem -ParameterFilter {
+                            $Include -contains '*.psm1'
+                        } -MockWith {
+                            return @{
+                                Directory = @{
+                                    Name = 'DscResource.Common'
+                                }
+                                BaseName = 'DscResource.Common'
+                                # Need to use DirectorySeparatorChar to make the mocked path correctly cross-plattform.
+                                FullName = "$BuiltModuleBase{0}Modules{0}DscResource.Common{0}DscResource.Common.psm1" -f $([System.IO.Path]::DirectorySeparatorChar)
+                            }
+                        }
 
-                #         Mock -CommandName Test-ModuleManifest -RemoveParameterValidation 'Path' -MockWith {
-                #             return @{
-                #                 Version = '2.0.0'
-                #             }
-                #         }
+                        Mock -CommandName Test-ModuleManifest -RemoveParameterValidation 'Path' -MockWith {
+                            return @{
+                                Version = '2.0.0'
+                            }
+                        }
 
-                #         Mock -CommandName Get-Item -RemoveParameterValidation 'Path' -MockWith {
-                #             return @{
-                #                 FullName = "$BuiltModuleBase{0}Modules{0}DscResource.Common{0}DscResource.Common.psm1" -f $([System.IO.Path]::DirectorySeparatorChar)
-                #             }
-                #         }
+                        Mock -CommandName Get-Item -RemoveParameterValidation 'Path' -MockWith {
+                            return @{
+                                FullName = "$BuiltModuleBase{0}Modules{0}DscResource.Common{0}DscResource.Common.psm1" -f $([System.IO.Path]::DirectorySeparatorChar)
+                            }
+                        }
 
-                #         Mock -CommandName Update-Metadata
-                #     }
+                        Mock -CommandName Update-Metadata
+                    }
 
-                #     It 'Should throw the correct error' {
-                #         {
-                #             Invoke-Build -Task 'Build_NestedModules_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
-                #         } | Should -Throw -ExpectedMessage '*Path must point to a .psd1 file*'
-                #     }
-                # }
+                    It 'Should run the build task without throwing' {
+                        {
+                            Invoke-Build -Task 'Build_NestedModules_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
+                        } | Should -Not -Throw
+
+                        Should -Invoke -CommandName Update-Metadata -ParameterFilter {
+                            $Value -contains '.{0}{0}Modules{0}DscResource.Common{0}DscResource.Common.psm1' -f $([System.IO.Path]::DirectorySeparatorChar)
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
             }
 
             Context 'When nested module is built' {

--- a/tests/Unit/tasks/Build-Module.ModuleBuilder.build.Tests.ps1
+++ b/tests/Unit/tasks/Build-Module.ModuleBuilder.build.Tests.ps1
@@ -362,62 +362,62 @@ Describe 'Build_NestedModules_ModuleBuilder' {
                     }
                 }
 
-                Context 'When copied nested module just contain a module script file' {
-                    BeforeAll {
-                        $BuildInfo.NestedModule = @{
-                            'DscResource.Common' = @{
-                                CopyOnly = $true
-                                AddToManifest = $true
-                                Exclude = 'PSGetModuleInfo.xml'
-                            }
-                        }
+                # Context 'When copied nested module just contain a module script file' {
+                #     BeforeAll {
+                #         $BuildInfo.NestedModule = @{
+                #             'DscResource.Common' = @{
+                #                 CopyOnly = $true
+                #                 AddToManifest = $true
+                #                 Exclude = 'PSGetModuleInfo.xml'
+                #             }
+                #         }
 
-                        Mock -CommandName Get-SamplerModuleInfo -MockWith {
-                            return @{
-                                NestedModules = @()
-                            }
-                        } -RemoveParameterValidation 'ModuleManifestPath'
+                #         Mock -CommandName Get-SamplerModuleInfo -MockWith {
+                #             return @{
+                #                 NestedModules = @()
+                #             }
+                #         } -RemoveParameterValidation 'ModuleManifestPath'
 
-                        Mock -CommandName Copy-Item
+                #         Mock -CommandName Copy-Item
 
-                        Mock -CommandName Get-ChildItem -ParameterFilter {
-                            $Include -contains '*.psd1'
-                        }
+                #         Mock -CommandName Get-ChildItem -ParameterFilter {
+                #             $Include -contains '*.psd1'
+                #         }
 
-                        Mock -CommandName Get-ChildItem -ParameterFilter {
-                            $Include -contains '*.psm1'
-                        } -MockWith {
-                            return @{
-                                Directory = @{
-                                    Name = 'DscResource.Common'
-                                }
-                                BaseName = 'DscResource.Common'
-                                # Need to use DirectorySeparatorChar to make the mocked path correctly cross-plattform.
-                                FullName = "$BuiltModuleBase{0}Modules{0}DscResource.Common{0}DscResource.Common.psm1" -f $([System.IO.Path]::DirectorySeparatorChar)
-                            }
-                        }
+                #         Mock -CommandName Get-ChildItem -ParameterFilter {
+                #             $Include -contains '*.psm1'
+                #         } -MockWith {
+                #             return @{
+                #                 Directory = @{
+                #                     Name = 'DscResource.Common'
+                #                 }
+                #                 BaseName = 'DscResource.Common'
+                #                 # Need to use DirectorySeparatorChar to make the mocked path correctly cross-plattform.
+                #                 FullName = "$BuiltModuleBase{0}Modules{0}DscResource.Common{0}DscResource.Common.psm1" -f $([System.IO.Path]::DirectorySeparatorChar)
+                #             }
+                #         }
 
-                        Mock -CommandName Test-ModuleManifest -RemoveParameterValidation 'Path' -MockWith {
-                            return @{
-                                Version = '2.0.0'
-                            }
-                        }
+                #         Mock -CommandName Test-ModuleManifest -RemoveParameterValidation 'Path' -MockWith {
+                #             return @{
+                #                 Version = '2.0.0'
+                #             }
+                #         }
 
-                        Mock -CommandName Get-Item -RemoveParameterValidation 'Path' -MockWith {
-                            return @{
-                                FullName = "$BuiltModuleBase{0}Modules{0}DscResource.Common{0}DscResource.Common.psm1" -f $([System.IO.Path]::DirectorySeparatorChar)
-                            }
-                        }
+                #         Mock -CommandName Get-Item -RemoveParameterValidation 'Path' -MockWith {
+                #             return @{
+                #                 FullName = "$BuiltModuleBase{0}Modules{0}DscResource.Common{0}DscResource.Common.psm1" -f $([System.IO.Path]::DirectorySeparatorChar)
+                #             }
+                #         }
 
-                        Mock -CommandName Update-Metadata
-                    }
+                #         Mock -CommandName Update-Metadata
+                #     }
 
-                    It 'Should run the build task without throwing' {
-                        {
-                            Invoke-Build -Task 'Build_NestedModules_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
-                        } | Should -Throw -ExpectedMessage '*Path must point to a .psd1 file*'
-                    }
-                }
+                #     It 'Should throw the correct error' {
+                #         {
+                #             Invoke-Build -Task 'Build_NestedModules_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
+                #         } | Should -Throw -ExpectedMessage '*Path must point to a .psd1 file*'
+                #     }
+                # }
             }
 
             Context 'When nested module is built' {


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Fixed
- `Set-SamplerTaskVariable`
  - Reverted code that was removed in pull request #383. The code is
    necessary because how the commands `Get-BuiltModuleVersion`,
    `Get-SamplerBuiltModuleManifest`, `Get-SamplerBuiltModuleBase`, and 
    `Get-SamplerModuleRootPath` are currently built. The code that was
    reverted handles resolving the wildcard (`*`) in the returned paths
    from the mentioned commands.

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [ ] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/391)
<!-- Reviewable:end -->
