### PR TITLE
feat: Add support for publishing NuGet package with .NET SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Task `publish_nupkg_to_gallery`
+  - Add support for publishing a NuGet package to a gallery using the .NET SDK in addition to using nuget.exe. Fixes [#433](https://github.com/gaelcolas/Sampler/issues/433)
+
 ### Fixed
 
 - Fix unit tests that was wrongly written and failed on Pester 5.5.
@@ -117,7 +122,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Script `Set-SamplerTaskVariable.ps1`
   - Added debug output of PSModulePath
-
 
 ## [0.116.1] - 2023-01-09
 

--- a/tests/Unit/tasks/release.module.build.Tests.ps1
+++ b/tests/Unit/tasks/release.module.build.Tests.ps1
@@ -280,6 +280,37 @@ Describe 'publish_nupkg_to_gallery' {
             Should -Invoke -CommandName nuget -Exactly -Times 1 -Scope It
         }
     }
+
+    Context 'When publish Nuget package with .NET SDK' {
+        BeforeAll {
+            # Stub for executable dotnet
+            function dotnet {}
+
+            Mock -CommandName dotnet -MockWith {
+                return '0'
+            }
+
+            Mock -CommandName Get-Command -ParameterFilter {
+                $Name -eq 'nuget' -and  $ErrorAction -eq 'SilentlyContinue'
+            } -MockWith {
+                $null
+            }
+
+            Mock -CommandName Get-ChildItem -ParameterFilter {
+                $Path -match '\.nupkg'
+            } -MockWith {
+                return $TestDrive
+            }
+        }
+
+        It 'Should run the build task without throwing' {
+            {
+                Invoke-Build -Task 'publish_nupkg_to_gallery' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Invoke -CommandName dotnet -Exactly -Times 1 -Scope It
+        }
+    }
 }
 
 Describe 'package_module_nupkg' {


### PR DESCRIPTION
# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Prepend the title with the [BREAKING CHANGE] if relevant,
    i.e. [BREAKING CHANGE] Add security descriptor property

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.
-->

## Pull Request (PR) description

Adds support for publishing a NuGet package with the .NET SDK, if installed.

Fixes [433](https://github.com/gaelcolas/Sampler/issues/433).

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/434)
<!-- Reviewable:end -->
