### PR TITLE
Support for PSResourceGet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Using ModuleFast will resolve dependencies much faster, but requires
   PowerShell 7.2.
 - Support for [PSResourceGet (beta release)](https://github.com/PowerShell/PSResourceGet).
-  If the modules PSResourceGet and PowerShellGet v2.9.0 (previous _CompatPowerShellGet_)
-  can be bootstrapped they will be used. If PSResourceGet cannot be
-  bootstrapped then it will revert to using PowerShellGet v2.2.5. If the
-  user requests or configures to use ModuleFast then that will override
-  both PSResourceGet and PowerShellGet. It is also possible to use
-  PSResourceGet by adding the parameter `UsePSResourceGet` to the `build.ps1`,
-  e.g. `./build.ps1 -Tasks noop -ResolveDependency -UseModuleFast`.
+  If the modules PSResourceGet can be bootstrapped they will be used. If
+  PSResourceGet cannot be bootstrapped then it will revert to using
+  PowerShellGet v2.2.5. If the user requests or configures to use ModuleFast
+  then that will override both PSResourceGet and PowerShellGet. The method
+  PSResourceGet can be enabled in the configuration file Resolve-Dependency.psd1.
+  It is also possible to use PSResourceGet by adding the parameter `UsePSResourceGet`
+  to the `build.ps1`, e.g. `./build.ps1 -Tasks noop -ResolveDependency -UsePSResourceGet`.
+- When using PSResourceGet to resolve dependencies it also possible to
+  use PowerShellGet v2.9.0 (previous _CompatPowerShellGet_). To use the
+  compatibility module it can be enabled in the configuration file Resolve-Dependency.psd1.
+  It is also possible to use it by adding the parameter `UsePowerShellGetCompatibilityModule`
+  to the `build.ps1`, e.g. `./build.ps1 -Tasks noop -ResolveDependency -UsePSResourceGet -UsePowerShellGetCompatibilityModule`.
+  _The 2.9.0-preview has since then been unlisted, the compatibility_
+  _module will now be released as PowerShellGet v3.0.0._
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sample Private function tests updated to Pester 5.
 - Sample Public function tests updated to Pester 5.
 - Sampler's build.ps1 and the template build.ps1 was aligned.
-- Split up unit tests and integration tests in separate pipeline jobs since
-  integration tests could change state on a developers machine, and in the
-  current PowerShell session. Integration tests no longer run when running
-  `./build.ps1 -Tasks test`. To run integration tests pass the parameter
-  `PesterPath`, e.g. `./build.ps1 -Tasks test -PesterPath 'tests/Integration'`.
 - PowerShell Team will release the PSResourceGet compatibility module
   (previously known as CompatPowerShellGet) as PowerShellGet v2.9.0 (or
   higher). The resolve dependency script, when PowerShellGet is used, will

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sample Private function tests updated to Pester 5.
 - Sample Public function tests updated to Pester 5.
 - Sampler's build.ps1 and the template build.ps1 was aligned.
+- Split up unit tests and integration tests in separate pipeline jobs since
+  integration tests could change state on a developers machine, and in the
+  current PowerShell session. Integration tests no longer run when running
+  `./build.ps1 -Tasks test`. To run integration tests pass the parameter
+  `PesterPath`, e.g. `./build.ps1 -Tasks test -PesterPath 'tests/Integration'`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   higher). The resolve dependency script, when PowerShellGet is used, will
   use `MaximumVersion` set to `2.8.999` to make sure the expected
   PowerShellGet version is installed, today that it is v2.2.5.
+  _The 2.9.0-preview has since then been unlisted, the compatibility_
+  _module will now be released as PowerShellGet v3.0.0._
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or by enabling it in the configuration file Resolve-Dependency.psd1.
   Using ModuleFast will resolve dependencies much faster, but requires
   PowerShell 7.2.
