### PR TITLE
Improve script `Resolve-Dependency.ps1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     module version.
   - Fix message on `Write-Progress` statement.
   - Small style cleanups.
+- Fixed aliases in `prefix.ps1` to support ModuleBuild v3.0.0. The fix
+  makes ModuleBuilder not seeing the aliases (using AST) so that the module
+  manifest is not changed during build, instead they are exported during
+  module import. In the future we could add a separate public file that
+  defines the aliases to export so the module manifest is updated during
+  build.
 
 ## [0.116.2] - 2023-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   since it is not direct requirement for any project. _It will still be saved_
   _to `output/RequiredModules` for a project as it is defined as a required_
   _module in Sampler's module manifest, and Sampler is still a required modul._
+- Pipeline script for resolving dependencies improved.
+  - Evaluating PowerShellGet version now supports parameter `AllowOldPowerShellGetModule`
+    (still not recommended to use this parameter).
+  - Now defaults to save the modules PowerShellGet and PackageManagement
+    to the folder `output/RequiredModules` (same logic as for module PSDepend)
+    to not make permanent changes to the contributors machine. If parameter
+    `PSDependTarget` is either set to `CurrentUser` or `AllUsers` the modules
+    are installed.
 
 ### Fixed
 
@@ -59,6 +67,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Fixes [#326](https://github.com/gaelcolas/Sampler/issues/326).
 - Now correctly uses the key `CodeCoverage` in the file `build.yaml.template`.
   Fixes [#359](https://github.com/gaelcolas/Sampler/issues/359).
+- Pipeline script for resolving dependencies improved.
+  - `Get-PackageProvider` no longer throws an exception when NuGet provider
+    is missing (in Windows PowerShell in a clean Windows install).
+  - `Install-PackageProvider` now defaults to installing in the current
+    user scope to avoid requiring an elevated prompt. This is the only
+    change that is permanent on the contributors machine. It is not possible
+    to avoid this as long at the module PowerShellGet requires the NuGet
+    package provider.
+  - Remove duplicate code that set `AllowPrerelease` when installing package
+    provider.
+  - Fixed wrong splatting variable that prevented `Install-PackageProvider`
+    to run.
+  - Removing all existing PowerShellGet and PackageManagement module that
+    is loaded into the session to load the newly saved or installed.
+  - Handle parameter `AllowOldPowerShellGetModule` when loading PowerShellGet
+    module version.
+  - Fix message on `Write-Progress` statement.
+  - Small style cleanups.
 
 ## [0.116.2] - 2023-03-01
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 Please check out common DSC Community [contributing guidelines](https://dsccommunity.org/guidelines/contributing).
 
+If you want to contribute code to this repository and is new to contributing
+on GitHub then start with the guide [Getting Started as a Contributor](https://dsccommunity.org/guidelines/getting-started/).
+
 ## Running the Tests
 
 If want to know how to run this module's tests you can look at the [Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines/#running-tests).

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -333,7 +333,6 @@ try
 
             $saveModuleParameters = @{
                 Name           = 'PowerShellGet'
-                MaximumVersion = '2.99.99'
                 Repository     = $Gallery
                 Path           = $PSDependTarget
                 Force          = $true

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -155,7 +155,7 @@ try
 
                 $PSBoundParameters.Add($parameterName, $variableValue)
 
-                Set-Variable -Name $parameterName -value $variableValue -Force -ErrorAction 'SilentlyContinue'
+                Set-Variable -Name $parameterName -Value $variableValue -Force -ErrorAction 'SilentlyContinue'
             }
             catch
             {
@@ -171,19 +171,32 @@ catch
 
 Write-Progress -Activity 'Bootstrap:' -PercentComplete 0 -CurrentOperation 'NuGet Bootstrap'
 
-# TODO: This should handle the parameter $AllowOldPowerShellGetModule.
-$powerShellGetModule = Import-Module -Name 'PowerShellGet' -MinimumVersion '2.0' -ErrorAction 'SilentlyContinue' -PassThru
+$importModuleParameters = @{
+    Name           = 'PowerShellGet'
+    MinimumVersion = '2.0'
+    ErrorAction    = 'SilentlyContinue'
+    PassThru       = $true
+}
+
+if ($AllowOldPowerShellGetModule)
+{
+    $importModuleParameters.Remove('MinimumVersion')
+}
+
+$powerShellGetModule = Import-Module @importModuleParameters
 
 # Install the package provider if it is not available.
-$nuGetProvider = Get-PackageProvider -Name 'NuGet' -ListAvailable | Select-Object -First 1
+$nuGetProvider = Get-PackageProvider -Name 'NuGet' -ListAvailable -ErrorAction 'SilentlyContinue' |
+    Select-Object -First 1
 
 if (-not $powerShellGetModule -and -not $nuGetProvider)
 {
     $providerBootstrapParameters = @{
-        Name           = 'nuget'
+        Name           = 'NuGet'
         Force          = $true
         ForceBootstrap = $true
         ErrorAction    = 'Stop'
+        Scope          = $Scope
     }
 
     switch ($PSBoundParameters.Keys)
@@ -198,26 +211,15 @@ if (-not $powerShellGetModule -and -not $nuGetProvider)
             $providerBootstrapParameters.Add('ProxyCredential', $ProxyCredential)
         }
 
-        'Scope'
-        {
-            $providerBootstrapParameters.Add('Scope', $Scope)
-        }
-
         'AllowPrerelease'
         {
             $providerBootstrapParameters.Add('AllowPrerelease', $AllowPrerelease)
         }
     }
 
-    if ($AllowPrerelease)
-    {
-        $providerBootstrapParameters.Add('AllowPrerelease', $true)
-    }
-
     Write-Information -MessageData 'Bootstrap: Installing NuGet Package Provider from the web (Make sure Microsoft addresses/ranges are allowed).'
 
-    # TODO: This does not handle a private Gallery yet.
-    $null = Install-PackageProvider @providerBootstrapParams
+    $null = Install-PackageProvider @providerBootstrapParameters
 
     $nuGetProvider = Get-PackageProvider -Name 'NuGet' -ListAvailable | Select-Object -First 1
 
@@ -285,48 +287,82 @@ try
     # Versions below 2.0 are considered old, unreliable & not recommended
     if (-not $powerShellGetVersion -or ($powerShellGetVersion -lt [System.Version] '2.0' -and -not $AllowOldPowerShellGetModule))
     {
-        Write-Progress -Activity 'Bootstrap:' -PercentComplete 40 -CurrentOperation 'Installing newer version of PowerShellGet'
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 40 -CurrentOperation 'Fetching newer version of PowerShellGet'
 
-        $installPowerShellGetParameters = @{
-            Name               = 'PowerShellGet'
-            Force              = $True
-            SkipPublisherCheck = $true
-            AllowClobber       = $true
-            Scope              = $Scope
-            Repository         = $Gallery
-        }
-
-        switch ($PSBoundParameters.Keys)
+        # PowerShellGet module not found, installing or saving it.
+        if ($PSDependTarget -in 'CurrentUser', 'AllUsers')
         {
-            'Proxy'
-            {
-                $installPowerShellGetParameters.Add('Proxy', $Proxy)
+            Write-Debug -Message "PowerShellGet module not found. Attempting to install from Gallery $Gallery."
+
+            Write-Warning -Message "Installing PowerShellGet in $PSDependTarget Scope."
+
+            $installPowerShellGetParameters = @{
+                Name               = 'PowerShellGet'
+                Force              = $true
+                SkipPublisherCheck = $true
+                AllowClobber       = $true
+                Scope              = $Scope
+                Repository         = $Gallery
             }
 
-            'ProxyCredential'
+            switch ($PSBoundParameters.Keys)
             {
-                $installPowerShellGetParameters.Add('ProxyCredential', $ProxyCredential)
+                'Proxy'
+                {
+                    $installPowerShellGetParameters.Add('Proxy', $Proxy)
+                }
+
+                'ProxyCredential'
+                {
+                    $installPowerShellGetParameters.Add('ProxyCredential', $ProxyCredential)
+                }
+
+                'GalleryCredential'
+                {
+                    $installPowerShellGetParameters.Add('Credential', $GalleryCredential)
+                }
             }
 
-            'GalleryCredential'
-            {
-                $installPowerShellGetParameters.Add('Credential', $GalleryCredential)
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation 'Installing newer version of PowerShellGet'
+
+            Install-Module @installPowerShellGetParameters
+        }
+        else
+        {
+            Write-Debug -Message "PowerShellGet module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
+
+            $saveModuleParameters = @{
+                Name           = 'PowerShellGet'
+                MaximumVersion = '2.99.99'
+                Repository     = $Gallery
+                Path           = $PSDependTarget
+                Force          = $true
             }
 
-            'AllowPrerelease'
-            {
-                $installPowerShellGetParameters.Add('AllowPrerelease', $AllowPrerelease)
-            }
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation "Saving PowerShellGet from $Gallery to $Scope"
+
+            Save-Module @saveModuleParameters
         }
 
-        Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation 'Installing newer version of PowerShellGet'
+        Write-Debug -Message 'Removing previous versions of PowerShellGet and PackageManagement from session'
 
-        Install-Module @installPowerShellGetParameters
+        Get-Module -Name 'PowerShellGet' -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
+        Get-Module -Name 'PackageManagement' -All | Remove-Module -Force
 
-        Remove-Module -Name 'PowerShellGet' -Force -ErrorAction 'SilentlyContinue'
-        Remove-Module -Name 'PackageManagement' -Force
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 65 -CurrentOperation 'Loading latest version of PowerShellGet'
 
-        $powerShellGetModule = Import-Module PowerShellGet -Force -PassThru
+        Write-Debug -Message 'Importing latest PowerShellGet and PackageManagement versions into session'
+
+        if ($AllowOldPowerShellGetModule)
+        {
+            $powerShellGetModule = Import-Module -Name 'PowerShellGet' -Force -PassThru
+        }
+        else
+        {
+            Import-Module -Name 'PackageManagement' -MinimumVersion '1.4.8.1' -Force
+
+            $powerShellGetModule = Import-Module -Name 'PowerShellGet' -MinimumVersion '2.2.5' -Force -PassThru
+        }
 
         $powerShellGetVersion = $powerShellGetModule.Version.ToString()
 
@@ -396,7 +432,7 @@ try
                 $saveModuleParameters.add('MinimumVersion', $MinimumPSDependVersion)
             }
 
-            Write-Progress -Activity 'Bootstrap:' -PercentComplete 75 -CurrentOperation "Saving & Importing PSDepend from $Gallery to $Scope"
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 75 -CurrentOperation "Saving PSDepend from $Gallery to $Scope"
 
             Save-Module @saveModuleParameters
         }
@@ -439,13 +475,17 @@ try
         }
         else
         {
-            Write-Verbose "PowerShell-Yaml is already available"
+            Write-Verbose -Message 'PowerShell-Yaml is already available'
         }
+
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 88 -CurrentOperation 'Importing PowerShell module PowerShell-Yaml'
+
+        Import-Module -Name 'PowerShell-Yaml' -ErrorAction 'Stop'
     }
 
     Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoke PSDepend'
 
-    Write-Progress -Activity "PSDepend:" -PercentComplete 0 -CurrentOperation "Restoring Build Dependencies"
+    Write-Progress -Activity 'PSDepend:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
 
     if (Test-Path -Path $DependencyFile)
     {
@@ -458,9 +498,9 @@ try
         Invoke-PSDepend @psDependParameters
     }
 
-    Write-Progress -Activity "PSDepend:" -PercentComplete 100 -CurrentOperation "Dependencies restored" -Completed
+    Write-Progress -Activity 'PSDepend:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
 
-    Write-Progress -Activity 'Bootstrap:' -PercentComplete 100 -CurrentOperation "Bootstrap complete" -Completed
+    Write-Progress -Activity 'Bootstrap:' -PercentComplete 100 -CurrentOperation 'Bootstrap complete' -Completed
 }
 finally
 {
@@ -475,7 +515,7 @@ finally
         Write-Verbose -Message "Reverting private package repository '$Gallery' to previous location URI:s."
 
         $registerPSRepositoryParameters = @{
-            Name = $previousRegisteredRepository.Name
+            Name               = $previousRegisteredRepository.Name
             InstallationPolicy = $previousRegisteredRepository.InstallationPolicy
         }
 
@@ -512,5 +552,5 @@ finally
         }
     }
 
-    Write-Verbose -Message "Project Bootstrapped, returning to Invoke-Build"
+    Write-Verbose -Message 'Project Bootstrapped, returning to Invoke-Build.'
 }

--- a/Sampler/Templates/Build/CONTRIBUTING.md
+++ b/Sampler/Templates/Build/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 Please check out common DSC Community [contributing guidelines](https://dsccommunity.org/guidelines/contributing).
 
+If you want to contribute code to this repository and is new to contributing
+on GitHub then start with the guide [Getting Started as a Contributor](https://dsccommunity.org/guidelines/getting-started/).
+
 ## Running the Tests
 
 If want to know how to run this module's tests you can look at the [Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines/#running-tests).

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -333,7 +333,6 @@ try
 
             $saveModuleParameters = @{
                 Name           = 'PowerShellGet'
-                MaximumVersion = '2.99.99'
                 Repository     = $Gallery
                 Path           = $PSDependTarget
                 Force          = $true

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -155,7 +155,7 @@ try
 
                 $PSBoundParameters.Add($parameterName, $variableValue)
 
-                Set-Variable -Name $parameterName -value $variableValue -Force -ErrorAction 'SilentlyContinue'
+                Set-Variable -Name $parameterName -Value $variableValue -Force -ErrorAction 'SilentlyContinue'
             }
             catch
             {
@@ -171,19 +171,32 @@ catch
 
 Write-Progress -Activity 'Bootstrap:' -PercentComplete 0 -CurrentOperation 'NuGet Bootstrap'
 
-# TODO: This should handle the parameter $AllowOldPowerShellGetModule.
-$powerShellGetModule = Import-Module -Name 'PowerShellGet' -MinimumVersion '2.0' -ErrorAction 'SilentlyContinue' -PassThru
+$importModuleParameters = @{
+    Name           = 'PowerShellGet'
+    MinimumVersion = '2.0'
+    ErrorAction    = 'SilentlyContinue'
+    PassThru       = $true
+}
+
+if ($AllowOldPowerShellGetModule)
+{
+    $importModuleParameters.Remove('MinimumVersion')
+}
+
+$powerShellGetModule = Import-Module @importModuleParameters
 
 # Install the package provider if it is not available.
-$nuGetProvider = Get-PackageProvider -Name 'NuGet' -ListAvailable | Select-Object -First 1
+$nuGetProvider = Get-PackageProvider -Name 'NuGet' -ListAvailable -ErrorAction 'SilentlyContinue' |
+    Select-Object -First 1
 
 if (-not $powerShellGetModule -and -not $nuGetProvider)
 {
     $providerBootstrapParameters = @{
-        Name           = 'nuget'
+        Name           = 'NuGet'
         Force          = $true
         ForceBootstrap = $true
         ErrorAction    = 'Stop'
+        Scope          = $Scope
     }
 
     switch ($PSBoundParameters.Keys)
@@ -198,26 +211,15 @@ if (-not $powerShellGetModule -and -not $nuGetProvider)
             $providerBootstrapParameters.Add('ProxyCredential', $ProxyCredential)
         }
 
-        'Scope'
-        {
-            $providerBootstrapParameters.Add('Scope', $Scope)
-        }
-
         'AllowPrerelease'
         {
             $providerBootstrapParameters.Add('AllowPrerelease', $AllowPrerelease)
         }
     }
 
-    if ($AllowPrerelease)
-    {
-        $providerBootstrapParameters.Add('AllowPrerelease', $true)
-    }
-
     Write-Information -MessageData 'Bootstrap: Installing NuGet Package Provider from the web (Make sure Microsoft addresses/ranges are allowed).'
 
-    # TODO: This does not handle a private Gallery yet.
-    $null = Install-PackageProvider @providerBootstrapParams
+    $null = Install-PackageProvider @providerBootstrapParameters
 
     $nuGetProvider = Get-PackageProvider -Name 'NuGet' -ListAvailable | Select-Object -First 1
 
@@ -285,47 +287,82 @@ try
     # Versions below 2.0 are considered old, unreliable & not recommended
     if (-not $powerShellGetVersion -or ($powerShellGetVersion -lt [System.Version] '2.0' -and -not $AllowOldPowerShellGetModule))
     {
-        Write-Progress -Activity 'Bootstrap:' -PercentComplete 40 -CurrentOperation 'Installing newer version of PowerShellGet'
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 40 -CurrentOperation 'Fetching newer version of PowerShellGet'
 
-        $installPowerShellGetParameters = @{
-            Name               = 'PowerShellGet'
-            Force              = $True
-            SkipPublisherCheck = $true
-            AllowClobber       = $true
-            Scope              = $Scope
-            Repository         = $Gallery
-        }
-
-        switch ($PSBoundParameters.Keys)
+        # PowerShellGet module not found, installing or saving it.
+        if ($PSDependTarget -in 'CurrentUser', 'AllUsers')
         {
-            'Proxy'
-            {
-                $installPowerShellGetParameters.Add('Proxy', $Proxy)
+            Write-Debug -Message "PowerShellGet module not found. Attempting to install from Gallery $Gallery."
+
+            Write-Warning -Message "Installing PowerShellGet in $PSDependTarget Scope."
+
+            $installPowerShellGetParameters = @{
+                Name               = 'PowerShellGet'
+                Force              = $true
+                SkipPublisherCheck = $true
+                AllowClobber       = $true
+                Scope              = $Scope
+                Repository         = $Gallery
             }
 
-            'ProxyCredential'
+            switch ($PSBoundParameters.Keys)
             {
-                $installPowerShellGetParameters.Add('ProxyCredential', $ProxyCredential)
+                'Proxy'
+                {
+                    $installPowerShellGetParameters.Add('Proxy', $Proxy)
+                }
+
+                'ProxyCredential'
+                {
+                    $installPowerShellGetParameters.Add('ProxyCredential', $ProxyCredential)
+                }
+
+                'GalleryCredential'
+                {
+                    $installPowerShellGetParameters.Add('Credential', $GalleryCredential)
+                }
             }
 
-            'GalleryCredential'
-            {
-                $installPowerShellGetParameters.Add('Credential', $GalleryCredential)
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation 'Installing newer version of PowerShellGet'
+
+            Install-Module @installPowerShellGetParameters
+        }
+        else
+        {
+            Write-Debug -Message "PowerShellGet module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
+
+            $saveModuleParameters = @{
+                Name           = 'PowerShellGet'
+                MaximumVersion = '2.99.99'
+                Repository     = $Gallery
+                Path           = $PSDependTarget
+                Force          = $true
             }
-            'AllowPrerelease'
-            {
-                $installPowerShellGetParameters.Add('AllowPrerelease', $AllowPrerelease)
-            }
+
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation "Saving PowerShellGet from $Gallery to $Scope"
+
+            Save-Module @saveModuleParameters
         }
 
-        Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation 'Installing newer version of PowerShellGet'
+        Write-Debug -Message 'Removing previous versions of PowerShellGet and PackageManagement from session'
 
-        Install-Module @installPowerShellGetParameters
+        Get-Module -Name 'PowerShellGet' -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
+        Get-Module -Name 'PackageManagement' -All | Remove-Module -Force
 
-        Remove-Module -Name 'PowerShellGet' -Force -ErrorAction 'SilentlyContinue'
-        Remove-Module -Name 'PackageManagement' -Force
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 65 -CurrentOperation 'Loading latest version of PowerShellGet'
 
-        $powerShellGetModule = Import-Module PowerShellGet -Force -PassThru
+        Write-Debug -Message 'Importing latest PowerShellGet and PackageManagement versions into session'
+
+        if ($AllowOldPowerShellGetModule)
+        {
+            $powerShellGetModule = Import-Module -Name 'PowerShellGet' -Force -PassThru
+        }
+        else
+        {
+            Import-Module -Name 'PackageManagement' -MinimumVersion '1.4.8.1' -Force
+
+            $powerShellGetModule = Import-Module -Name 'PowerShellGet' -MinimumVersion '2.2.5' -Force -PassThru
+        }
 
         $powerShellGetVersion = $powerShellGetModule.Version.ToString()
 
@@ -395,7 +432,7 @@ try
                 $saveModuleParameters.add('MinimumVersion', $MinimumPSDependVersion)
             }
 
-            Write-Progress -Activity 'Bootstrap:' -PercentComplete 75 -CurrentOperation "Saving & Importing PSDepend from $Gallery to $Scope"
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 75 -CurrentOperation "Saving PSDepend from $Gallery to $Scope"
 
             Save-Module @saveModuleParameters
         }
@@ -438,13 +475,17 @@ try
         }
         else
         {
-            Write-Verbose "PowerShell-Yaml is already available"
+            Write-Verbose -Message 'PowerShell-Yaml is already available'
         }
+
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 88 -CurrentOperation 'Importing PowerShell module PowerShell-Yaml'
+
+        Import-Module -Name 'PowerShell-Yaml' -ErrorAction 'Stop'
     }
 
     Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoke PSDepend'
 
-    Write-Progress -Activity "PSDepend:" -PercentComplete 0 -CurrentOperation "Restoring Build Dependencies"
+    Write-Progress -Activity 'PSDepend:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
 
     if (Test-Path -Path $DependencyFile)
     {
@@ -457,9 +498,9 @@ try
         Invoke-PSDepend @psDependParameters
     }
 
-    Write-Progress -Activity "PSDepend:" -PercentComplete 100 -CurrentOperation "Dependencies restored" -Completed
+    Write-Progress -Activity 'PSDepend:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
 
-    Write-Progress -Activity 'Bootstrap:' -PercentComplete 100 -CurrentOperation "Bootstrap complete" -Completed
+    Write-Progress -Activity 'Bootstrap:' -PercentComplete 100 -CurrentOperation 'Bootstrap complete' -Completed
 }
 finally
 {
@@ -474,7 +515,7 @@ finally
         Write-Verbose -Message "Reverting private package repository '$Gallery' to previous location URI:s."
 
         $registerPSRepositoryParameters = @{
-            Name = $previousRegisteredRepository.Name
+            Name               = $previousRegisteredRepository.Name
             InstallationPolicy = $previousRegisteredRepository.InstallationPolicy
         }
 
@@ -511,5 +552,5 @@ finally
         }
     }
 
-    Write-Verbose -Message "Project Bootstrapped, returning to Invoke-Build"
+    Write-Verbose -Message 'Project Bootstrapped, returning to Invoke-Build.'
 }

--- a/Sampler/suffix.ps1
+++ b/Sampler/suffix.ps1
@@ -7,4 +7,6 @@ Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'tasks\*') -Includ
         Set-Alias -Name $taskFileAliasName -Value $_.FullName
     }
 
-Set-Alias -Name 'Set-SamplerTaskVariable' -Value "$PSScriptRoot/scripts/Set-SamplerTaskVariable.ps1"
+$SetSamplerTaskVariableAliasName = 'Set-SamplerTaskVariable'
+$SetSamplerTaskVariableAliasValue = "$PSScriptRoot/scripts/Set-SamplerTaskVariable.ps1"
+Set-Alias -Name $SetSamplerTaskVariableAliasName -Value $SetSamplerTaskVariableAliasValue


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Changed

- Pipeline script for resolving dependencies improved.
  - Evaluating PowerShellGet version now supports parameter `AllowOldPowerShellGetModule`
    (still not recommended to use this parameter).
  - Now defaults to save the modules PowerShellGet and PackageManagement
    to the folder `output/RequiredModules` (same logic as for module PSDepend)
    to not make permanent changes to the contributors machine. If parameter
    `PSDependTarget` is either set to `CurrentUser` or `AllUsers` the modules
    are installed.
- Updated text in the CONTRIBUTING.md to help contributors more easily find
  a guide where to start.

### Fixed

- Pipeline script for resolving dependencies improved.
  - `Get-PackageProvider` no longer throws an exception when NuGet provider
    is missing (in Windows PowerShell in a clean Windows install).
  - `Install-PackageProvider` now defaults to installing in the current
    user scope to avoid requiring an elevated prompt. This is the only
    change that is permanent on the contributors machine. It is not possible
    to avoid this as long at the module PowerShellGet requires the NuGet
    package provider.
  - Remove duplicate code that set `AllowPrerelease` when installing package
    provider.
  - Fixed wrong splatting variable that prevented `Install-PackageProvider`
    to run.
  - Removing all existing PowerShellGet and PackageManagement module that
    is loaded into the session to load the newly saved or installed.
  - Handle parameter `AllowOldPowerShellGetModule` when loading PowerShellGet
    module version.
  - Fix message on `Write-Progress` statement.
  - Small style cleanups.
 
## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [ ] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/419)
<!-- Reviewable:end -->
