### PR TITLE
`Convert_Pester_Coverage`: No longer throws an exception

### DIFF
--- a/.build/tasks/JaCoCo.coverage.build.ps1
+++ b/.build/tasks/JaCoCo.coverage.build.ps1
@@ -358,7 +358,7 @@ task Convert_Pester_Coverage {
         to the correct type even if there is just one item so that Convert-LineNumber
         works.
     #>
-    [System.Collections.ArrayList] $missedCommands = $originalMissedCommands |
+    [System.Collections.ArrayList] $missedCommands = , $originalMissedCommands |
         Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
 
     <#
@@ -366,7 +366,7 @@ task Convert_Pester_Coverage {
         to the correct type even if there is just one item so that Convert-LineNumber
         works.
     #>
-    [System.Collections.ArrayList] $hitCommands = $originalHitCommands |
+    [System.Collections.ArrayList] $hitCommands = , $originalHitCommands |
         Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
 
     <#

--- a/.build/tasks/JaCoCo.coverage.build.ps1
+++ b/.build/tasks/JaCoCo.coverage.build.ps1
@@ -353,21 +353,25 @@ task Convert_Pester_Coverage {
         $originalHitCommands = $pesterObject.CodeCoverage.HitCommands
     }
 
-    <#
-        Get all missed commands that are in the main module file. Must be cast
-        to the correct type even if there is just one item so that Convert-LineNumber
-        works.
-    #>
-    [System.Collections.ArrayList] $missedCommands = , $originalMissedCommands |
-        Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
+    # Get all missed commands that are in the main module file.
+    $missedCommands = $originalMissedCommands |
+            Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
 
-    <#
-        Get all hit commands that are in the main module file. Must be cast
-        to the correct type even if there is just one item so that Convert-LineNumber
-        works.
-    #>
-    [System.Collections.ArrayList] $hitCommands = , $originalHitCommands |
-        Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
+    if ($null -ne $missedCommands)
+    {
+        # Handle if there is just one item retuned, casting back to array.
+        $missedCommands = @($missedCommands)
+    }
+
+    # Get all hit commands that are in the main module file.
+    $hitCommands = $originalHitCommands |
+            Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
+
+    if ($null -ne $hitCommands)
+    {
+        # Handle if there is just one item retuned, casting back to array.
+        $hitCommands = @($hitCommands)
+    }
 
     <#
         The command Convert-LineNumber uses 'PassThru' very strange. It is needed

--- a/.build/tasks/JaCoCo.coverage.build.ps1
+++ b/.build/tasks/JaCoCo.coverage.build.ps1
@@ -353,12 +353,20 @@ task Convert_Pester_Coverage {
         $originalHitCommands = $pesterObject.CodeCoverage.HitCommands
     }
 
-    # Get all missed commands that are in the main module file.
-    $missedCommands = , $originalMissedCommands |
+    <#
+        Get all missed commands that are in the main module file. Must be cast
+        to the correct type even if there is just one item so that Convert-LineNumber
+        works.
+    #>
+    [System.Collections.ArrayList] $missedCommands = $originalMissedCommands |
         Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
 
-    # Get all hit commands that are in the main module file.
-    $hitCommands = , $originalHitCommands |
+    <#
+        Get all hit commands that are in the main module file. Must be cast
+        to the correct type even if there is just one item so that Convert-LineNumber
+        works.
+    #>
+    [System.Collections.ArrayList] $hitCommands = $originalHitCommands |
         Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
 
     <#

--- a/.build/tasks/JaCoCo.coverage.build.ps1
+++ b/.build/tasks/JaCoCo.coverage.build.ps1
@@ -355,7 +355,7 @@ task Convert_Pester_Coverage {
 
     # Get all missed commands that are in the main module file.
     $missedCommands = $originalMissedCommands |
-            Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
+        Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
 
     if ($null -ne $missedCommands)
     {
@@ -365,7 +365,7 @@ task Convert_Pester_Coverage {
 
     # Get all hit commands that are in the main module file.
     $hitCommands = $originalHitCommands |
-            Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
+        Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
 
     if ($null -ne $hitCommands)
     {

--- a/.build/tasks/JaCoCo.coverage.build.ps1
+++ b/.build/tasks/JaCoCo.coverage.build.ps1
@@ -354,11 +354,11 @@ task Convert_Pester_Coverage {
     }
 
     # Get all missed commands that are in the main module file.
-    $missedCommands = $originalMissedCommands |
+    $missedCommands = , $originalMissedCommands |
         Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
 
     # Get all hit commands that are in the main module file.
-    $hitCommands = $originalHitCommands |
+    $hitCommands = , $originalHitCommands |
         Where-Object -FilterScript { $_.File -match [RegEx]::Escape($moduleFileName) }
 
     <#

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Get-MofSchemaName`
   - Permanently skipped a test that the build worker `ubuntu-latest` were
     unable to run due to missing shared library 'libmi'.
+- Task `Convert_Pester_Coverage`
+  - No longer throws an exception when there was just one missed command
+    for a test suite. Fixes [#407](https://github.com/gaelcolas/Sampler/issues/407).
 
 ### Added
 

--- a/tests/Unit/tasks/JaCoCo.coverage.build.Tests.ps1
+++ b/tests/Unit/tasks/JaCoCo.coverage.build.Tests.ps1
@@ -262,8 +262,23 @@ Describe 'Convert_Pester_Coverage' {
                                 EndColumn   = 144
                                 Class       = $null
                                 Function    = 'Get-MockCommand'
-                                Command     = "Get-Something -MockParameter 'MyMockValue'"
+                                Command     = "Get-Something1 -MockParameter 'MyMockValue'"
                                 HitCount    = 0
+                            }
+                        )
+
+                        CommandsExecuted = [System.Collections.ArrayList] @(
+                            [PSCustomObject] @{
+                                File = Join-Path -Path $TestDrive -ChildPath 'output/MyModule/1.0.0/MyModule.psm1'
+                                Line        = 625
+                                StartLine   = 625
+                                EndLine     = 625
+                                StartColumn = 23
+                                EndColumn   = 144
+                                Class       = $null
+                                Function    = 'Get-MockCommand'
+                                Command     = "Get-Something2 -MockParameter 'MyMockValue'"
+                                HitCount    = 1
                             }
                         )
                     }

--- a/tests/Unit/tasks/JaCoCo.coverage.build.Tests.ps1
+++ b/tests/Unit/tasks/JaCoCo.coverage.build.Tests.ps1
@@ -251,6 +251,7 @@ Describe 'Convert_Pester_Coverage' {
                 return @{
                     Version = '5.3.3'
                     CodeCoverage = @{
+                        # Mocking that same types as Pester uses.
                         CommandsMissed = [System.Collections.ArrayList] @(
                             [PSCustomObject] @{
                                 File = Join-Path -Path $TestDrive -ChildPath 'output/MyModule/1.0.0/MyModule.psm1'

--- a/tests/Unit/tasks/JaCoCo.coverage.build.Tests.ps1
+++ b/tests/Unit/tasks/JaCoCo.coverage.build.Tests.ps1
@@ -250,8 +250,26 @@ Describe 'Convert_Pester_Coverage' {
             Mock -CommandName Import-Clixml -MockWith {
                 return @{
                     Version = '5.3.3'
+                    CodeCoverage = @{
+                        CommandsMissed = [System.Collections.ArrayList] @(
+                            [PSCustomObject] @{
+                                File = Join-Path -Path $TestDrive -ChildPath 'output/MyModule/1.0.0/MyModule.psm1'
+                                Line        = 624
+                                StartLine   = 624
+                                EndLine     = 624
+                                StartColumn = 23
+                                EndColumn   = 144
+                                Class       = $null
+                                Function    = 'Get-MockCommand'
+                                Command     = "Get-Something -MockParameter 'MyMockValue'"
+                                HitCount    = 0
+                            }
+                        )
+                    }
                 }
             }
+
+            Mock -CommandName Convert-LineNumber
 
             Mock -CommandName New-SamplerJaCoCoDocument -MockWith {
                 return [Xml] '<xml></xml>'


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Fixed
- Task `Convert_Pester_Coverage`
  - No longer throws an exception when there was just one missed command
    for a test suite. Fixes [#407](https://github.com/gaelcolas/Sampler/issues/407).

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/sampler/408)
<!-- Reviewable:end -->