+- Support for [PSResourceGet (beta release)](https://github.com/PowerShell/PSResourceGet).
+  If the modules PSResourceGet and CompatPowerShellGet can be bootstrapped
+  they will be used. If PSResourceGet cannot be bootstrapped then it will
+  revert to using PowerShellGet. If user requests or configures to use
+  ModuleFast then that will override PSResourceGet and PowerShellGet.
+  It is also possible to use PSResourceGet by adding the parameter
+  `UsePSResourceGet` to the `build.ps1`, e.g.
+  `./build.ps1 -Tasks noop -ResolveDependency -UseModuleFast`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Using ModuleFast will resolve dependencies much faster, but requires
   PowerShell 7.2.
 - Support for [PSResourceGet (beta release)](https://github.com/PowerShell/PSResourceGet).
-  If the modules PSResourceGet and CompatPowerShellGet can be bootstrapped
-  they will be used. If PSResourceGet cannot be bootstrapped then it will
-  revert to using PowerShellGet. If user requests or configures to use
-  ModuleFast then that will override PSResourceGet and PowerShellGet.
-  It is also possible to use PSResourceGet by adding the parameter
-  `UsePSResourceGet` to the `build.ps1`, e.g.
-  `./build.ps1 -Tasks noop -ResolveDependency -UseModuleFast`.
+  If the modules PSResourceGet and PowerShellGet v2.9.0 (previous _CompatPowerShellGet_)
+  can be bootstrapped they will be used. If PSResourceGet cannot be
+  bootstrapped then it will revert to using PowerShellGet v2.2.5. If the
+  user requests or configures to use ModuleFast then that will override
+  both PSResourceGet and PowerShellGet. It is also possible to use
+  PSResourceGet by adding the parameter `UsePSResourceGet` to the `build.ps1`,
+  e.g. `./build.ps1 -Tasks noop -ResolveDependency -UseModuleFast`.
 
 ### Changed
 
@@ -45,6 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   current PowerShell session. Integration tests no longer run when running
   `./build.ps1 -Tasks test`. To run integration tests pass the parameter
   `PesterPath`, e.g. `./build.ps1 -Tasks test -PesterPath 'tests/Integration'`.
+- PowerShell Team will release the PSResourceGet compatibility module
+  (previously known as CompatPowerShellGet) as PowerShellGet v2.9.0 (or
+  higher). The resolve dependency script, when PowerShellGet is used, will
+  use `MaximumVersion` set to `2.8.999` to make sure the expected
+  PowerShellGet version is installed, today that it is v2.2.5.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ Check the video for a quick intro:
 Because we resolve dependencies from a nuget feed, whether the public
 PowerShellGallery or your private repository, a working version of PowerShellGet
 is required. Using PowerShellGet is the default if no other configuration
-is done. We recommend the latest version of PowerShellGet v2. PSResourceGet
-v3 will be supported when it is released.
+is done. We recommend the latest version of PowerShellGet v2.
 
 #### ModuleFast
 
@@ -54,6 +53,17 @@ It is also possible to allow the repository to use PowerShellGet as the
 default and choose to use ModuleFast from the command line by passing
 the parameter `UseModuleFast` to the build script `build.ps1`, e.g.
 `.\build.ps1 -ResolveDependency -Tasks noop -UseModuleFast`
+
+#### PSResourceGet
+
+It is possible to use [PSResourceGet](https://github.com/PowerShell/PSResourceGet)
+to resolve dependencies. PSResourceGet works with WIndows PowerShell and
+PowerShell (some restrictions on versions exist). To use PSResourceGet as
+a replacement for PowerShellGet it is possible to enable it in the configuration
+file `Resolve-Dependency.psd1`. It is also possible to allow the repository
+to use PowerShellGet as the default and choose to use PSResourceGet from the
+command line by passing the parameter `UsePSResourceGet` to the build script
+`build.ps1`, e.g. `.\build.ps1 -ResolveDependency -Tasks noop -UseModuleFast`
 
 ### Managing the Module versions (optional)
 
@@ -220,6 +230,11 @@ the build process so that anyone doing a git clone can 're-hydrate' the
 project and start testing and producing the build artefact locally with
 minimal environmental dependencies.
 
+>[!NOTE]
+>Try to avoid mixing these different methods in the same session. When
+>switching to use a different method, open a new PowerShell session so
+>none of the modules dependencies are loaded into the session.
+
 The following command will resolve dependencies using PowerShellGet:
 
 ```powershell
@@ -234,6 +249,14 @@ The following command will resolve dependencies using [ModuleFast](https://githu
 cd C:\source\MySimpleModule
 
 ./build.ps1 -ResolveDependency -Tasks noop -UseModuleFast
+```
+
+The following command will resolve dependencies using [PSResourceGet](https://github.com/PowerShell/PSResourceGet):
+
+```powershell
+cd C:\source\MySimpleModule
+
+./build.ps1 -ResolveDependency -Tasks noop -UsePSResourceGet
 ```
 
 The dependencies will be downloaded (or updated) from the PowerShell Gallery (unless

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check the video for a quick intro:
 
 > _Note: The video was made when Sampler was in early stages. Since that time_
 > _there have been a lot of improvements and changes, so please read the_
-> _ documentation below._
+> _documentation below._
 
 [![Sampler demo video](https://img.youtube.com/vi/bbpFBsl8K9k/0.jpg)](https://www.youtube.com/watch?v=bbpFBsl8K9k&ab_channel=DSCCommunity)
 
@@ -234,6 +234,22 @@ minimal environmental dependencies.
 >Try to avoid mixing these different methods in the same session. When
 >switching to use a different method, open a new PowerShell session so
 >none of the modules dependencies are loaded into the session.
+
+```mermaid
+graph LR
+
+RD[Resolve dependencies] --> Method{Method?}
+Method{Method?} -->|"(Default)"| PowerShellGet(["PowerShellGet"])
+Method -->|"parameter
+-UseModuleFast"| ModuleFast(["ModuleFast"])
+Method -->|"parameter
+-UsePSResourceGet"| PSResourceGet(["PSResourceGet"])
+PowerShellGet -->|"Invoke-PSDepend"| InvokeRD
+ModuleFast -->|"Install-ModuleFast"| InvokeRD
+PSResourceGet -->|"Save-PSResource"| InvokeRD
+InvokeRD[Use preferred method]  <--> PSGallery["PowerShell Gallery"]
+InvokeRD ---> Save[["Save to RequiredModules"]]
+```
 
 The following command will resolve dependencies using PowerShellGet:
 
@@ -627,7 +643,6 @@ _Guest Configuration_. This process will be replaced with a Plaster template.
    ```
 
 1. Now resolve dependencies and run the task `gcpack`:
-
    ```powershell
    build.ps1 -task gcpack -ResolveDependency
    ```
@@ -1343,6 +1358,7 @@ running tests.
 > **Note:** Running the command `Get-Help -Name 'Set-SamplerTaskVariable'` will
 > only return help for the alias. To see the comment-based help for the script,
 > run:
+>
 > ```powershell
 > Import-Module -Name Sampler
 >

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -227,14 +227,13 @@ if ($UseModuleFast)
 
 if ($UsePSResourceGet)
 {
-    # Check if it is already imported (then we can't download it again because of locked files)
-    if ((Get-Module -Name 'Microsoft.PowerShell.PSResourceGet'))
+    if ((Get-Module -Name 'Microsoft.PowerShell.PSResourceGet' -ListAvailable))
     {
-        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet already exist in the session.'
+        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet already exist, skip saving to RequiredModules.'
     }
     else
     {
-        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet not in session, save the module to RequiredModules.'
+        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet do not exist, save the module to RequiredModules.'
 
         $psResourceGetDownloaded = $false
 

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -339,9 +339,9 @@ if ($UsePSResourceGet)
             }
 
             Save-PSResource @savePowerShellGetParameters
-        }
 
-        Import-Module -Name "$PSDependTarget/PowerShellGet"
+            Import-Module -Name "$PSDependTarget/PowerShellGet"
+        }
     }
 }
 

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -322,20 +322,24 @@ if ($UsePSResourceGet)
 
         Write-Information -MessageData ('Using {0} v{1}.' -f $psResourceGetModuleName, $psResourceGetModuleVersion) -InformationAction 'Continue'
 
-        if ($UsePowerShellGetCompatibilityModuleVersion)
+        if ($UsePowerShellGetCompatibilityModule)
         {
             $savePowerShellGetParameters = @{
                 Name            = 'PowerShellGet'
-                Version         = $UsePowerShellGetCompatibilityModuleVersion
                 Path            = $PSDependTarget
                 Repository      = 'PSGallery'
                 TrustRepository = $true
             }
 
-            # Check if the version is a prerelease.
-            if ($UsePowerShellGetCompatibilityModuleVersion -match '\d+\.\d+\.\d+-.*')
+            if ($UsePowerShellGetCompatibilityModuleVersion)
             {
-                $savePowerShellGetParameters.Prerelease = $true
+                $savePowerShellGetParameters.Version = $UsePowerShellGetCompatibilityModuleVersion
+
+                # Check if the version is a prerelease.
+                if ($UsePowerShellGetCompatibilityModuleVersion -match '\d+\.\d+\.\d+-.*')
+                {
+                    $savePowerShellGetParameters.Prerelease = $true
+                }
             }
 
             Save-PSResource @savePowerShellGetParameters

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -304,7 +304,7 @@ if ($UsePSResourceGet)
 
             Import-Module -Name $expandArchiveParameters.DestinationPath -Force
 
-            # Successfully bootstrapped PSResourceGet and CompatPowerShellGet, so let's use it.
+            # Successfully bootstrapped PSResourceGet, so let's use it.
             $UsePSResourceGet = $true
         }
     }
@@ -323,7 +323,9 @@ if ($UsePSResourceGet)
         Write-Information -MessageData ('Using {0} v{1}.' -f $psResourceGetModuleName, $psResourceGetModuleVersion) -InformationAction 'Continue'
 
         $savePSResourceParameters = @{
-            Name            = 'CompatPowerShellGet' #cSpell: ignore compat
+            Name            = 'PowerShellGet'
+            Version         = '2.9.0-preview'
+            Prerelease      = $true
             Path            = $PSDependTarget
             Repository      = 'PSGallery'
             TrustRepository = $true
@@ -331,7 +333,7 @@ if ($UsePSResourceGet)
 
         Save-PSResource @savePSResourceParameters
 
-        Import-Module -Name "$PSDependTarget/CompatPowerShellGet"
+        Import-Module -Name "$PSDependTarget/PowerShellGet"
     }
 }
 
@@ -356,6 +358,7 @@ if (-not ($UseModuleFast -or $UsePSResourceGet))
     $importModuleParameters = @{
         Name           = 'PowerShellGet'
         MinimumVersion = '2.0'
+        MaximumVersion = '2.8.999'
         ErrorAction    = 'SilentlyContinue'
         PassThru       = $true
     }
@@ -488,6 +491,7 @@ try
                     AllowClobber       = $true
                     Scope              = $Scope
                     Repository         = $Gallery
+                    MaximumVersion     = '2.8.999'
                 }
 
                 switch ($PSBoundParameters.Keys)
@@ -517,10 +521,11 @@ try
                 Write-Debug -Message "PowerShellGet module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
 
                 $saveModuleParameters = @{
-                    Name       = 'PowerShellGet'
-                    Repository = $Gallery
-                    Path       = $PSDependTarget
-                    Force      = $true
+                    Name           = 'PowerShellGet'
+                    Repository     = $Gallery
+                    Path           = $PSDependTarget
+                    Force          = $true
+                    MaximumVersion = '2.8.999'
                 }
 
                 Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation "Saving PowerShellGet from $Gallery to $Scope"

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -292,7 +292,14 @@ if ($UsePSResourceGet)
 
             $psResourceGetModule = Import-Module -Name $expandArchiveParameters.DestinationPath -Force -PassThru
 
-            Write-Information -MessageData ('Using Microsoft.PowerShell.PSResourceGet v{0}-{1}' -f $psResourceGetModule.Version.ToString(),$psResourceGetModule.PrivateData.PSData.Prerelease) -InformationAction 'Continue'
+            $psResourceGetModuleVersion = $psResourceGetModule.Version.ToString()
+
+            if ($psResourceGetModule.PrivateData.PSData.Prerelease)
+            {
+                $psResourceGetModuleVersion += '-{0}' -f $psResourceGetModule.PrivateData.PSData.Prerelease
+            }
+
+            Write-Information -MessageData ('Using Microsoft.PowerShell.PSResourceGet v{0}.' -f $psResourceGetModuleVersion) -InformationAction 'Continue'
 
             # Successfully bootstrapped PSResourceGet and CompatPowerShellGet, so let's use it.
             $UsePSResourceGet = $true

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -227,9 +227,10 @@ if ($UseModuleFast)
 
 if ($UsePSResourceGet)
 {
-    if ((Get-Module -Name 'Microsoft.PowerShell.PSResourceGet' -ListAvailable))
+    # If PSResourceGet was used prior it will be locked and we can't replace it.
+    if ((Test-Path -Path "$PSDependTarget/Microsoft.PowerShell.PSResourceGet" -PathType 'Container') -and (Get-Module -Name 'Microsoft.PowerShell.PSResourceGet'))
     {
-        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet already exist, skip saving to RequiredModules.'
+        Write-Information -MessageData 'Microsoft.PowerShell.PSResourceGet is already save and loaded into the session, skip saving to RequiredModules. To refresh the module open a new session and resolve dependencies again.' -InformationAction 'Continue'
     }
     else
     {

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -200,6 +200,66 @@ if ($UseModuleFast)
 
 if (-not $UseModuleFast)
 {
+    $psResourceGetDownloaded = $false
+
+    try
+    {
+        $invokeWebRequestParameters = @{
+            # TODO: This should be hardcoded to a stable release in the future.
+            Uri         = 'https://www.powershellgallery.com/api/v2/package/Microsoft.PowerShell.PSResourceGet/0.5.24-beta24'
+            OutFile     = "$PSDependTarget/Microsoft.PowerShell.PSResourceGet.nupkg" # cSpell: ignore nupkg
+            ErrorAction = 'Stop'
+        }
+
+        $previousProgressPreference = $ProgressPreference
+        $ProgressPreference = 'SilentlyContinue'
+
+        # Bootstrapping Microsoft.PowerShell.PSResourceGet.
+        Invoke-WebRequest @invokeWebRequestParameters
+
+        $ProgressPreference = $previousProgressPreference
+
+        $psResourceGetDownloaded = $true
+    }
+    catch
+    {
+        Write-Warning -Message ('PSResourceGet could not be bootstrapped. Reverting to PowerShellGet. Error: {0}' -f $_.Exception.Message)
+    }
+
+    $usePSResourceGet = $false
+
+    if ($psResourceGetDownloaded)
+    {
+        $expandArchiveParameters = @{
+            Path            = $invokeWebRequestParameters.OutFile
+            DestinationPath = "$PSDependTarget/Microsoft.PowerShell.PSResourceGet"
+            Force           = $true
+        }
+
+        Expand-Archive @expandArchiveParameters
+
+        Remove-Item -Path $invokeWebRequestParameters.OutFile
+
+        Import-Module -Name $expandArchiveParameters.DestinationPath -Force
+
+        $savePSResourceParameters = @{
+            Name            = 'CompatPowerShellGet' #cSpell: ignore compat
+            Path            = $PSDependTarget
+            Repository      = 'PSGallery'
+            TrustRepository = $true
+        }
+
+        Save-PSResource @savePSResourceParameters
+
+        Import-Module -Name "$PSDependTarget/CompatPowerShellGet"
+
+        # Successfully bootstrapped PSResourceGet and CompatPowerShellGet, so let's use it.
+        $usePSResourceGet = $true
+    }
+}
+
+if (-not ($UseModuleFast.IsPresent -or $usePSResourceGet))
+{
     if ($PSVersionTable.PSVersion.Major -le 5)
     {
         <#
@@ -308,13 +368,16 @@ if (-not $UseModuleFast)
             Register-PSRepository @RegisterGallery
         }
     }
+}
 
+if (-not $UseModuleFast.IsPresent)
+{
     Write-Progress -Activity 'Bootstrap:' -PercentComplete 10 -CurrentOperation "Ensuring Gallery $Gallery is trusted"
 
     # Fail if the given PSGallery is not registered.
-    $previousGalleryInstallationPolicy = (Get-PSRepository -Name $Gallery -ErrorAction 'Stop').InstallationPolicy
+    $previousGalleryInstallationPolicy = (Get-PSRepository -Name $Gallery -ErrorAction 'Stop').Trusted
 
-    if ($previousGalleryInstallationPolicy -ne 'Trusted')
+    if ($previousGalleryInstallationPolicy -ne $true)
     {
         # Only change policy if the repository is not trusted
         Set-PSRepository -Name $Gallery -InstallationPolicy 'Trusted' -ErrorAction 'Ignore'
@@ -323,7 +386,7 @@ if (-not $UseModuleFast)
 
 try
 {
-    if (-not $UseModuleFast)
+    if (-not ($UseModuleFast -or $usePSResourceGet))
     {
         Write-Progress -Activity 'Bootstrap:' -PercentComplete 25 -CurrentOperation 'Checking PowerShellGet'
 
@@ -535,12 +598,8 @@ try
 
     if (Test-Path -Path $DependencyFile)
     {
-        if ($UseModuleFast)
+        if ($UseModuleFast -or $usePSResourceGet)
         {
-            Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking ModuleFast'
-
-            Write-Progress -Activity 'ModuleFast:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
-
             $requiredModules = Import-PowerShellDataFile -Path $DependencyFile
 
             $requiredModules = $requiredModules.GetEnumerator() |
@@ -570,30 +629,74 @@ try
                 $modulesToSave += 'PowerShell-Yaml'
             }
 
-            $moduleFastPlan = $modulesToSave | Get-ModuleFastPlan
-
-            if ($moduleFastPlan)
+            if ($UseModuleFast.IsPresent)
             {
-                # Clear all modules in plan from the current session so they can be fetched again.
-                $moduleFastPlan.Name | Get-Module | Remove-Module -Force
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking ModuleFast'
 
-                $installModuleFastParameters = @{
-                    ModulesToInstall     = $moduleFastPlan
-                    Destination          = $PSDependTarget
-                    NoPSModulePathUpdate = $true
-                    NoProfileUpdate      = $true
-                    Update               = $true
-                    Confirm              = $false
+                Write-Progress -Activity 'ModuleFast:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
+
+                $moduleFastPlan = $modulesToSave | Get-ModuleFastPlan
+
+                if ($moduleFastPlan)
+                {
+                    # Clear all modules in plan from the current session so they can be fetched again.
+                    $moduleFastPlan.Name | Get-Module | Remove-Module -Force
+
+                    $installModuleFastParameters = @{
+                        ModulesToInstall     = $moduleFastPlan
+                        Destination          = $PSDependTarget
+                        NoPSModulePathUpdate = $true
+                        NoProfileUpdate      = $true
+                        Update               = $true
+                        Confirm              = $false
+                    }
+
+                    Install-ModuleFast @installModuleFastParameters
+                }
+                else
+                {
+                    Write-Verbose -Message 'All modules were already up to date'
                 }
 
-                Install-ModuleFast @installModuleFastParameters
-            }
-            else
-            {
-                Write-Verbose -Message 'All modules were already up to date'
+                Write-Progress -Activity 'ModuleFast:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
             }
 
-            Write-Progress -Activity 'ModuleFast:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
+            if ($usePSResourceGet)
+            {
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking PSResourceGet'
+
+                $progressPercentage = 0
+
+                Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies'
+
+                $percentagePerModule = [Math]::Floor(100 / $modulesToSave.Length)
+
+                foreach ($currentModule in $modulesToSave)
+                {
+                    Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies' -Status ('Installing module {0}' -f $savePSResourceParameters.Name)
+
+                    $savePSResourceParameters = @{
+                        Path    = $PSDependTarget
+                        Confirm = $false
+                    }
+
+                    if ($currentModule -is [System.Collections.Hashtable])
+                    {
+                        $savePSResourceParameters.Name = $currentModule.Name
+                        $savePSResourceParameters.Version = $currentModule.RequiredVersion
+                    }
+                    else
+                    {
+                        $savePSResourceParameters.Name = $currentModule
+                    }
+
+                    Save-PSResource @savePSResourceParameters
+
+                    $progressPercentage += $percentagePerModule
+                }
+
+                Write-Progress -Activity 'PSResourceGet:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
+            }
         }
         else
         {
@@ -658,10 +761,10 @@ finally
     # Only try to revert installation policy if the repository exist
     if ((Get-PSRepository -Name $Gallery -ErrorAction 'SilentlyContinue'))
     {
-        if ($previousGalleryInstallationPolicy -and $previousGalleryInstallationPolicy -ne 'Trusted')
+        if ($previousGalleryInstallationPolicy -ne $true)
         {
             # Reverting the Installation Policy for the given gallery if it was not already trusted
-            Set-PSRepository -Name $Gallery -InstallationPolicy $previousGalleryInstallationPolicy
+            Set-PSRepository -Name $Gallery -InstallationPolicy 'Untrusted'
         }
     }
 

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -290,7 +290,9 @@ if ($UsePSResourceGet)
 
             Remove-Item -Path $psResourceGetZipArchivePath
 
-            Import-Module -Name $expandArchiveParameters.DestinationPath -Force
+            $psResourceGetModule = Import-Module -Name $expandArchiveParameters.DestinationPath -Force -PassThru
+
+            Write-Information -MessageData ('Using Microsoft.PowerShell.PSResourceGet v{0}-{1}' -f $psResourceGetModule.Version.ToString(),$psResourceGetModule.PrivateData.PSData.Prerelease) -InformationAction 'Continue'
 
             # Successfully bootstrapped PSResourceGet and CompatPowerShellGet, so let's use it.
             $UsePSResourceGet = $true

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -166,7 +166,6 @@ catch
     Write-Warning -Message "Error attempting to import Bootstrap's default parameters from '$resolveDependencyConfigPath': $($_.Exception.Message)."
 }
 
-
 if ($UseModuleFast)
 {
     try

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -234,7 +234,7 @@ if ($UsePSResourceGet)
     }
     else
     {
-        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet no in session, save the module to RequiredModules.'
+        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet not in session, save the module to RequiredModules.'
 
         $psResourceGetDownloaded = $false
 
@@ -667,7 +667,7 @@ try
                 $modulesToSave += 'PowerShell-Yaml'
             }
 
-            if ($UseModuleFast.IsPresent)
+            if ($UseModuleFast)
             {
                 Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking ModuleFast'
 

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -322,16 +322,24 @@ if ($UsePSResourceGet)
 
         Write-Information -MessageData ('Using {0} v{1}.' -f $psResourceGetModuleName, $psResourceGetModuleVersion) -InformationAction 'Continue'
 
-        $savePSResourceParameters = @{
-            Name            = 'PowerShellGet'
-            Version         = '2.9.0-preview'
-            Prerelease      = $true
-            Path            = $PSDependTarget
-            Repository      = 'PSGallery'
-            TrustRepository = $true
-        }
+        if ($UsePowerShellGetCompatibilityModuleVersion)
+        {
+            $savePowerShellGetParameters = @{
+                Name            = 'PowerShellGet'
+                Version         = $UsePowerShellGetCompatibilityModuleVersion
+                Path            = $PSDependTarget
+                Repository      = 'PSGallery'
+                TrustRepository = $true
+            }
 
-        Save-PSResource @savePSResourceParameters
+            # Check if the version is a prerelease.
+            if ($UsePowerShellGetCompatibilityModuleVersion -match '\d+\.\d+\.\d+-.*')
+            {
+                $savePowerShellGetParameters.Prerelease = $true
+            }
+
+            Save-PSResource @savePowerShellGetParameters
+        }
 
         Import-Module -Name "$PSDependTarget/PowerShellGet"
     }

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -243,7 +243,7 @@ if ($UsePSResourceGet)
             $invokeWebRequestParameters = @{
                 # TODO: This should be hardcoded to a stable release in the future.
                 # TODO: Should support proxy parameters passed to the script.
-                Uri         = 'https://www.powershellgallery.com/api/v2/package/Microsoft.PowerShell.PSResourceGet/0.5.24-beta24'
+                Uri         = 'https://www.powershellgallery.com/api/v2/package/Microsoft.PowerShell.PSResourceGet/0.9.0-rc1'
                 OutFile     = "$PSDependTarget/Microsoft.PowerShell.PSResourceGet.nupkg" # cSpell: ignore nupkg
                 ErrorAction = 'Stop'
             }

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -45,5 +45,6 @@
     # will be used to resolve dependencies.
     #UsePSResourceGet = $true
     #PSResourceGetVersion = '1.0.0'
+    #UsePowerShellGetCompatibilityModule = $true
     #UsePowerShellGetCompatibilityModuleVersion = '3.0.22-beta22'
 }

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -39,4 +39,9 @@
     # If this is not configured or set to $false then PowerShellGet and PackageManagement
     # will be used to resolve dependencies.
     #UseModuleFast   = $true
+
+    # Enable PSResourceGet to resolve dependencies. Requires PowerShell 7.2 or higher.
+    # If this is not configured or set to $false then PowerShellGet and PackageManagement
+    # will be used to resolve dependencies.
+    #UsePSResourceGet = $true
 }

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -44,4 +44,5 @@
     # If this is not configured or set to $false then PowerShellGet and PackageManagement
     # will be used to resolve dependencies.
     #UsePSResourceGet = $true
+    #PSResourceGetVersion = '1.0.0'
 }

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -45,4 +45,5 @@
     # will be used to resolve dependencies.
     #UsePSResourceGet = $true
     #PSResourceGetVersion = '1.0.0'
+    #UsePowerShellGetCompatibilityModuleVersion = '3.0.22-beta22'
 }

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -339,9 +339,9 @@ if ($UsePSResourceGet)
             }
 
             Save-PSResource @savePowerShellGetParameters
-        }
 
-        Import-Module -Name "$PSDependTarget/PowerShellGet"
+            Import-Module -Name "$PSDependTarget/PowerShellGet"
+        }
     }
 }
 

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -322,20 +322,24 @@ if ($UsePSResourceGet)
 
         Write-Information -MessageData ('Using {0} v{1}.' -f $psResourceGetModuleName, $psResourceGetModuleVersion) -InformationAction 'Continue'
 
