### PR TITLE
Fixing code style `module.tests.ps1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `Get-SamplerModuleRootPath` are currently built. The code that was
     reverted handles resolving the wildcard (`*`) in the returned paths
     from the mentioned commands.
+- `module.tests.ps1.template`
+  - Fixed code style according to this project's standard.
 
 ## [0.115.0] - 2022-06-09
 

--- a/Sampler/Templates/Sampler/module.tests.ps1.template
+++ b/Sampler/Templates/Sampler/module.tests.ps1.template
@@ -1,135 +1,211 @@
-$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+BeforeDiscovery {
+    $script:moduleName = $ProjectName
 
-# Convert-path required for PS7 or Join-Path fails
-$ProjectPath = "$here\..\.." | Convert-Path
-$ProjectName = (Get-ChildItem $ProjectPath\*\*.psd1 | Where-Object {
-    ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-        $(try
-            {
-                Test-ModuleManifest $_.FullName -ErrorAction Stop
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
+
+    $mut = Get-Module -Name $script:moduleName -ListAvailable |
+        Select-Object -First 1 |
+            Import-Module -Force -ErrorAction Stop -PassThru
+}
+
+BeforeAll {
+    $script:moduleName = $ProjectName
+
+    # Convert-Path required for PS7 or Join-Path fails
+    $projectPath = "$($PSScriptRoot)\..\.." | Convert-Path
+
+    $sourcePath = (
+        Get-ChildItem -Path $projectPath\*\*.psd1 |
+            Where-Object -FilterScript {
+                ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) `
+                    -and $(
+                    try
+                    {
+                        Test-ModuleManifest -Path $_.FullName -ErrorAction Stop
+                    }
+                    catch
+                    {
+                        $false
+                    }
+                )
             }
