### PR TITLE
Fix QA test for ChangelogManagement v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Get-MofSchemaName`
   - Permanently skipped a test that the build worker `ubuntu-latest` were
     unable to run due to missing shared library 'libmi'.
+- Now the QA test that verifies that the Unreleased section header is present
+  in the CHANGELOG.md correctly supports ChangelogManagement v3.0.1.
 
 ### Added
 
 - Task `Build_ModuleOutput_ModuleBuilder`
   - Proper support for DSC composite resources (*.schema.psm1).
+
+### Changed
+
+- The QA tests can now be debugged by `Invoke-Pester` directly, before it
+  had to be started by the build script `build.ps1`. This will also help
+  the Pester Tests VS Code extension to be able to run the tests.
 
 ## [0.116.0] - 2022-11-08
 

--- a/Sampler/Templates/Sampler/module.tests.ps1.template
+++ b/Sampler/Templates/Sampler/module.tests.ps1.template
@@ -8,7 +8,7 @@ BeforeDiscovery {
     if (-not $ProjectName)
     {
         # Assuming project folder name is project name.
-        $ProjectName = Split-Path -Path $projectPath -Leaf
+        $ProjectName = Get-SamplerProjectName -BuildRoot $projectPath
     }
 
     $script:moduleName = $ProjectName
@@ -31,7 +31,7 @@ BeforeAll {
     if (-not $ProjectName)
     {
         # Assuming project folder name is project name.
-        $ProjectName = Split-Path -Path $projectPath -Leaf
+        $ProjectName = Get-SamplerProjectName -BuildRoot $projectPath
     }
 
     $script:moduleName = $ProjectName

--- a/Sampler/Templates/Sampler/module.tests.ps1.template
+++ b/Sampler/Templates/Sampler/module.tests.ps1.template
@@ -1,4 +1,16 @@
 BeforeDiscovery {
+    $projectPath = "$($PSScriptRoot)\..\.." | Convert-Path
+
+    <#
+        If the QA tests are run outside of the build script (e.g with Invoke-Pester)
+        the parent scope has not set the variable $ProjectName.
+    #>
+    if (-not $ProjectName)
+    {
+        # Assuming project folder name is project name.
+        $ProjectName = Split-Path -Path $projectPath -Leaf
+    }
+
     $script:moduleName = $ProjectName
 
     Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
@@ -9,10 +21,20 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:moduleName = $ProjectName
-
     # Convert-Path required for PS7 or Join-Path fails
     $projectPath = "$($PSScriptRoot)\..\.." | Convert-Path
+
+    <#
+        If the QA tests are run outside of the build script (e.g with Invoke-Pester)
+        the parent scope has not set the variable $ProjectName.
+    #>
+    if (-not $ProjectName)
+    {
+        # Assuming project folder name is project name.
+        $ProjectName = Split-Path -Path $projectPath -Leaf
+    }
+
+    $script:moduleName = $ProjectName
 
     $sourcePath = (
         Get-ChildItem -Path $projectPath\*\*.psd1 |
@@ -57,7 +79,7 @@ Describe 'Changelog Management' -Tag 'Changelog' {
     }
 
     It 'Changelog should have an Unreleased header' -Skip:$skipTest {
-            (Get-ChangelogData -Path (Join-Path -Path $ProjectPath -ChildPath 'CHANGELOG.md') -ErrorAction Stop).Unreleased.RawData | Should -Not -BeNullOrEmpty
+            (Get-ChangelogData -Path (Join-Path -Path $ProjectPath -ChildPath 'CHANGELOG.md') -ErrorAction Stop).Unreleased | Should -Not -BeNullOrEmpty
     }
 }
 

--- a/tests/QA/module.tests.ps1
+++ b/tests/QA/module.tests.ps1
@@ -8,7 +8,7 @@ BeforeDiscovery {
     if (-not $ProjectName)
     {
         # Assuming project folder name is project name.
-        $ProjectName = Split-Path -Path $projectPath -Leaf
+        $ProjectName = Get-SamplerProjectName -BuildRoot $projectPath
     }
 
     $script:moduleName = $ProjectName
@@ -31,7 +31,7 @@ BeforeAll {
     if (-not $ProjectName)
     {
         # Assuming project folder name is project name.
-        $ProjectName = Split-Path -Path $projectPath -Leaf
+        $ProjectName = Get-SamplerProjectName -BuildRoot $projectPath
     }
 
     $script:moduleName = $ProjectName

--- a/tests/QA/module.tests.ps1
+++ b/tests/QA/module.tests.ps1
@@ -1,4 +1,16 @@
 BeforeDiscovery {
+    $projectPath = "$($PSScriptRoot)\..\.." | Convert-Path
+
+    <#
+        If the QA tests are run outside of the build script (e.g with Invoke-Pester)
+        the parent scope has not set the variable $ProjectName.
+    #>
+    if (-not $ProjectName)
+    {
+        # Assuming project folder name is project name.
+        $ProjectName = Split-Path -Path $projectPath -Leaf
+    }
+
     $script:moduleName = $ProjectName
 
     Remove-Module -Name $script:moduleName -Force -ErrorAction SilentlyContinue
@@ -9,10 +21,20 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:moduleName = $ProjectName
-
     # Convert-Path required for PS7 or Join-Path fails
     $projectPath = "$($PSScriptRoot)\..\.." | Convert-Path
+
+    <#
+        If the QA tests are run outside of the build script (e.g with Invoke-Pester)
+        the parent scope has not set the variable $ProjectName.
+    #>
+    if (-not $ProjectName)
+    {
+        # Assuming project folder name is project name.
+        $ProjectName = Split-Path -Path $projectPath -Leaf
+    }
+
+    $script:moduleName = $ProjectName
 
     $sourcePath = (
         Get-ChildItem -Path $projectPath\*\*.psd1 |
@@ -57,7 +79,7 @@ Describe 'Changelog Management' -Tag 'Changelog' {
     }
 
     It 'Changelog should have an Unreleased header' -Skip:$skipTest {
-            (Get-ChangelogData -Path (Join-Path -Path $ProjectPath -ChildPath 'CHANGELOG.md') -ErrorAction Stop).Unreleased.RawData | Should -Not -BeNullOrEmpty
+            (Get-ChangelogData -Path (Join-Path -Path $ProjectPath -ChildPath 'CHANGELOG.md') -ErrorAction Stop).Unreleased | Should -Not -BeNullOrEmpty
     }
 }
 


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Changed

- The QA tests can now be debugged by `Invoke-Pester` directly, before it
  had to be started by the build script `build.ps1`. This will also help
  the Pester Tests VS Code extension to be able to run the tests.

### Fixed

- Now the QA test that verifies that the Unreleased section header is present
  in the CHANGELOG.md correctly supports ChangelogManagement v3.0.1.

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/405)
<!-- Reviewable:end -->
