### PR TITLE
Fixes #394

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     necessary because how the commands `Get-BuiltModuleVersion`,
     `Get-SamplerBuiltModuleManifest`, `Get-SamplerBuiltModuleBase`, and
     `Get-SamplerModuleRootPath` are currently built. The code that was
-    reverted handles resolving the wildcard (`*`) in the returned paths
-    from the mentioned commands.
+    reverted handles resolving the wil
+- `Resolve-Dependency.ps1`
+  - Fixes #394, `AllowPrerelease` is ignored for bootstrap.
 
 ## [0.115.0] - 2022-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     necessary because how the commands `Get-BuiltModuleVersion`,
     `Get-SamplerBuiltModuleManifest`, `Get-SamplerBuiltModuleBase`, and
     `Get-SamplerModuleRootPath` are currently built. The code that was
-    reverted handles resolving the wil
+    reverted handles resolving the wildcard (`*`) in the returned paths
+    from the mentioned commands.
 - `Resolve-Dependency.ps1`
   - Fixes #394, `AllowPrerelease` is ignored for bootstrap.
 

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -307,6 +307,10 @@ try
             {
                 $installPowerShellGetParameters.Add('Credential', $GalleryCredential)
             }
+            'AllowPrerelease'
+            {
+                $installPowerShellGetParameters.Add('AllowPrerelease', $AllowPrerelease)
+            }
         }
 
         Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation 'Installing newer version of PowerShellGet'

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -202,6 +202,11 @@ if (-not $powerShellGetModule -and -not $nuGetProvider)
         {
             $providerBootstrapParameters.Add('Scope', $Scope)
         }
+
+        'AllowPrerelease'
+        {
+            $providerBootstrapParameters.Add('AllowPrerelease', $AllowPrerelease)
+        }
     }
 
     if ($AllowPrerelease)
@@ -307,6 +312,7 @@ try
             {
                 $installPowerShellGetParameters.Add('Credential', $GalleryCredential)
             }
+
             'AllowPrerelease'
             {
                 $installPowerShellGetParameters.Add('AllowPrerelease', $AllowPrerelease)

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -307,6 +307,10 @@ try
             {
                 $installPowerShellGetParameters.Add('Credential', $GalleryCredential)
             }
+            'AllowPrerelease'
+            {
+                $installPowerShellGetParameters.Add('AllowPrerelease', $AllowPrerelease)
+            }
         }
 
         Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation 'Installing newer version of PowerShellGet'

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -202,6 +202,11 @@ if (-not $powerShellGetModule -and -not $nuGetProvider)
         {
             $providerBootstrapParameters.Add('Scope', $Scope)
         }
+
+        'AllowPrerelease'
+        {
+            $providerBootstrapParameters.Add('AllowPrerelease', $AllowPrerelease)
+        }
     }
 
     if ($AllowPrerelease)


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

Fixes #394: When having AllowPrerelease set to $true in Resolve-Dependency.psd1, this setting is ignored.

### Fixed
- #394

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/395)
<!-- Reviewable:end -->