-            catch
-            {
-                $false
-            }) }
-).BaseName
-
-$SourcePath = (Get-ChildItem $ProjectPath\*\*.psd1 | Where-Object {
-        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-        $(try
-            {
-                Test-ModuleManifest $_.FullName -ErrorAction Stop
-            }
-            catch
-            {
-                $false
-            }) }
-).Directory.FullName
-
-$mut = Import-Module -Name $ProjectName -ErrorAction Stop -PassThru -Force
-$allModuleFunctions = &$mut { Get-Command -Module $args[0] -CommandType Function } $ProjectName
+    ).Directory.FullName
+}
 
 Describe 'Changelog Management' -Tag 'Changelog' {
     It 'Changelog has been updated' -Skip:(
-        -not ([bool](Get-Command git -EA SilentlyContinue) -and
+        -not ([bool](Get-Command git -ErrorAction SilentlyContinue) -and
             [bool](&(Get-Process -Id $PID).Path -NoProfile -Command 'git rev-parse --is-inside-work-tree 2>$null'))
     ) {
-        # Get the list of changed files compared with master
-        $HeadCommit = &git rev-parse HEAD
-        $MasterCommit = &git rev-parse origin/main
-        $filesChanged = &git @('diff', "$MasterCommit...$HeadCommit", '--name-only')
+        # Get the list of changed files compared with branch main
+        $headCommit = &git rev-parse HEAD
+        $defaultBranchCommit = &git rev-parse origin/main
+        $filesChanged = &git @('diff', "$defaultBranchCommit...$headCommit", '--name-only')
+        $filesStagedAndUnstaged = &git @('diff', 'HEAD', '--name-only')
 
-        if ($HeadCommit -ne $MasterCommit)
+        $filesChanged += $filesStagedAndUnstaged
+
+        # Only check if there are any changed files.
+        if ($filesChanged)
         {
-            # if we're not testing same commit (i.e. master..master)
-            $filesChanged.Where{ (Split-Path $_ -Leaf) -match '^changelog' } | Should -Not -BeNullOrEmpty
+            $filesChanged | Should -Contain 'CHANGELOG.md' -Because 'the CHANGELOG.md must be updated with at least one entry in the Unreleased section for each PR'
         }
     }
 
     It 'Changelog format compliant with keepachangelog format' -Skip:(![bool](Get-Command git -EA SilentlyContinue)) {
-        { Get-ChangelogData (Join-Path $ProjectPath 'CHANGELOG.md') -ErrorAction Stop } | Should -Not -Throw
+        { Get-ChangelogData -Path (Join-Path $ProjectPath 'CHANGELOG.md') -ErrorAction Stop } | Should -Not -Throw
+    }
+
+    It 'Changelog should have an Unreleased header' -Skip:$skipTest {
+            (Get-ChangelogData -Path (Join-Path -Path $ProjectPath -ChildPath 'CHANGELOG.md') -ErrorAction Stop).Unreleased.RawData | Should -Not -BeNullOrEmpty
     }
 }
 
 Describe 'General module control' -Tags 'FunctionalQuality' {
+    It 'Should import without errors' {
+        { Import-Module -Name $script:moduleName -Force -ErrorAction Stop } | Should -Not -Throw
 
-    It 'Imports without errors' {
-        { Import-Module -Name $ProjectName -Force -ErrorAction Stop } | Should -Not -Throw
-        Get-Module $ProjectName | Should -Not -BeNullOrEmpty
+        Get-Module -Name $script:moduleName | Should -Not -BeNullOrEmpty
     }
 
-    It 'Removes without error' {
-        { Remove-Module -Name $ProjectName -ErrorAction Stop } | Should -Not -Throw
-        Get-Module $ProjectName | Should -BeNullOrEmpty
+    It 'Should remove without error' {
+        { Remove-Module -Name $script:moduleName -ErrorAction Stop } | Should -Not -Throw
+
+        Get-Module $script:moduleName | Should -BeNullOrEmpty
     }
 }
 
-if (Get-Command Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue)
-{
-    $scriptAnalyzerRules = Get-ScriptAnalyzerRule
-}
-else
-{
-    if ($ErrorActionPreference -ne 'Stop')
+BeforeDiscovery {
+    # Must use the imported module to build test cases.
+    $allModuleFunctions = & $mut { Get-Command -Module $args[0] -CommandType Function } $script:moduleName
+
+    # Build test cases.
+    $testCases = @()
+
+    foreach ($function in $allModuleFunctions)
     {
-        Write-Warning 'ScriptAnalyzer not found!'
-    }
-    else
-    {
-        throw 'ScriptAnalyzer not found!'
-    }
-}
-
-foreach ($function in $allModuleFunctions)
-{
-    $functionFile = Get-ChildItem -Path $SourcePath -Recurse -Include "$($function.Name).ps1"
-    Describe "Quality for $($function.Name)" -Tags 'TestQuality' {
-        It "$($function.Name) has a unit test" {
-            Get-ChildItem 'tests\' -Recurse -Include "$($function.Name).Tests.ps1" | Should Not BeNullOrEmpty
+        $testCases += @{
+            Name = $function.Name
         }
+    }
+}
 
-        if ($scriptAnalyzerRules)
+Describe 'Quality for module' -Tags 'TestQuality' {
+    BeforeDiscovery {
+        if (Get-Command -Name Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue)
         {
-            It "Script Analyzer for $($functionFile.FullName)" {
-                $PSSAResult = (Invoke-ScriptAnalyzer -Path $functionFile.FullName)
-                $Report = $PSSAResult | Format-Table -AutoSize | Out-String -Width 110
-                $PSSAResult | Should -BeNullOrEmpty -Because `
-                    "Some rule triggered.`r`n`r`n $Report"
+            $scriptAnalyzerRules = Get-ScriptAnalyzerRule
+        }
+        else
+        {
+            if ($ErrorActionPreference -ne 'Stop')
+            {
+                Write-Warning -Message 'ScriptAnalyzer not found!'
+            }
+            else
+            {
+                throw 'ScriptAnalyzer not found!'
+            }
+        }
+    }
+
+    It 'Should have a unit test for <Name>' -ForEach $testCases {
+        Get-ChildItem -Path 'tests\' -Recurse -Include "$Name.Tests.ps1" | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Should pass Script Analyzer for <Name>' -ForEach $testCases -Skip:(-not $scriptAnalyzerRules) {
+        $functionFile = Get-ChildItem -Path $sourcePath -Recurse -Include "$Name.ps1"
+
+        $pssaResult = (Invoke-ScriptAnalyzer -Path $functionFile.FullName)
+        $report = $pssaResult | Format-Table -AutoSize | Out-String -Width 110
+        $pssaResult | Should -BeNullOrEmpty -Because `
+            "some rule triggered.`r`n`r`n $report"
+    }
+}
+
+Describe 'Help for module' -Tags 'helpQuality' {
+    It 'Should have .SYNOPSIS for <Name>' -ForEach $testCases {
+        $functionFile = Get-ChildItem -Path $sourcePath -Recurse -Include "$Name.ps1"
+
+        $scriptFileRawContent = Get-Content -Raw -Path $functionFile.FullName
+
+        $abstractSyntaxTree = [System.Management.Automation.Language.Parser]::ParseInput($scriptFileRawContent, [ref] $null, [ref] $null)
+
+        $astSearchDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
+
+        $parsedFunction = $abstractSyntaxTree.FindAll( $astSearchDelegate, $true ) |
+            Where-Object -FilterScript {
+                $_.Name -eq $Name
             }
 
-        }
+        $functionHelp = $parsedFunction.GetHelpContent()
+
+        $functionHelp.Synopsis | Should -Not -BeNullOrEmpty
     }
 
-    Describe "Help for $($function.Name)" -Tags 'HelpQuality' {
-        $AbstractSyntaxTree = [System.Management.Automation.Language.Parser]::
-        ParseInput((Get-Content -Raw $functionFile.FullName), [ref]$null, [ref]$null)
-        $AstSearchDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
-        $ParsedFunction = $AbstractSyntaxTree.FindAll( $AstSearchDelegate, $true ) |
-            ? Name -EQ $function.Name
+    It 'Should have a .DESCRIPTION with length greater than 40 characters for <Name>' -ForEach $testCases {
+        $functionFile = Get-ChildItem -Path $sourcePath -Recurse -Include "$Name.ps1"
 
-        $FunctionHelp = $ParsedFunction.GetHelpContent()
+        $scriptFileRawContent = Get-Content -Raw -Path $functionFile.FullName
 
-        It 'Has a SYNOPSIS' {
-            $FunctionHelp.Synopsis | Should not BeNullOrEmpty
-        }
+        $abstractSyntaxTree = [System.Management.Automation.Language.Parser]::ParseInput($scriptFileRawContent, [ref] $null, [ref] $null)
 
-        It 'Has a Description, with length > 40' {
-            $FunctionHelp.Description.Length | Should beGreaterThan 40
-        }
+        $astSearchDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
 
-        It 'Has at least 1 example' {
-            $FunctionHelp.Examples.Count | Should beGreaterThan 0
-            $FunctionHelp.Examples[0] | Should match ([regex]::Escape($function.Name))
-            $FunctionHelp.Examples[0].Length | Should BeGreaterThan ($function.Name.Length + 10)
-        }
+        $parsedFunction = $abstractSyntaxTree.FindAll($astSearchDelegate, $true) |
+            Where-Object -FilterScript {
+                $_.Name -eq $Name
+            }
 
-        $parameters = $ParsedFunction.Body.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
+        $functionHelp = $parsedFunction.GetHelpContent()
+
+        $functionHelp.Description.Length | Should -BeGreaterThan 40
+    }
+
+    It 'Should have at least one (1) example for <Name>' -ForEach $testCases {
+        $functionFile = Get-ChildItem -Path $sourcePath -Recurse -Include "$Name.ps1"
+
+        $scriptFileRawContent = Get-Content -Raw -Path $functionFile.FullName
+
+        $abstractSyntaxTree = [System.Management.Automation.Language.Parser]::ParseInput($scriptFileRawContent, [ref] $null, [ref] $null)
+
+        $astSearchDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
+
+        $parsedFunction = $abstractSyntaxTree.FindAll( $astSearchDelegate, $true ) |
+            Where-Object -FilterScript {
+                $_.Name -eq $Name
+            }
+
+        $functionHelp = $parsedFunction.GetHelpContent()
+
+        $functionHelp.Examples.Count | Should -BeGreaterThan 0
+        $functionHelp.Examples[0] | Should -Match ([regex]::Escape($function.Name))
+        $functionHelp.Examples[0].Length | Should -BeGreaterThan ($function.Name.Length + 10)
+
+    }
+
+    It 'Should have described all parameters for <Name>' -ForEach $testCases {
+        $functionFile = Get-ChildItem -Path $sourcePath -Recurse -Include "$Name.ps1"
+
+        $scriptFileRawContent = Get-Content -Raw -Path $functionFile.FullName
+
+        $abstractSyntaxTree = [System.Management.Automation.Language.Parser]::ParseInput($scriptFileRawContent, [ref] $null, [ref] $null)
+
+        $astSearchDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
+
+        $parsedFunction = $abstractSyntaxTree.FindAll( $astSearchDelegate, $true ) |
+            Where-Object -FilterScript {
+                $_.Name -eq $Name
+            }
+
+        $functionHelp = $parsedFunction.GetHelpContent()
+
+        $parameters = $parsedFunction.Body.ParamBlock.Parameters.Name.VariablePath.ForEach({ $_.ToString() })
+
         foreach ($parameter in $parameters)
         {
-            It "Has help for Parameter: $parameter" {
-                $FunctionHelp.Parameters.($parameter.ToUpper()) | Should Not BeNullOrEmpty
-                $FunctionHelp.Parameters.($parameter.ToUpper()).Length | Should BeGreaterThan 25
-            }
+            $functionHelp.Parameters.($parameter.ToUpper()) | Should -Not -BeNullOrEmpty -Because ('the parameter {0} must have a description' -f $parameter)
+            $functionHelp.Parameters.($parameter.ToUpper()).Length | Should -BeGreaterThan 25 -Because ('the parameter {0} must have descriptive description' -f $parameter)
         }
     }
 }

--- a/Sampler/Templates/Sampler/module.tests.ps1.template
+++ b/Sampler/Templates/Sampler/module.tests.ps1.template
@@ -4,109 +4,132 @@ $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ProjectPath = "$here\..\.." | Convert-Path
 $ProjectName = (Get-ChildItem $ProjectPath\*\*.psd1 | Where-Object {
     ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-    $(try { Test-ModuleManifest $_.FullName -ErrorAction Stop }catch{$false}) }
+        $(try
+            {
+                Test-ModuleManifest $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            }) }
 ).BaseName
 
 $SourcePath = (Get-ChildItem $ProjectPath\*\*.psd1 | Where-Object {
         ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-        $(try { Test-ModuleManifest $_.FullName -ErrorAction Stop }catch { $false }) }
-    ).Directory.FullName
+        $(try
+            {
+                Test-ModuleManifest $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            }) }
+).Directory.FullName
 
 $mut = Import-Module -Name $ProjectName -ErrorAction Stop -PassThru -Force
-$allModuleFunctions = &$mut {Get-Command -Module $args[0] -CommandType Function } $ProjectName
+$allModuleFunctions = &$mut { Get-Command -Module $args[0] -CommandType Function } $ProjectName
 
-    Describe 'Changelog Management' -Tag 'Changelog' {
-        It 'Changelog has been updated' -skip:(
-            !([bool](Get-Command git -EA SilentlyContinue) -and
-              [bool](&(Get-Process -id $PID).Path -NoProfile -Command 'git rev-parse --is-inside-work-tree 2>$null'))
-            ) {
-            # Get the list of changed files compared with master
-            $HeadCommit = &git rev-parse HEAD
-            $MasterCommit = &git rev-parse origin/<%=if($PLASTER_PARAM_MainGitBranch -eq 'master') {'master'} else {'main'} %>
-            $filesChanged = &git @('diff', "$MasterCommit...$HeadCommit", '--name-only')
+Describe 'Changelog Management' -Tag 'Changelog' {
+    It 'Changelog has been updated' -Skip:(
+        -not ([bool](Get-Command git -EA SilentlyContinue) -and
+            [bool](&(Get-Process -Id $PID).Path -NoProfile -Command 'git rev-parse --is-inside-work-tree 2>$null'))
+    ) {
+        # Get the list of changed files compared with master
+        $HeadCommit = &git rev-parse HEAD
+        $MasterCommit = &git rev-parse origin/main
+        $filesChanged = &git @('diff', "$MasterCommit...$HeadCommit", '--name-only')
 
-            if ($HeadCommit -ne $MasterCommit) { # if we're not testing same commit (i.e. master..master)
-                $filesChanged.Where{ (Split-Path $_ -Leaf) -match '^changelog' } | Should -Not -BeNullOrEmpty
-            }
-        }
-
-        It 'Changelog format compliant with keepachangelog format' -skip:(![bool](Get-Command git -EA SilentlyContinue)) {
-            { Get-ChangelogData (Join-Path $ProjectPath 'CHANGELOG.md') -ErrorAction Stop } | Should -Not -Throw
+        if ($HeadCommit -ne $MasterCommit)
+        {
+            # if we're not testing same commit (i.e. master..master)
+            $filesChanged.Where{ (Split-Path $_ -Leaf) -match '^changelog' } | Should -Not -BeNullOrEmpty
         }
     }
 
-    Describe 'General module control' -Tags 'FunctionalQuality' {
+    It 'Changelog format compliant with keepachangelog format' -Skip:(![bool](Get-Command git -EA SilentlyContinue)) {
+        { Get-ChangelogData (Join-Path $ProjectPath 'CHANGELOG.md') -ErrorAction Stop } | Should -Not -Throw
+    }
+}
 
-        It 'imports without errors' {
-            { Import-Module -Name $ProjectName -Force -ErrorAction Stop } | Should -Not -Throw
-            Get-Module $ProjectName | Should -Not -BeNullOrEmpty
+Describe 'General module control' -Tags 'FunctionalQuality' {
+
+    It 'Imports without errors' {
+        { Import-Module -Name $ProjectName -Force -ErrorAction Stop } | Should -Not -Throw
+        Get-Module $ProjectName | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Removes without error' {
+        { Remove-Module -Name $ProjectName -ErrorAction Stop } | Should -Not -Throw
+        Get-Module $ProjectName | Should -BeNullOrEmpty
+    }
+}
+
+if (Get-Command Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue)
+{
+    $scriptAnalyzerRules = Get-ScriptAnalyzerRule
+}
+else
+{
+    if ($ErrorActionPreference -ne 'Stop')
+    {
+        Write-Warning 'ScriptAnalyzer not found!'
+    }
+    else
+    {
+        throw 'ScriptAnalyzer not found!'
+    }
+}
+
+foreach ($function in $allModuleFunctions)
+{
+    $functionFile = Get-ChildItem -Path $SourcePath -Recurse -Include "$($function.Name).ps1"
+    Describe "Quality for $($function.Name)" -Tags 'TestQuality' {
+        It "$($function.Name) has a unit test" {
+            Get-ChildItem 'tests\' -Recurse -Include "$($function.Name).Tests.ps1" | Should Not BeNullOrEmpty
         }
 
-        It 'Removes without error' {
-            { Remove-Module -Name $ProjectName -ErrorAction Stop } | Should -not -Throw
-            Get-Module $ProjectName | Should -beNullOrEmpty
+        if ($scriptAnalyzerRules)
+        {
+            It "Script Analyzer for $($functionFile.FullName)" {
+                $PSSAResult = (Invoke-ScriptAnalyzer -Path $functionFile.FullName)
+                $Report = $PSSAResult | Format-Table -AutoSize | Out-String -Width 110
+                $PSSAResult | Should -BeNullOrEmpty -Because `
+                    "Some rule triggered.`r`n`r`n $Report"
+            }
+
         }
     }
 
-    if (Get-Command Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue) {
-        $scriptAnalyzerRules = Get-ScriptAnalyzerRule
-    }
-    else {
-        if ($ErrorActionPreference -ne 'Stop') {
-            Write-Warning "ScriptAnalyzer not found!"
-        }
-        else {
-            Throw "ScriptAnalyzer not found!"
-        }
-    }
+    Describe "Help for $($function.Name)" -Tags 'HelpQuality' {
+        $AbstractSyntaxTree = [System.Management.Automation.Language.Parser]::
+        ParseInput((Get-Content -Raw $functionFile.FullName), [ref]$null, [ref]$null)
+        $AstSearchDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
+        $ParsedFunction = $AbstractSyntaxTree.FindAll( $AstSearchDelegate, $true ) |
+            ? Name -EQ $function.Name
 
-    foreach ($function in $allModuleFunctions) {
-        $functionFile = Get-ChildItem -path $SourcePath -Recurse -Include "$($function.Name).ps1"
-        Describe "Quality for $($function.Name)" -Tags 'TestQuality' {
-            It "$($function.Name) has a unit test" {
-                Get-ChildItem "tests\" -recurse -include "$($function.Name).Tests.ps1" | Should Not BeNullOrEmpty
-            }
+        $FunctionHelp = $ParsedFunction.GetHelpContent()
 
-            if ($scriptAnalyzerRules) {
-                It "Script Analyzer for $($functionFile.FullName)" {
-                    $PSSAResult = (Invoke-ScriptAnalyzer -Path $functionFile.FullName)
-                    $Report = $PSSAResult | Format-Table -AutoSize | Out-String -Width 110
-                    $PSSAResult  | Should -BeNullOrEmpty -Because `
-                        "some rule triggered.`r`n`r`n $Report"
-                }
-
-            }
+        It 'Has a SYNOPSIS' {
+            $FunctionHelp.Synopsis | Should not BeNullOrEmpty
         }
 
-        Describe "Help for $($function.Name)" -Tags 'helpQuality' {
-            $AbstractSyntaxTree = [System.Management.Automation.Language.Parser]::
-            ParseInput((Get-Content -raw $functionFile.FullName), [ref]$null, [ref]$null)
-            $AstSearchDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
-            $ParsedFunction = $AbstractSyntaxTree.FindAll( $AstSearchDelegate, $true ) |
-                ? Name -eq $function.Name
+        It 'Has a Description, with length > 40' {
+            $FunctionHelp.Description.Length | Should beGreaterThan 40
+        }
 
-            $FunctionHelp = $ParsedFunction.GetHelpContent()
+        It 'Has at least 1 example' {
+            $FunctionHelp.Examples.Count | Should beGreaterThan 0
+            $FunctionHelp.Examples[0] | Should match ([regex]::Escape($function.Name))
+            $FunctionHelp.Examples[0].Length | Should BeGreaterThan ($function.Name.Length + 10)
+        }
 
-            It 'Has a SYNOPSIS' {
-                $FunctionHelp.Synopsis | should not BeNullOrEmpty
-            }
-
-            It 'Has a Description, with length > 40' {
-                $FunctionHelp.Description.Length | Should beGreaterThan 40
-            }
-
-            It 'Has at least 1 example' {
-                $FunctionHelp.Examples.Count | Should beGreaterThan 0
-                $FunctionHelp.Examples[0] | Should match ([regex]::Escape($function.Name))
-                $FunctionHelp.Examples[0].Length | Should BeGreaterThan ($function.Name.Length + 10)
-            }
-
-            $parameters = $ParsedFunction.Body.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
-            foreach ($parameter in $parameters) {
-                It "Has help for Parameter: $parameter" {
-                    $FunctionHelp.Parameters.($parameter.ToUpper()) | Should Not BeNullOrEmpty
-                    $FunctionHelp.Parameters.($parameter.ToUpper()).Length | Should BeGreaterThan 25
-                }
+        $parameters = $ParsedFunction.Body.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
+        foreach ($parameter in $parameters)
+        {
+            It "Has help for Parameter: $parameter" {
+                $FunctionHelp.Parameters.($parameter.ToUpper()) | Should Not BeNullOrEmpty
+                $FunctionHelp.Parameters.($parameter.ToUpper()).Length | Should BeGreaterThan 25
             }
         }
     }
+}

--- a/tests/QA/module.tests.ps1
+++ b/tests/QA/module.tests.ps1
@@ -1,15 +1,15 @@
 BeforeDiscovery {
-    $script:moduleName = 'Sampler'
+    $script:moduleName = $ProjectName
 
-    Remove-Module -Name $script:moduleName -Force -ErrorAction 'SilentlyContinue'
+    Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
 
     $mut = Get-Module -Name $script:moduleName -ListAvailable |
         Select-Object -First 1 |
-        Import-Module -Force -ErrorAction 'Stop' -PassThru
+            Import-Module -Force -ErrorAction Stop -PassThru
 }
 
 BeforeAll {
-    $script:moduleName = 'Sampler'
+    $script:moduleName = $ProjectName
 
     # Convert-Path required for PS7 or Join-Path fails
     $projectPath = "$($PSScriptRoot)\..\.." | Convert-Path
@@ -18,10 +18,10 @@ BeforeAll {
         Get-ChildItem -Path $projectPath\*\*.psd1 |
             Where-Object -FilterScript {
                 ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) `
-                -and $(
+                    -and $(
                     try
                     {
-                        Test-ModuleManifest -Path $_.FullName -ErrorAction 'Stop'
+                        Test-ModuleManifest -Path $_.FullName -ErrorAction Stop
                     }
                     catch
                     {
@@ -32,34 +32,34 @@ BeforeAll {
     ).Directory.FullName
 }
 
-    Describe 'Changelog Management' -Tag 'Changelog' {
-        It 'Changelog has been updated' -skip:(
-            !([bool](Get-Command git -EA SilentlyContinue) -and
-              [bool](&(Get-Process -id $PID).Path -NoProfile -Command 'git rev-parse --is-inside-work-tree 2>$null'))
-        ) {
-            # Get the list of changed files compared with branch main
-            $HeadCommit = &git rev-parse HEAD
-            $defaultBranchCommit = &git rev-parse origin/main
-            $filesChanged = &git @('diff', "$defaultBranchCommit...$HeadCommit", '--name-only')
-            $filesStagedAndUnstaged = &git @('diff', "HEAD", '--name-only')
+Describe 'Changelog Management' -Tag 'Changelog' {
+    It 'Changelog has been updated' -Skip:(
+        -not ([bool](Get-Command git -ErrorAction SilentlyContinue) -and
+            [bool](&(Get-Process -Id $PID).Path -NoProfile -Command 'git rev-parse --is-inside-work-tree 2>$null'))
+    ) {
+        # Get the list of changed files compared with branch main
+        $headCommit = &git rev-parse HEAD
+        $defaultBranchCommit = &git rev-parse origin/main
+        $filesChanged = &git @('diff', "$defaultBranchCommit...$headCommit", '--name-only')
+        $filesStagedAndUnstaged = &git @('diff', 'HEAD', '--name-only')
 
-            $filesChanged += $filesStagedAndUnstaged
+        $filesChanged += $filesStagedAndUnstaged
 
-            # Only check if there are any changed files.
-            if ($filesChanged)
-            {
-                $filesChanged | Should -Contain 'CHANGELOG.md' -Because 'the CHANGELOG.md must be updated with at least one entry in the Unreleased section for each PR'
-            }
-        }
-
-        It 'Changelog format compliant with keepachangelog format' -skip:(![bool](Get-Command git -EA SilentlyContinue)) {
-            { Get-ChangelogData (Join-Path $ProjectPath 'CHANGELOG.md') -ErrorAction Stop } | Should -Not -Throw
-        }
-
-        It 'Changelog should have an Unreleased header' -Skip:$skipTest {
-            (Get-ChangelogData -Path (Join-Path -Path $ProjectPath -ChildPath 'CHANGELOG.md') -ErrorAction 'Stop').Unreleased.RawData | Should -Not -BeNullOrEmpty
+        # Only check if there are any changed files.
+        if ($filesChanged)
+        {
+            $filesChanged | Should -Contain 'CHANGELOG.md' -Because 'the CHANGELOG.md must be updated with at least one entry in the Unreleased section for each PR'
         }
     }
+
+    It 'Changelog format compliant with keepachangelog format' -Skip:(![bool](Get-Command git -EA SilentlyContinue)) {
+        { Get-ChangelogData -Path (Join-Path $ProjectPath 'CHANGELOG.md') -ErrorAction Stop } | Should -Not -Throw
+    }
+
+    It 'Changelog should have an Unreleased header' -Skip:$skipTest {
+            (Get-ChangelogData -Path (Join-Path -Path $ProjectPath -ChildPath 'CHANGELOG.md') -ErrorAction Stop).Unreleased.RawData | Should -Not -BeNullOrEmpty
+    }
+}
 
 Describe 'General module control' -Tags 'FunctionalQuality' {
     It 'Should import without errors' {
@@ -118,7 +118,7 @@ Describe 'Quality for module' -Tags 'TestQuality' {
 
         $pssaResult = (Invoke-ScriptAnalyzer -Path $functionFile.FullName)
         $report = $pssaResult | Format-Table -AutoSize | Out-String -Width 110
-        $pssaResult  | Should -BeNullOrEmpty -Because `
+        $pssaResult | Should -BeNullOrEmpty -Because `
             "some rule triggered.`r`n`r`n $report"
     }
 }
@@ -152,7 +152,7 @@ Describe 'Help for module' -Tags 'helpQuality' {
 
         $astSearchDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
 
-        $parsedFunction = $abstractSyntaxTree.FindAll( $astSearchDelegate, $true ) |
+        $parsedFunction = $abstractSyntaxTree.FindAll($astSearchDelegate, $true) |
             Where-Object -FilterScript {
                 $_.Name -eq $Name
             }


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

This PR almost only applies this project's code style rules to the file `\tests\QA\module.tests.ps1`. The only functional change is making use of the variable `$ProjectName` instead of using the hard coded name `Sampler`.

The file `\Sampler\Templates\Sampler\module.tests.ps1.template` was synced with `\tests\QA\module.tests.ps1` as the file `module.tests.ps1.template` still used the Pester 4 syntax and simply does not work with new modules.

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/396)
<!-- Reviewable:end -->