-        if ($UsePowerShellGetCompatibilityModuleVersion)
+        if ($UsePowerShellGetCompatibilityModule)
         {
             $savePowerShellGetParameters = @{
                 Name            = 'PowerShellGet'
-                Version         = $UsePowerShellGetCompatibilityModuleVersion
                 Path            = $PSDependTarget
                 Repository      = 'PSGallery'
                 TrustRepository = $true
             }
 
-            # Check if the version is a prerelease.
-            if ($UsePowerShellGetCompatibilityModuleVersion -match '\d+\.\d+\.\d+-.*')
+            if ($UsePowerShellGetCompatibilityModuleVersion)
             {
-                $savePowerShellGetParameters.Prerelease = $true
+                $savePowerShellGetParameters.Version = $UsePowerShellGetCompatibilityModuleVersion
+
+                # Check if the version is a prerelease.
+                if ($UsePowerShellGetCompatibilityModuleVersion -match '\d+\.\d+\.\d+-.*')
+                {
+                    $savePowerShellGetParameters.Prerelease = $true
+                }
             }
 
             Save-PSResource @savePowerShellGetParameters

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -227,9 +227,10 @@ if ($UseModuleFast)
 
 if ($UsePSResourceGet)
 {
-    if ((Get-Module -Name 'Microsoft.PowerShell.PSResourceGet' -ListAvailable))
+    # If PSResourceGet was used prior it will be locked and we can't replace it.
+    if ((Test-Path -Path "$PSDependTarget/Microsoft.PowerShell.PSResourceGet" -PathType 'Container') -and (Get-Module -Name 'Microsoft.PowerShell.PSResourceGet'))
     {
-        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet already exist, skip saving to RequiredModules.'
+        Write-Information -MessageData 'Microsoft.PowerShell.PSResourceGet is already save and loaded into the session, skip saving to RequiredModules. To refresh the module open a new session and resolve dependencies again.' -InformationAction 'Continue'
     }
     else
     {

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -198,7 +198,7 @@ if ($UseModuleFast)
     try
     {
         $invokeWebRequestParameters = @{
-            Uri = 'bit.ly/modulefast' # cSpell: disable-line
+            Uri         = 'bit.ly/modulefast' # cSpell: disable-line
             ErrorAction = 'Stop'
         }
 
@@ -227,49 +227,65 @@ if ($UseModuleFast)
 
 if ($UsePSResourceGet)
 {
-    $psResourceGetDownloaded = $false
-
-    try
+    # Check if it is already imported (then we can't download it again because of locked files)
+    if ((Get-Module -Name 'Microsoft.PowerShell.PSResourceGet'))
     {
-        $invokeWebRequestParameters = @{
-            # TODO: This should be hardcoded to a stable release in the future.
-            # TODO: Should support proxy parameters passed to the script.
-            Uri         = 'https://www.powershellgallery.com/api/v2/package/Microsoft.PowerShell.PSResourceGet/0.5.24-beta24'
-            OutFile     = "$PSDependTarget/Microsoft.PowerShell.PSResourceGet.nupkg" # cSpell: ignore nupkg
-            ErrorAction = 'Stop'
+        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet already exist in the session.'
+    }
+    else
+    {
+        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet no in session, save the module to RequiredModules.'
+
+        $psResourceGetDownloaded = $false
+
+        try
+        {
+            $invokeWebRequestParameters = @{
+                # TODO: This should be hardcoded to a stable release in the future.
+                # TODO: Should support proxy parameters passed to the script.
+                Uri         = 'https://www.powershellgallery.com/api/v2/package/Microsoft.PowerShell.PSResourceGet/0.5.24-beta24'
+                OutFile     = "$PSDependTarget/Microsoft.PowerShell.PSResourceGet.nupkg" # cSpell: ignore nupkg
+                ErrorAction = 'Stop'
+            }
+
+            $previousProgressPreference = $ProgressPreference
+            $ProgressPreference = 'SilentlyContinue'
+
+            # Bootstrapping Microsoft.PowerShell.PSResourceGet.
+            Invoke-WebRequest @invokeWebRequestParameters
+
+            $ProgressPreference = $previousProgressPreference
+
+            $psResourceGetDownloaded = $true
+        }
+        catch
+        {
+            Write-Warning -Message ('PSResourceGet could not be bootstrapped. Reverting to PowerShellGet. Error: {0}' -f $_.Exception.Message)
         }
 
-        $previousProgressPreference = $ProgressPreference
-        $ProgressPreference = 'SilentlyContinue'
+        $UsePSResourceGet = $false
 
-        # Bootstrapping Microsoft.PowerShell.PSResourceGet.
-        Invoke-WebRequest @invokeWebRequestParameters
+        if ($psResourceGetDownloaded)
+        {
+            $expandArchiveParameters = @{
+                Path            = $invokeWebRequestParameters.OutFile
+                DestinationPath = "$PSDependTarget/Microsoft.PowerShell.PSResourceGet"
+                Force           = $true
+            }
 
-        $ProgressPreference = $previousProgressPreference
+            Expand-Archive @expandArchiveParameters
 
-        $psResourceGetDownloaded = $true
-    }
-    catch
-    {
-        Write-Warning -Message ('PSResourceGet could not be bootstrapped. Reverting to PowerShellGet. Error: {0}' -f $_.Exception.Message)
-    }
+            Remove-Item -Path $invokeWebRequestParameters.OutFile
 
-    $usePSResourceGet = $false
+            Import-Module -Name $expandArchiveParameters.DestinationPath -Force
 
-    if ($psResourceGetDownloaded)
-    {
-        $expandArchiveParameters = @{
-            Path            = $invokeWebRequestParameters.OutFile
-            DestinationPath = "$PSDependTarget/Microsoft.PowerShell.PSResourceGet"
-            Force           = $true
+            # Successfully bootstrapped PSResourceGet and CompatPowerShellGet, so let's use it.
+            $UsePSResourceGet = $true
         }
+    }
 
-        Expand-Archive @expandArchiveParameters
-
-        Remove-Item -Path $invokeWebRequestParameters.OutFile
-
-        Import-Module -Name $expandArchiveParameters.DestinationPath -Force
-
+    if ($UsePSResourceGet)
+    {
         $savePSResourceParameters = @{
             Name            = 'CompatPowerShellGet' #cSpell: ignore compat
             Path            = $PSDependTarget
@@ -280,13 +296,10 @@ if ($UsePSResourceGet)
         Save-PSResource @savePSResourceParameters
 
         Import-Module -Name "$PSDependTarget/CompatPowerShellGet"
-
-        # Successfully bootstrapped PSResourceGet and CompatPowerShellGet, so let's use it.
-        $usePSResourceGet = $true
     }
 }
 
-if (-not ($UseModuleFast -or $usePSResourceGet))
+if (-not ($UseModuleFast -or $UsePSResourceGet))
 {
     if ($PSVersionTable.PSVersion.Major -le 5)
     {
@@ -396,10 +409,7 @@ if (-not ($UseModuleFast -or $usePSResourceGet))
             Register-PSRepository @RegisterGallery
         }
     }
-}
 
-if (-not $UseModuleFast.IsPresent)
-{
     Write-Progress -Activity 'Bootstrap:' -PercentComplete 10 -CurrentOperation "Ensuring Gallery $Gallery is trusted"
 
     # Fail if the given PSGallery is not registered.
@@ -414,7 +424,7 @@ if (-not $UseModuleFast.IsPresent)
 
 try
 {
-    if (-not ($UseModuleFast -or $usePSResourceGet))
+    if (-not ($UseModuleFast -or $UsePSResourceGet))
     {
         Write-Progress -Activity 'Bootstrap:' -PercentComplete 25 -CurrentOperation 'Checking PowerShellGet'
 
@@ -626,7 +636,7 @@ try
 
     if (Test-Path -Path $DependencyFile)
     {
-        if ($UseModuleFast -or $usePSResourceGet)
+        if ($UseModuleFast -or $UsePSResourceGet)
         {
             $requiredModules = Import-PowerShellDataFile -Path $DependencyFile
 
@@ -689,7 +699,7 @@ try
                 Write-Progress -Activity 'ModuleFast:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
             }
 
-            if ($usePSResourceGet)
+            if ($UsePSResourceGet)
             {
                 Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking PSResourceGet'
 
@@ -697,15 +707,16 @@ try
 
                 Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies'
 
-                $percentagePerModule = [Math]::Floor(100 / $modulesToSave.Length)
+                $percentagePerModule = [System.Math]::Floor(100 / $modulesToSave.Length)
 
                 foreach ($currentModule in $modulesToSave)
                 {
                     Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies' -Status ('Saving module {0}' -f $savePSResourceParameters.Name)
 
                     $savePSResourceParameters = @{
-                        Path    = $PSDependTarget
-                        Confirm = $false
+                        Path            = $PSDependTarget
+                        TrustRepository = $true
+                        Confirm         = $false
                     }
 
                     if ($currentModule -is [System.Collections.Hashtable])
@@ -718,7 +729,12 @@ try
                         $savePSResourceParameters.Name = $currentModule
                     }
 
-                    Save-PSResource @savePSResourceParameters
+                    Save-PSResource @savePSResourceParameters -ErrorVariable 'savePSResourceError'
+
+                    if ($savePSResourceError)
+                    {
+                        Write-Warning -Message 'Save-PSResource could not save (replace) one or more dependencies. This can be due to the module is loaded into the session (and referencing assemblies). Close the current session and open a new session and try again.'
+                    }
 
                     $progressPercentage += $percentagePerModule
                 }

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -50,6 +50,10 @@
         Specifies to use ModuleFast instead of PowerShellGet to resolve dependencies
         faster.
 
+    .PARAMETER PSResourceGet
+        Specifies to use ModuleFast instead of PowerShellGet to resolve dependencies
+        faster.
+
     .NOTES
         Load defaults for parameters values from Resolve-Dependency.psd1 if not
         provided as parameter.
@@ -108,7 +112,11 @@ param
 
     [Parameter()]
     [System.Management.Automation.SwitchParameter]
-    $UseModuleFast
+    $UseModuleFast,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePSResourceGet
 )
 
 try
@@ -166,6 +174,24 @@ catch
     Write-Warning -Message "Error attempting to import Bootstrap's default parameters from '$resolveDependencyConfigPath': $($_.Exception.Message)."
 }
 
+# Handles when both ModuleFast and PSResourceGet is configured or/and passed as parameter.
+if ($UseModuleFast -and $UsePSResourceGet)
+{
+    Write-Information -MessageData 'Both ModuleFast and PSResourceGet is configured or/and passed as parameter.' -InformationAction 'Continue'
+
+    if ($PSVersionTable.PSVersion -ge '7.2')
+    {
+        $UsePSResourceGet = $false
+
+        Write-Information -MessageData 'PowerShell 7.2 or higher being used, prefer ModuleFast over PSResourceGet.' -InformationAction 'Continue'
+    }
+    else
+    {
+        $UseModuleFast = $false
+
+        Write-Information -MessageData 'Older PowerShell or Windows PowerShell being used, prefer PSResourceGet since ModuleFast is not supported on this version of PowerShell.' -InformationAction 'Continue'
+    }
+}
 
 if ($UseModuleFast)
 {
@@ -199,7 +225,68 @@ if ($UseModuleFast)
     }
 }
 
-if (-not $UseModuleFast)
+if ($UsePSResourceGet)
+{
+    $psResourceGetDownloaded = $false
+
+    try
+    {
+        $invokeWebRequestParameters = @{
+            # TODO: This should be hardcoded to a stable release in the future.
+            # TODO: Should support proxy parameters passed to the script.
+            Uri         = 'https://www.powershellgallery.com/api/v2/package/Microsoft.PowerShell.PSResourceGet/0.5.24-beta24'
+            OutFile     = "$PSDependTarget/Microsoft.PowerShell.PSResourceGet.nupkg" # cSpell: ignore nupkg
+            ErrorAction = 'Stop'
+        }
+
+        $previousProgressPreference = $ProgressPreference
+        $ProgressPreference = 'SilentlyContinue'
+
+        # Bootstrapping Microsoft.PowerShell.PSResourceGet.
+        Invoke-WebRequest @invokeWebRequestParameters
+
+        $ProgressPreference = $previousProgressPreference
+
+        $psResourceGetDownloaded = $true
+    }
+    catch
+    {
+        Write-Warning -Message ('PSResourceGet could not be bootstrapped. Reverting to PowerShellGet. Error: {0}' -f $_.Exception.Message)
+    }
+
+    $usePSResourceGet = $false
+
+    if ($psResourceGetDownloaded)
+    {
+        $expandArchiveParameters = @{
+            Path            = $invokeWebRequestParameters.OutFile
+            DestinationPath = "$PSDependTarget/Microsoft.PowerShell.PSResourceGet"
+            Force           = $true
+        }
+
+        Expand-Archive @expandArchiveParameters
+
+        Remove-Item -Path $invokeWebRequestParameters.OutFile
+
+        Import-Module -Name $expandArchiveParameters.DestinationPath -Force
+
+        $savePSResourceParameters = @{
+            Name            = 'CompatPowerShellGet' #cSpell: ignore compat
+            Path            = $PSDependTarget
+            Repository      = 'PSGallery'
+            TrustRepository = $true
+        }
+
+        Save-PSResource @savePSResourceParameters
+
+        Import-Module -Name "$PSDependTarget/CompatPowerShellGet"
+
+        # Successfully bootstrapped PSResourceGet and CompatPowerShellGet, so let's use it.
+        $usePSResourceGet = $true
+    }
+}
+
+if (-not ($UseModuleFast -or $usePSResourceGet))
 {
     if ($PSVersionTable.PSVersion.Major -le 5)
     {
@@ -309,13 +396,16 @@ if (-not $UseModuleFast)
             Register-PSRepository @RegisterGallery
         }
     }
+}
 
+if (-not $UseModuleFast.IsPresent)
+{
     Write-Progress -Activity 'Bootstrap:' -PercentComplete 10 -CurrentOperation "Ensuring Gallery $Gallery is trusted"
 
     # Fail if the given PSGallery is not registered.
-    $previousGalleryInstallationPolicy = (Get-PSRepository -Name $Gallery -ErrorAction 'Stop').InstallationPolicy
+    $previousGalleryInstallationPolicy = (Get-PSRepository -Name $Gallery -ErrorAction 'Stop').Trusted
 
-    if ($previousGalleryInstallationPolicy -ne 'Trusted')
+    if ($previousGalleryInstallationPolicy -ne $true)
     {
         # Only change policy if the repository is not trusted
         Set-PSRepository -Name $Gallery -InstallationPolicy 'Trusted' -ErrorAction 'Ignore'
@@ -324,7 +414,7 @@ if (-not $UseModuleFast)
 
 try
 {
-    if (-not $UseModuleFast)
+    if (-not ($UseModuleFast -or $usePSResourceGet))
     {
         Write-Progress -Activity 'Bootstrap:' -PercentComplete 25 -CurrentOperation 'Checking PowerShellGet'
 
@@ -536,12 +626,8 @@ try
 
     if (Test-Path -Path $DependencyFile)
     {
-        if ($UseModuleFast)
+        if ($UseModuleFast -or $usePSResourceGet)
         {
-            Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking ModuleFast'
-
-            Write-Progress -Activity 'ModuleFast:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
-
             $requiredModules = Import-PowerShellDataFile -Path $DependencyFile
 
             $requiredModules = $requiredModules.GetEnumerator() |
@@ -571,30 +657,74 @@ try
                 $modulesToSave += 'PowerShell-Yaml'
             }
 
-            $moduleFastPlan = $modulesToSave | Get-ModuleFastPlan
-
-            if ($moduleFastPlan)
+            if ($UseModuleFast.IsPresent)
             {
-                # Clear all modules in plan from the current session so they can be fetched again.
-                $moduleFastPlan.Name | Get-Module | Remove-Module -Force
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking ModuleFast'
 
-                $installModuleFastParameters = @{
-                    ModulesToInstall     = $moduleFastPlan
-                    Destination          = $PSDependTarget
-                    NoPSModulePathUpdate = $true
-                    NoProfileUpdate      = $true
-                    Update               = $true
-                    Confirm              = $false
+                Write-Progress -Activity 'ModuleFast:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
+
+                $moduleFastPlan = $modulesToSave | Get-ModuleFastPlan
+
+                if ($moduleFastPlan)
+                {
+                    # Clear all modules in plan from the current session so they can be fetched again.
+                    $moduleFastPlan.Name | Get-Module | Remove-Module -Force
+
+                    $installModuleFastParameters = @{
+                        ModulesToInstall     = $moduleFastPlan
+                        Destination          = $PSDependTarget
+                        NoPSModulePathUpdate = $true
+                        NoProfileUpdate      = $true
+                        Update               = $true
+                        Confirm              = $false
+                    }
+
+                    Install-ModuleFast @installModuleFastParameters
+                }
+                else
+                {
+                    Write-Verbose -Message 'All modules were already up to date'
                 }
 
-                Install-ModuleFast @installModuleFastParameters
-            }
-            else
-            {
-                Write-Verbose -Message 'All modules were already up to date'
+                Write-Progress -Activity 'ModuleFast:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
             }
 
-            Write-Progress -Activity 'ModuleFast:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
+            if ($usePSResourceGet)
+            {
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking PSResourceGet'
+
+                $progressPercentage = 0
+
+                Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies'
+
+                $percentagePerModule = [Math]::Floor(100 / $modulesToSave.Length)
+
+                foreach ($currentModule in $modulesToSave)
+                {
+                    Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies' -Status ('Saving module {0}' -f $savePSResourceParameters.Name)
+
+                    $savePSResourceParameters = @{
+                        Path    = $PSDependTarget
+                        Confirm = $false
+                    }
+
+                    if ($currentModule -is [System.Collections.Hashtable])
+                    {
+                        $savePSResourceParameters.Name = $currentModule.Name
+                        $savePSResourceParameters.Version = $currentModule.RequiredVersion
+                    }
+                    else
+                    {
+                        $savePSResourceParameters.Name = $currentModule
+                    }
+
+                    Save-PSResource @savePSResourceParameters
+
+                    $progressPercentage += $percentagePerModule
+                }
+
+                Write-Progress -Activity 'PSResourceGet:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
+            }
         }
         else
         {
@@ -659,10 +789,10 @@ finally
     # Only try to revert installation policy if the repository exist
     if ((Get-PSRepository -Name $Gallery -ErrorAction 'SilentlyContinue'))
     {
-        if ($previousGalleryInstallationPolicy -and $previousGalleryInstallationPolicy -ne 'Trusted')
+        if ($previousGalleryInstallationPolicy -ne $true)
         {
             # Reverting the Installation Policy for the given gallery if it was not already trusted
-            Set-PSRepository -Name $Gallery -InstallationPolicy $previousGalleryInstallationPolicy
+            Set-PSRepository -Name $Gallery -InstallationPolicy 'Untrusted'
         }
     }
 

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -322,16 +322,24 @@ if ($UsePSResourceGet)
 
         Write-Information -MessageData ('Using {0} v{1}.' -f $psResourceGetModuleName, $psResourceGetModuleVersion) -InformationAction 'Continue'
 
-        $savePSResourceParameters = @{
-            Name            = 'PowerShellGet'
-            Version         = '2.9.0-preview'
-            Prerelease      = $true
-            Path            = $PSDependTarget
-            Repository      = 'PSGallery'
-            TrustRepository = $true
-        }
+        if ($UsePowerShellGetCompatibilityModuleVersion)
+        {
+            $savePowerShellGetParameters = @{
+                Name            = 'PowerShellGet'
+                Version         = $UsePowerShellGetCompatibilityModuleVersion
+                Path            = $PSDependTarget
+                Repository      = 'PSGallery'
+                TrustRepository = $true
+            }
 
-        Save-PSResource @savePSResourceParameters
+            # Check if the version is a prerelease.
+            if ($UsePowerShellGetCompatibilityModuleVersion -match '\d+\.\d+\.\d+-.*')
+            {
+                $savePowerShellGetParameters.Prerelease = $true
+            }
+
+            Save-PSResource @savePowerShellGetParameters
+        }
 
         Import-Module -Name "$PSDependTarget/PowerShellGet"
     }

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -227,14 +227,13 @@ if ($UseModuleFast)
 
 if ($UsePSResourceGet)
 {
-    # Check if it is already imported (then we can't download it again because of locked files)
-    if ((Get-Module -Name 'Microsoft.PowerShell.PSResourceGet'))
+    if ((Get-Module -Name 'Microsoft.PowerShell.PSResourceGet' -ListAvailable))
     {
-        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet already exist in the session.'
+        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet already exist, skip saving to RequiredModules.'
     }
     else
     {
-        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet no in session, save the module to RequiredModules.'
+        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet do not exist, save the module to RequiredModules.'
 
         $psResourceGetDownloaded = $false
 
@@ -267,15 +266,28 @@ if ($UsePSResourceGet)
 
         if ($psResourceGetDownloaded)
         {
+            # On Windows PowerShell the command Expand-Archive do not like .nupkg as a zip archive extension.
+            $zipFileName = ((Split-Path -Path $invokeWebRequestParameters.OutFile -Leaf) -replace 'nupkg', 'zip')
+
+            $renameItemParameters = @{
+                Path    = $invokeWebRequestParameters.OutFile
+                NewName = $zipFileName
+                Force   = $true
+            }
+
+            Rename-Item @renameItemParameters
+
+            $psResourceGetZipArchivePath = Join-Path -Path (Split-Path -Path $invokeWebRequestParameters.OutFile -Parent) -ChildPath $zipFileName
+
             $expandArchiveParameters = @{
-                Path            = $invokeWebRequestParameters.OutFile
+                Path            = $psResourceGetZipArchivePath
                 DestinationPath = "$PSDependTarget/Microsoft.PowerShell.PSResourceGet"
                 Force           = $true
             }
 
             Expand-Archive @expandArchiveParameters
 
-            Remove-Item -Path $invokeWebRequestParameters.OutFile
+            Remove-Item -Path $psResourceGetZipArchivePath
 
             Import-Module -Name $expandArchiveParameters.DestinationPath -Force
 
@@ -667,7 +679,7 @@ try
                 $modulesToSave += 'PowerShell-Yaml'
             }
 
-            if ($UseModuleFast.IsPresent)
+            if ($UseModuleFast)
             {
                 Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking ModuleFast'
 
@@ -729,11 +741,26 @@ try
                         $savePSResourceParameters.Name = $currentModule
                     }
 
-                    Save-PSResource @savePSResourceParameters -ErrorVariable 'savePSResourceError'
+                    # Modules that Sampler depend on that cannot be refreshed without a new session.
+                    $skipModule = @('powershell-yaml')
 
-                    if ($savePSResourceError)
+                    if ($savePSResourceParameters.Name -in $skipModule -and (Get-Module -Name 'powershell-yaml'))
                     {
-                        Write-Warning -Message 'Save-PSResource could not save (replace) one or more dependencies. This can be due to the module is loaded into the session (and referencing assemblies). Close the current session and open a new session and try again.'
+                        Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies' -Status ('Skipping module {0}' -f $savePSResourceParameters.Name)
+
+                        Write-Information -MessageData ('Skipping the module {0} since it cannot be refresh while loaded into the session. To refresh the module open a new session and resolve dependencies again.' -f $savePSResourceParameters.Name) -InformationAction 'Continue'
+                    }
+                    else
+                    {
+                        # Clear all module from the current session so any new version fetched will be re-imported.
+                        Get-Module -Name $savePSResourceParameters.Name | Remove-Module -Force
+
+                        Save-PSResource @savePSResourceParameters -ErrorVariable 'savePSResourceError'
+
+                        if ($savePSResourceError)
+                        {
+                            Write-Warning -Message 'Save-PSResource could not save (replace) one or more dependencies. This can be due to the module is loaded into the session (and referencing assemblies). Close the current session and open a new session and try again.'
+                        }
                     }
 
                     $progressPercentage += $percentagePerModule

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -116,7 +116,11 @@ param
 
     [Parameter()]
     [System.Management.Automation.SwitchParameter]
-    $UsePSResourceGet
+    $UsePSResourceGet,
+
+    [Parameter()]
+    [System.String]
+    $PSResourceGetVersion
 )
 
 try
@@ -227,24 +231,32 @@ if ($UseModuleFast)
 
 if ($UsePSResourceGet)
 {
+    $psResourceGetModuleName = 'Microsoft.PowerShell.PSResourceGet'
+
     # If PSResourceGet was used prior it will be locked and we can't replace it.
-    if ((Test-Path -Path "$PSDependTarget/Microsoft.PowerShell.PSResourceGet" -PathType 'Container') -and (Get-Module -Name 'Microsoft.PowerShell.PSResourceGet'))
+    if ((Test-Path -Path "$PSDependTarget/$psResourceGetModuleName" -PathType 'Container') -and (Get-Module -Name $psResourceGetModuleName))
     {
-        Write-Information -MessageData 'Microsoft.PowerShell.PSResourceGet is already save and loaded into the session, skip saving to RequiredModules. To refresh the module open a new session and resolve dependencies again.' -InformationAction 'Continue'
+        Write-Information -MessageData ('{0} is already saved and loaded into the session. To refresh the module open a new session and resolve dependencies again.' -f $psResourceGetModuleName) -InformationAction 'Continue'
     }
     else
     {
-        Write-Debug -Message 'Microsoft.PowerShell.PSResourceGet do not exist, save the module to RequiredModules.'
+        Write-Debug -Message ('{0} do not exist, saving the module to RequiredModules.' -f $psResourceGetModuleName)
 
         $psResourceGetDownloaded = $false
 
         try
         {
+            if (-not $PSResourceGetVersion)
+            {
+                # Default version to use if non is specified in parameter or in configuration.
+                $PSResourceGetVersion = '0.9.0-rc1'
+            }
+
             $invokeWebRequestParameters = @{
                 # TODO: This should be hardcoded to a stable release in the future.
                 # TODO: Should support proxy parameters passed to the script.
-                Uri         = 'https://www.powershellgallery.com/api/v2/package/Microsoft.PowerShell.PSResourceGet/0.9.0-rc1'
-                OutFile     = "$PSDependTarget/Microsoft.PowerShell.PSResourceGet.nupkg" # cSpell: ignore nupkg
+                Uri         = "https://www.powershellgallery.com/api/v2/package/$psResourceGetModuleName/$PSResourceGetVersion"
+                OutFile     = "$PSDependTarget/$psResourceGetModuleName.nupkg" # cSpell: ignore nupkg
                 ErrorAction = 'Stop'
             }
 
@@ -260,7 +272,7 @@ if ($UsePSResourceGet)
         }
         catch
         {
-            Write-Warning -Message ('PSResourceGet could not be bootstrapped. Reverting to PowerShellGet. Error: {0}' -f $_.Exception.Message)
+            Write-Warning -Message ('{0} could not be bootstrapped. Reverting to PowerShellGet. Error: {1}' -f $psResourceGetModuleName, $_.Exception.Message)
         }
 
         $UsePSResourceGet = $false
@@ -282,7 +294,7 @@ if ($UsePSResourceGet)
 
             $expandArchiveParameters = @{
                 Path            = $psResourceGetZipArchivePath
-                DestinationPath = "$PSDependTarget/Microsoft.PowerShell.PSResourceGet"
+                DestinationPath = "$PSDependTarget/$psResourceGetModuleName"
                 Force           = $true
             }
 
@@ -290,9 +302,7 @@ if ($UsePSResourceGet)
 
             Remove-Item -Path $psResourceGetZipArchivePath
 
-            $psResourceGetModule = Import-Module -Name $expandArchiveParameters.DestinationPath -Force -PassThru
-
-            Write-Information -MessageData ('Using Microsoft.PowerShell.PSResourceGet v{0}-{1}' -f $psResourceGetModule.Version.ToString(),$psResourceGetModule.PrivateData.PSData.Prerelease) -InformationAction 'Continue'
+            Import-Module -Name $expandArchiveParameters.DestinationPath -Force
 
             # Successfully bootstrapped PSResourceGet, so let's use it.
             $UsePSResourceGet = $true
@@ -301,6 +311,17 @@ if ($UsePSResourceGet)
 
     if ($UsePSResourceGet)
     {
+        $psResourceGetModule = Get-Module -Name $psResourceGetModuleName
+
+        $psResourceGetModuleVersion = $psResourceGetModule.Version.ToString()
+
+        if ($psResourceGetModule.PrivateData.PSData.Prerelease)
+        {
+            $psResourceGetModuleVersion += '-{0}' -f $psResourceGetModule.PrivateData.PSData.Prerelease
+        }
+
+        Write-Information -MessageData ('Using {0} v{1}.' -f $psResourceGetModuleName, $psResourceGetModuleVersion) -InformationAction 'Continue'
+
         $savePSResourceParameters = @{
             Name            = 'PowerShellGet'
             Version         = '2.9.0-preview'

--- a/Sampler/Templates/Build/Resolve-Dependency.psd1.template
+++ b/Sampler/Templates/Build/Resolve-Dependency.psd1.template
@@ -51,5 +51,6 @@
     # will be used to resolve dependencies.
     #UsePSResourceGet = $true
     #PSResourceGetVersion = '1.0.0'
+    #UsePowerShellGetCompatibilityModule = $true
     #UsePowerShellGetCompatibilityModuleVersion = '3.0.22-beta22'
 }

--- a/Sampler/Templates/Build/Resolve-Dependency.psd1.template
+++ b/Sampler/Templates/Build/Resolve-Dependency.psd1.template
@@ -49,5 +49,6 @@
     # Enable PSResourceGet to resolve dependencies. Requires PowerShell 7.2 or higher.
     # If this is not configured or set to $false then PowerShellGet and PackageManagement
     # will be used to resolve dependencies.
-    UsePSResourceGet = $true
+    #UsePSResourceGet = $true
+    #PSResourceGetVersion = '1.0.0'
 }

--- a/Sampler/Templates/Build/Resolve-Dependency.psd1.template
+++ b/Sampler/Templates/Build/Resolve-Dependency.psd1.template
@@ -45,4 +45,9 @@
     # If this is not configured or set to $false then PowerShellGet and PackageManagement
     # will be used to resolve dependencies.
     #UseModuleFast   = $true
+
+    # Enable PSResourceGet to resolve dependencies. Requires PowerShell 7.2 or higher.
+    # If this is not configured or set to $false then PowerShellGet and PackageManagement
+    # will be used to resolve dependencies.
+    UsePSResourceGet = $true
 }

--- a/Sampler/Templates/Build/Resolve-Dependency.psd1.template
+++ b/Sampler/Templates/Build/Resolve-Dependency.psd1.template
@@ -51,4 +51,5 @@
     # will be used to resolve dependencies.
     #UsePSResourceGet = $true
     #PSResourceGetVersion = '1.0.0'
+    #UsePowerShellGetCompatibilityModuleVersion = '3.0.22-beta22'
 }

--- a/Sampler/Templates/Build/build.ps1
+++ b/Sampler/Templates/Build/build.ps1
@@ -64,6 +64,11 @@
     .PARAMETER UsePSResourceGet
         Specifies to use PSResourceGet instead of PowerShellGet to resolve dependencies
         faster. This can also be configured in Resolve-Dependency.psd1.
+
+    .PARAMETER UsePowerShellGetCompatibilityModule
+        Specifies to use the compatibility module PowerShellGet. This parameter
+        only works then the method of downloading dependencies is PSResourceGet.
+        This can also be configured in Resolve-Dependency.psd1.
 #>
 [CmdletBinding()]
 param
@@ -137,7 +142,11 @@ param
 
     [Parameter()]
     [System.Management.Automation.SwitchParameter]
-    $UsePSResourceGet
+    $UsePSResourceGet,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePowerShellGetCompatibilityModule
 )
 
 <#

--- a/Sampler/Templates/Build/build.ps1
+++ b/Sampler/Templates/Build/build.ps1
@@ -59,6 +59,10 @@
 
     .PARAMETER UseModuleFast
         Specifies to use ModuleFast instead of PowerShellGet to resolve dependencies
+        faster.
+
+    .PARAMETER UsePSResourceGet
+        Specifies to use PSResourceGet instead of PowerShellGet to resolve dependencies
         faster. This can also be configured in Resolve-Dependency.psd1.
 #>
 [CmdletBinding()]
@@ -129,7 +133,11 @@ param
 
     [Parameter()]
     [System.Management.Automation.SwitchParameter]
-    $UseModuleFast
+    $UseModuleFast,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePSResourceGet
 )
 
 <#

--- a/build.ps1
+++ b/build.ps1
@@ -64,6 +64,11 @@
     .PARAMETER UsePSResourceGet
         Specifies to use PSResourceGet instead of PowerShellGet to resolve dependencies
         faster. This can also be configured in Resolve-Dependency.psd1.
+
+    .PARAMETER UsePowerShellGetCompatibilityModule
+        Specifies to use the compatibility module PowerShellGet. This parameter
+        only works then the method of downloading dependencies is PSResourceGet.
+        This can also be configured in Resolve-Dependency.psd1.
 #>
 [CmdletBinding()]
 param
@@ -137,7 +142,11 @@ param
 
     [Parameter()]
     [System.Management.Automation.SwitchParameter]
-    $UsePSResourceGet
+    $UsePSResourceGet,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePowerShellGetCompatibilityModule
 )
 
 <#

--- a/build.ps1
+++ b/build.ps1
@@ -59,6 +59,10 @@
 
     .PARAMETER UseModuleFast
         Specifies to use ModuleFast instead of PowerShellGet to resolve dependencies
+        faster.
+
+    .PARAMETER UsePSResourceGet
+        Specifies to use PSResourceGet instead of PowerShellGet to resolve dependencies
         faster. This can also be configured in Resolve-Dependency.psd1.
 #>
 [CmdletBinding()]
@@ -129,7 +133,11 @@ param
 
     [Parameter()]
     [System.Management.Automation.SwitchParameter]
-    $UseModuleFast
+    $UseModuleFast,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePSResourceGet
 )
 
 <#

--- a/tests/Integration/ResolveDependencies.Integration.Tests.ps1
+++ b/tests/Integration/ResolveDependencies.Integration.Tests.ps1
@@ -30,7 +30,8 @@ Describe 'Resolve dependencies' {
         }
     }
 
-    Context 'When using ModuleFast' {
+    # Skip this test on Windows PowerShell as the method is unsupported.
+    Context 'When using ModuleFast' -Skip:($PSVersionTable.PSEdition -eq 'Desktop') {
         BeforeAll {
             $testTargetPath = Join-Path -Path $TestDrive -ChildPath 'ModuleFast'
 

--- a/tests/Integration/ResolveDependencies.Integration.Tests.ps1
+++ b/tests/Integration/ResolveDependencies.Integration.Tests.ps1
@@ -3,6 +3,10 @@ Describe 'Resolve dependencies' {
         $repositoryPath =  Join-Path -Path $PSScriptRoot -ChildPath '../../'
     }
 
+    AfterAll {
+        Set-Location -Path $repositoryPath
+    }
+
     Context 'When using PowerShellGet' {
         BeforeAll {
             $testTargetPath = Join-Path -Path $TestDrive -ChildPath 'PowerShellGet'

--- a/tests/Integration/ResolveDependencies.Integration.Tests.ps1
+++ b/tests/Integration/ResolveDependencies.Integration.Tests.ps1
@@ -1,0 +1,98 @@
+Describe 'Resolve dependencies' {
+    BeforeAll {
+        $repositoryPath =  Join-Path -Path $PSScriptRoot -ChildPath '../../'
+    }
+
+    Context 'When using PowerShellGet' {
+        BeforeAll {
+            $testTargetPath = Join-Path -Path $TestDrive -ChildPath 'PowerShellGet'
+
+            Copy-Item -Recurse -Path $repositoryPath -Destination $testTargetPath -Force
+
+            Remove-Item -Path (Join-Path -Path $testTargetPath -ChildPath 'output/RequiredModules') -Recurse -Force
+        }
+
+        BeforeEach {
+            # Must be set here so $Using:PWD works.
+            Set-Location -Path $testTargetPath
+        }
+
+        It 'Should resolve dependencies without throwing' {
+            # Running in separate job so that we do not mess up the current session.
+            Start-Job -ScriptBlock {
+                Set-Location $using:PWD
+
+                ./build.ps1 -ResolveDependency -Tasks 'noop' 4>&1 5>&1 6>&1 > $null
+            } |
+                Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
+
+            $buildError | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'When using ModuleFast' {
+        BeforeAll {
+            $testTargetPath = Join-Path -Path $TestDrive -ChildPath 'ModuleFast'
+
+            Copy-Item -Recurse -Path $repositoryPath -Destination $testTargetPath -Force
+
+            # Must keep the folder RequiredModules, but the content must be removed.
+            Remove-Item -Path (Join-Path -Path $testTargetPath -ChildPath 'output/RequiredModules/*') -Recurse -Force
+        }
+
+        BeforeEach {
+            # Must be set here so $Using:PWD works.
+            Set-Location -Path $testTargetPath
+        }
+
+        It 'Should resolve dependencies without throwing' {
+            # Running in separate job so that we do not mess up the current session.
+            Start-Job -ScriptBlock {
+                Set-Location $using:PWD
+
+                <#
+                    Remove the real Sampler output folder paths from PSModulePath so that
+                    the command Get-FastModulePlan does not find modules installed.
+                #>
+                $env:PSModulePath = (
+                    $env:PSModulePath -split [System.IO.Path]::PathSeparator |
+                        Where-Object -FilterScript {
+                            $_ -notlike '*Sampler*'
+                        }
+                ) -join [System.IO.Path]::PathSeparator
+
+                ./build.ps1 -ResolveDependency -Tasks 'noop' -UseModuleFast 4>&1 5>&1 6>&1 > $null
+            } |
+                Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
+
+            $buildError | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'When using PSResourceGet' {
+        BeforeAll {
+            $testTargetPath = Join-Path -Path $TestDrive -ChildPath 'PSResourceGet'
+
+            Copy-Item -Recurse -Path $repositoryPath -Destination $testTargetPath -Force
+
+            Remove-Item -Path (Join-Path -Path $testTargetPath -ChildPath 'output/RequiredModules') -Recurse -Force
+        }
+
+        BeforeEach {
+            # Must be set here so $Using:PWD works.
+            Set-Location -Path $testTargetPath
+        }
+
+        It 'Should resolve dependencies without throwing' {
+            # Running in separate job so that we do not mess up the current session.
+            Start-Job -ScriptBlock {
+                Set-Location $using:PWD
+
+                ./build.ps1 -ResolveDependency -Tasks 'noop' -UsePSResourceGet 4>&1 5>&1 6>&1 > $null
+            } |
+                Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
+
+            $buildError | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Integration/ResolveDependencies.Integration.Tests.ps1
+++ b/tests/Integration/ResolveDependencies.Integration.Tests.ps1
@@ -138,14 +138,16 @@ Describe 'Resolve dependencies' {
 }
 '@
 
-                    $mockRequiredModulesDataFile | Out-File -Path '.\RequiredModules.psd1' -Encoding UTF8 -NoClobber -NoNewline
+                    $mockRequiredModulesDataFile | Out-File -FilePath '.\RequiredModules.psd1' -Encoding UTF8 -NoClobber -NoNewline
 
                     ./build.ps1 -ResolveDependency -Tasks 'noop' -UsePSResourceGet 4>&1 5>&1 6>&1 > $null
                 } |
                     Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
 
                 $buildError | Should -BeNullOrEmpty
+            }
 
+            It 'Should have resolve the correct pre-release version' {
                 $pesterModuleManifest = Import-PowerShellDataFile -Path '.\output\RequiredModules\Pester\**\Pester.psd1'
 
                 $pesterModuleManifest.ModuleVersion | Should -Be '5.5.0'

--- a/tests/Integration/ResolveDependencies.Integration.Tests.ps1
+++ b/tests/Integration/ResolveDependencies.Integration.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Resolve dependencies' {
             Start-Job -ScriptBlock {
                 Set-Location $using:PWD
 
-                ./build.ps1 -ResolveDependency -Tasks 'noop' #4>&1 5>&1 6>&1 > $null
+                ./build.ps1 -ResolveDependency -Tasks 'noop' 4>&1 5>&1 6>&1 > $null
             } |
                 Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
 
@@ -66,7 +66,7 @@ Describe 'Resolve dependencies' {
                         }
                 ) -join [System.IO.Path]::PathSeparator
 
-                ./build.ps1 -ResolveDependency -Tasks 'noop' -UseModuleFast #4>&1 5>&1 6>&1 > $null
+                ./build.ps1 -ResolveDependency -Tasks 'noop' -UseModuleFast 4>&1 5>&1 6>&1 > $null
             } |
                 Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
 
@@ -93,7 +93,7 @@ Describe 'Resolve dependencies' {
             Start-Job -ScriptBlock {
                 Set-Location $using:PWD
 
-                ./build.ps1 -ResolveDependency -Tasks 'noop' -UsePSResourceGet -Verbose -Debug #4>&1 5>&1 6>&1 > $null
+                ./build.ps1 -ResolveDependency -Tasks 'noop' -UsePSResourceGet 4>&1 5>&1 6>&1 > $null
             } |
                 Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
 
@@ -140,7 +140,7 @@ Describe 'Resolve dependencies' {
 
                     $mockRequiredModulesDataFile | Out-File -FilePath '.\RequiredModules.psd1' -Encoding UTF8 -NoClobber -NoNewline
 
-                    ./build.ps1 -ResolveDependency -Tasks 'noop' -UsePSResourceGet #4>&1 5>&1 6>&1 > $null
+                    ./build.ps1 -ResolveDependency -Tasks 'noop' -UsePSResourceGet 4>&1 5>&1 6>&1 > $null
                 } |
                     Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
 

--- a/tests/Integration/ResolveDependencies.Integration.Tests.ps1
+++ b/tests/Integration/ResolveDependencies.Integration.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Resolve dependencies' {
             Start-Job -ScriptBlock {
                 Set-Location $using:PWD
 
-                ./build.ps1 -ResolveDependency -Tasks 'noop' 4>&1 5>&1 6>&1 > $null
+                ./build.ps1 -ResolveDependency -Tasks 'noop' #4>&1 5>&1 6>&1 > $null
             } |
                 Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
 
@@ -66,7 +66,7 @@ Describe 'Resolve dependencies' {
                         }
                 ) -join [System.IO.Path]::PathSeparator
 
-                ./build.ps1 -ResolveDependency -Tasks 'noop' -UseModuleFast 4>&1 5>&1 6>&1 > $null
+                ./build.ps1 -ResolveDependency -Tasks 'noop' -UseModuleFast #4>&1 5>&1 6>&1 > $null
             } |
                 Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
 
@@ -93,7 +93,7 @@ Describe 'Resolve dependencies' {
             Start-Job -ScriptBlock {
                 Set-Location $using:PWD
 
-                ./build.ps1 -ResolveDependency -Tasks 'noop' -UsePSResourceGet 4>&1 5>&1 6>&1 > $null
+                ./build.ps1 -ResolveDependency -Tasks 'noop' -UsePSResourceGet -Verbose -Debug #4>&1 5>&1 6>&1 > $null
             } |
                 Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
 
@@ -140,7 +140,7 @@ Describe 'Resolve dependencies' {
 
                     $mockRequiredModulesDataFile | Out-File -FilePath '.\RequiredModules.psd1' -Encoding UTF8 -NoClobber -NoNewline
 
-                    ./build.ps1 -ResolveDependency -Tasks 'noop' -UsePSResourceGet 4>&1 5>&1 6>&1 > $null
+                    ./build.ps1 -ResolveDependency -Tasks 'noop' -UsePSResourceGet #4>&1 5>&1 6>&1 > $null
                 } |
                     Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
 

--- a/tests/Integration/ResolveDependencies.Integration.Tests.ps1
+++ b/tests/Integration/ResolveDependencies.Integration.Tests.ps1
@@ -99,5 +99,58 @@ Describe 'Resolve dependencies' {
 
             $buildError | Should -BeNullOrEmpty
         }
+
+        Context 'When RequiredModules.psd1 contain pre-releases' {
+            It 'Should resolve dependencies without throwing' {
+                # Running in separate job so that we do not mess up the current session.
+                Start-Job -ScriptBlock {
+                    Set-Location $using:PWD
+
+                    Remove-Item -Path '.\RequiredModules.psd1' -Force
+
+                    $mockRequiredModulesDataFile = @'
+@{
+    PSDependOptions             = @{
+        AddToPath  = $true
+        Target     = 'output\RequiredModules'
+        Parameters = @{}
+    }
+
+    Pester                         = @{
+        Version    = '5.5.0-rc1'
+        Parameters = @{
+            AllowPrerelease = $true
+        }
+    }
+
+    InvokeBuild                 = 'latest'
+    PSScriptAnalyzer            = 'latest'
+    Plaster                     = 'latest'
+    ModuleBuilder               = 'latest'
+    MarkdownLinkCheck           = 'latest'
+    ChangelogManagement         = 'latest'
+    'Sampler.GitHubTasks'       = 'latest'
+    'DscResource.Test'          = 'latest'
+    'DscResource.AnalyzerRules' = 'latest'
+    xDscResourceDesigner        = 'latest'
+
+    PlatyPS = 'latest'
+}
+'@
+
+                    $mockRequiredModulesDataFile | Out-File -Path '.\RequiredModules.psd1' -Encoding UTF8 -NoClobber -NoNewline
+
+                    ./build.ps1 -ResolveDependency -Tasks 'noop' -UsePSResourceGet 4>&1 5>&1 6>&1 > $null
+                } |
+                    Receive-Job -Wait -AutoRemoveJob -ErrorVariable buildError
+
+                $buildError | Should -BeNullOrEmpty
+
+                $pesterModuleManifest = Import-PowerShellDataFile -Path '.\output\RequiredModules\Pester\**\Pester.psd1'
+
+                $pesterModuleManifest.ModuleVersion | Should -Be '5.5.0'
+                $pesterModuleManifest.PrivateData.PSData.Prerelease | Should -Be 'rc1'
+            }
+        }
     }
 }


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Added
- Support for [PSResourceGet (beta release)](https://github.com/PowerShell/PSResourceGet).
  If the modules PSResourceGet can be bootstrapped they will be used. If
  PSResourceGet cannot be bootstrapped then it will revert to using
  PowerShellGet v2.2.5. If the user requests or configures to use ModuleFast
  then that will override both PSResourceGet and PowerShellGet. The method
  PSResourceGet can be enabled in the configuration file Resolve-Dependency.psd1.
  It is also possible to use PSResourceGet by adding the parameter `UsePSResourceGet`
  to the `build.ps1`, e.g. `./build.ps1 -Tasks noop -ResolveDependency -UsePSResourceGet`.
- When using PSResourceGet to resolve dependencies it also possible to
  use PowerShellGet v2.9.0 (previous _CompatPowerShellGet_). To use the
  compatibility module it can be enabled in the configuration file Resolve-Dependency.psd1.
  It is also possible to use it by adding the parameter `UsePowerShellGetCompatibilityModule`
  to the `build.ps1`, e.g. `./build.ps1 -Tasks noop -ResolveDependency -UsePSResourceGet -UsePowerShellGetCompatibilityModule`.
  _The 2.9.0-preview has since then been unlisted, the compatibility_
  _module will now be released as PowerShellGet v3.0.0._

### Changed
- PowerShell Team will release the PSResourceGet compatibility module
  (previously known as CompatPowerShellGet) as PowerShellGet v2.9.0 (or
  higher). The resolve dependency script, when PowerShellGet is used, will
  use `MaximumVersion` set to `2.8.999` to make sure the expected
  PowerShellGet version is installed, today that it is v2.2.5.
  _The 2.9.0-preview has since then been unlisted, the compatibility_
  _module will now be released as PowerShellGet v3.0.0._

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/438)
<!-- Reviewable:end -->
