### PR TITLE
Support prerelease with ModuleFast and make PSResourceGet the default method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   this configuration.
 - Update PSResourceGet to default to v1.0.1 if no version is passes in parameter
   or specific version is configured.
+- Templates was changed to use PSResourceGet as the default method
+  of resolving dependencies. It is possible to change to the method
+  PowerShellGet & PSDepend by changing the configuration.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Built module is now built in a separate folder. This is to split the paths
   for the built module and all required modules, to avoid returning duplicate
   modules when using `Get-Module -ListAvailable`.
+- Update PSResourceGet to default to v1.0.1 if no version is passes in parameter
+  or specific version is configured.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for the built module and all required modules, to avoid returning duplicate
   modules when using `Get-Module -ListAvailable`. The templates already has
   this configuration.
-- Update PSResourceGet to default to v1.0.1 if no version is passes in parameter
+- Update PSResourceGet to default to v1.0.1 if no version is passed in parameter
   or specific version is configured.
 - Templates was changed to use PSResourceGet as the default method
   of resolving dependencies. It is possible to change to the method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   point to the single version.
 - Correct description of the parameter `GalleryApiToken` in the build task
   script release.module.build.ps1. Fixes [#442](https://github.com/gaelcolas/Sampler/issues/442)
+- ModuleFast now supports resolving individual pre-release dependencies
+  that is part of _RequiredModules.psd1_. This only works when setting the
+  parameter value `ModuleFastBleedingEdge` to `$true` in the configuration
+  file _Resolve-Dependencies.psd1_. When `ModuleFastBleedingEdge` is enabled
+  it is also possible to specify [NuGet version ranges](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges)
+  in _RequiredModules.psd1_, although then the file is not compatible with
+  PSResourceGet or PSDepend (so no fallback can happen).
 
 ## [0.117.0] - 2023-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update template for SECURITY.md and add it to Sampler repository as well.
+- Built module is now built in a separate folder. This is to split the paths
+  for the built module and all required modules, to avoid returning duplicate
+  modules when using `Get-Module -ListAvailable`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update template for SECURITY.md and add it to Sampler repository as well.
 - Built module is now built in a separate folder. This is to split the paths
   for the built module and all required modules, to avoid returning duplicate
-  modules when using `Get-Module -ListAvailable`.
+  modules when using `Get-Module -ListAvailable`. The templates already has
+  this configuration.
 - Update PSResourceGet to default to v1.0.1 if no version is passes in parameter
   or specific version is configured.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct description of the parameter `GalleryApiToken` in the build task
   script release.module.build.ps1. Fixes [#442](https://github.com/gaelcolas/Sampler/issues/442)
 - ModuleFast now supports resolving individual pre-release dependencies
-  that is part of _RequiredModules.psd1_. This only works when setting the
-  parameter value `ModuleFastBleedingEdge` to `$true` in the configuration
-  file _Resolve-Dependencies.psd1_. When `ModuleFastBleedingEdge` is enabled
-  it is also possible to specify [NuGet version ranges](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges)
+  that is part of _RequiredModules.psd1_. It is also possible to specify
+  [NuGet version ranges](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges)
   in _RequiredModules.psd1_, although then the file is not compatible with
   PSResourceGet or PSDepend (so no fallback can happen).
 

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ InvokeRD[Use preferred method]  <--> PSGallery["PowerShell Gallery"]
 InvokeRD ---> Save[["Save to RequiredModules"]]
 ```
 
-The following command will resolve dependencies using PowerShellGet:
+The following command will resolve dependencies using PSResourceGet:
 
 ```powershell
 cd C:\source\MySimpleModule
@@ -549,9 +549,10 @@ environment like so:
    dependencies available in your session for module discovery and auto-loading,
    and also make it possible to use one or more of those modules as part of your built
    module.
-1. Making sure you have a compatible version of the modules _PowerShellGet_ and
+1. (Optional) Making sure you have a compatible version of the modules _PowerShellGet_ and
    _PackageManagement_ (`version -gt 1.6`). If not, these will be installed from the
-   configured repository.
+   configured repository. Only required if you plan to use legacy PowerShellGet, default
+   PSResourceGet is used.
 1. Download or install the `PowerShell-yaml` and `PSDepend` modules needed
    for further dependency management.
 1. Read the `build.yaml` configuration.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ It is not required for PSResourceGet or ModuleFast.
 #### PSResourceGet
 
 It is possible to use [PSResourceGet](https://github.com/PowerShell/PSResourceGet)
-to resolve dependencies. PSResourceGet works with WIndows PowerShell and
+to resolve dependencies. PSResourceGet works with Windows PowerShell and
 PowerShell (some restrictions on versions exist). To use PSResourceGet as
 a replacement for PowerShellGet it is possible to enable it in the configuration
 file `Resolve-Dependency.psd1`. It is also possible to allow the repository
@@ -147,23 +147,26 @@ for more information of the available syntax.
    'ComputerManagementDsc' =  ':9.1.0-preview0002'
    'ComputerManagementDsc' =  ':[9.1.0-preview0002]'
 
-   # Must be greater than 9.1.0-preview0002
+   # Must be a higher version than 9.1.0-preview0002
    'ComputerManagementDsc' =  '>9.1.0-preview0002'
 
-   # Must be less than 9.1.0-preview0002
+   # Must be a lower version than 9.1.0-preview0002
    'ComputerManagementDsc' =  '<9.1.0-preview0002'
 
-   # Must be less than or equal to 9.1.0-preview0002
+   # Must be a lower version than or equal to 9.1.0-preview0002
    'ComputerManagementDsc' =  '<=9.1.0-preview0002'
 
-   # Must be greater than or equal to 9.1.0-preview0002
+   # Must be a higher version than or equal to 9.1.0-preview0002
    'ComputerManagementDsc' =  '>=9.1.0-preview0002'
 
-   # Must be greater than 9.1.0-preview0002
-   'ComputerManagementDsc' =  ':9.1.0-preview0002'
+   # Exact range, exclusive. Must be lower version than 9.2.0. 9.2.0 is not allowed.
+   'ComputerManagementDsc' =  ':(,9.2.0)'
 
-   # Must be less than 9.1.0-preview0002
-   'ComputerManagementDsc' =  ':(,9.1.0-preview0002)'
+   # Exact range, exclusive. Must be higher version than 9.0.0. 9.0.0 is not allowed.
+   'ComputerManagementDsc' =  ':(9.0.0,)'
+
+   # Exact range, inclusive. Must be version than 9.0.0 or higher up to or equal to 9.2.0.
+   'ComputerManagementDsc' =  ':[9.0.0,9.2.0]'
 }
 
 ```
@@ -349,10 +352,13 @@ minimal environmental dependencies.
 graph LR
 
 RD[Resolve dependencies] --> Method{Method?}
-Method{Method?} -->|"(Default)"| PowerShellGet(["PowerShellGet"])
+Method{Method?} -->|"(Legacy, to use,
+disable other
+methods)"| PowerShellGet(["PowerShellGet"])
 Method -->|"parameter
 -UseModuleFast"| ModuleFast(["ModuleFast"])
-Method -->|"parameter
+Method -->|"(Default),
+parameter
 -UsePSResourceGet"| PSResourceGet(["PSResourceGet"])
 PowerShellGet -->|"Invoke-PSDepend"| InvokeRD
 ModuleFast -->|"Install-ModuleFast"| InvokeRD

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ a replacement for PowerShellGet it is possible to enable it in the configuration
 file `Resolve-Dependency.psd1`. It is also possible to allow the repository
 to use PowerShellGet as the default and choose to use PSResourceGet from the
 command line by passing the parameter `UsePSResourceGet` to the build script
-`build.ps1`, e.g. `.\build.ps1 -ResolveDependency -Tasks noop -UseModuleFast`
+`build.ps1`, e.g. `.\build.ps1 -ResolveDependency -Tasks noop -UsePSResourceGet`
 
 If both PSResourceGet and ModuleFast is enabled then PSResource will be
 preferred on Windows PowerShell and PowerShell 7.2 or lower. ModuleFast

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -1,8 +1,8 @@
 @{
     <#
-        This is only required if you need to use PSDepend (using PowerShellGet)
-        It is not required for PSResourceGet or ModuleFast.
-        See Resolve-Dependency.psd1 on how to enable PSResourceGet or ModuleFast.
+        This is only required if you need to use the method PowerShellGet & PSDepend
+        It is not required for PSResourceGet or ModuleFast (and will be ignored).
+        See Resolve-Dependency.psd1 on how to enable methods.
     #>
     # PSDependOptions                = @{
     #     AddToPath  = $true
@@ -25,43 +25,4 @@
     xDscResourceDesigner        = 'latest'
 
     PlatyPS = 'latest'
-
-    # TODO: This need to be documented.
-
-    # PSDepend format is also supported. Must be exactly 9.1.0-preview0002
-
-    'ComputerManagementDsc'                         = @{
-       Version    = '9.1.0-preview0002'
-       Parameters = @{
-           AllowPrerelease = $true
-       }
-    }
-    # PSPKI                          = '3.7.2'
-    # LoopbackAdapter                = 'latest'
-
-
-    # Below Nuget formats are supported for ModuleFast and only when ModuleFastBleedingEdge is set to $true.
-
-    # Must be exactly 9.1.0-preview0002
-    #'ComputerManagementDsc'        = '9.1.0-preview0002'
-    #'ComputerManagementDsc'        = '@9.1.0-preview0002'
-    #'ComputerManagementDsc'        = ':[9.1.0-preview0002]'
-
-    # Must be greater than 9.1.0-preview0002
-    #'ComputerManagementDsc'        = '>9.1.0-preview0002'
-
-    # Must be less than 9.1.0-preview0002
-    #'ComputerManagementDsc'        = '<9.1.0-preview0002'
-
-    # Must be less than or equal to 9.1.0-preview0002
-    #'ComputerManagementDsc'        = '<=9.1.0-preview0002'
-
-    # Must be greater than or equal to 9.1.0-preview0002
-    #'ComputerManagementDsc'        = '>=9.1.0-preview0002'
-
-    # Must be greater than 9.1.0-preview0002
-    #'ComputerManagementDsc'        = ':9.1.0-preview0002'
-
-    # Must be less than 9.1.0-preview0002
-    #'ComputerManagementDsc'        = ':(,9.1.0-preview0002)'
 }

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -39,6 +39,7 @@
     # PSPKI                          = '3.7.2'
     # LoopbackAdapter                = 'latest'
 
+
     # Below Nuget formats are supported for ModuleFast and only when ModuleFastBleedingEdge is set to $true.
 
     # Must be exactly 9.1.0-preview0002

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -30,12 +30,12 @@
 
     # PSDepend format is also supported. Must be exactly 9.1.0-preview0002
 
-    #'ComputerManagementDsc'                         = @{
-    #    Version    = '9.1.0-preview0002'
-    #    Parameters = @{
-    #        AllowPrerelease = $true
-    #    }
-    #}
+    'ComputerManagementDsc'                         = @{
+       Version    = '9.1.0-preview0002'
+       Parameters = @{
+           AllowPrerelease = $true
+       }
+    }
     # PSPKI                          = '3.7.2'
     # LoopbackAdapter                = 'latest'
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -4,13 +4,13 @@
         It is not required for PSResourceGet or ModuleFast (and will be ignored).
         See Resolve-Dependency.psd1 on how to enable methods.
     #>
-    # PSDependOptions                = @{
-    #     AddToPath  = $true
-    #     Target     = 'output\RequiredModules'
-    #     Parameters = @{
-    #         Repository = 'PSGallery'
-    #     }
-    # }
+    #PSDependOptions                = @{
+    #    AddToPath  = $true
+    #    Target     = 'output\RequiredModules'
+    #    Parameters = @{
+    #        Repository = 'PSGallery'
+    #    }
+    #}
 
     InvokeBuild                 = 'latest'
     PSScriptAnalyzer            = 'latest'

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -1,9 +1,16 @@
 @{
-    PSDependOptions             = @{
-        AddToPath  = $true
-        Target     = 'output\RequiredModules'
-        Parameters = @{}
-    }
+    <#
+        This is only required if you need to use PSDepend (using PowerShellGet)
+        It is not required for PSResourceGet or ModuleFast.
+        See Resolve-Dependency.psd1 on how to enable PSResourceGet or ModuleFast.
+    #>
+    # PSDependOptions                = @{
+    #     AddToPath  = $true
+    #     Target     = 'output\RequiredModules'
+    #     Parameters = @{
+    #         Repository = 'PSGallery'
+    #     }
+    # }
 
     InvokeBuild                 = 'latest'
     PSScriptAnalyzer            = 'latest'
@@ -18,4 +25,42 @@
     xDscResourceDesigner        = 'latest'
 
     PlatyPS = 'latest'
+
+    # TODO: This need to be documented.
+
+    # PSDepend format is also supported. Must be exactly 9.1.0-preview0002
+
+    #'ComputerManagementDsc'                         = @{
+    #    Version    = '9.1.0-preview0002'
+    #    Parameters = @{
+    #        AllowPrerelease = $true
+    #    }
+    #}
+    # PSPKI                          = '3.7.2'
+    # LoopbackAdapter                = 'latest'
+
+    # Below Nuget formats are supported for ModuleFast and only when ModuleFastBleedingEdge is set to $true.
+
+    # Must be exactly 9.1.0-preview0002
+    #'ComputerManagementDsc'        = '9.1.0-preview0002'
+    #'ComputerManagementDsc'        = '@9.1.0-preview0002'
+    #'ComputerManagementDsc'        = ':[9.1.0-preview0002]'
+
+    # Must be greater than 9.1.0-preview0002
+    #'ComputerManagementDsc'        = '>9.1.0-preview0002'
+
+    # Must be less than 9.1.0-preview0002
+    #'ComputerManagementDsc'        = '<9.1.0-preview0002'
+
+    # Must be less than or equal to 9.1.0-preview0002
+    #'ComputerManagementDsc'        = '<=9.1.0-preview0002'
+
+    # Must be greater than or equal to 9.1.0-preview0002
+    #'ComputerManagementDsc'        = '>=9.1.0-preview0002'
+
+    # Must be greater than 9.1.0-preview0002
+    #'ComputerManagementDsc'        = ':9.1.0-preview0002'
+
+    # Must be less than 9.1.0-preview0002
+    #'ComputerManagementDsc'        = ':(,9.1.0-preview0002)'
 }

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -810,7 +810,7 @@ try
                             }
                             else
                             {
-                                $modulesToSave += ('{0}@{1}' -f $requiredModule.Name, $requiredModuleVersion)
+                                $modulesToSave += ('{0}[{1}]' -f $requiredModule.Name, $requiredModuleVersion)
                             }
                         }
                         else
@@ -822,13 +822,14 @@ try
                             else
                             {
                                 # Handle different nuget version operators.
-                                if ($requiredModule.Value -match '[@|:|[|(|,|>|<|=]')
+                                if ($requiredModule.Value -match '[:|[|(|,|>|<|=]')
                                 {
                                     $modulesToSave += ('{0}{1}' -f $requiredModule.Name, $requiredModule.Value)
                                 }
                                 else
                                 {
-                                    $modulesToSave += ('{0}@{1}' -f $requiredModule.Name, $requiredModule.Value)
+                                    # Assuming the version is a fixed version.
+                                    $modulesToSave += ('{0}[{1}]' -f $requiredModule.Name, $requiredModule.Value)
                                 }
                             }
                         }

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -206,7 +206,7 @@ if ($UseModuleFast -and $UsePSResourceGet)
     }
 }
 
-if ($UseModuleFast)
+if ($UseModuleFast -and -not (Get-Module -Name 'ModuleFast'))
 {
     try
     {
@@ -214,14 +214,12 @@ if ($UseModuleFast)
 
         if ($ModuleFastBleedingEdge)
         {
-            $moduleFastBootstrapUri = 'bit.ly/modulefastmain' # cSpell: disable-line
+            Write-Information -MessageData 'ModuleFast is configured to use Bleeding Edge (directly from ModuleFast''s main branch).' -InformationAction 'Continue'
 
             $moduleFastBootstrapScriptBlockParameters.UseMain = $true
         }
-        else
-        {
-            $moduleFastBootstrapUri = 'bit.ly/modulefast' # cSpell: disable-line
-        }
+
+        $moduleFastBootstrapUri = 'bit.ly/modulefastmain' # cSpell: disable-line
 
         Write-Debug -Message ('Using bootstrap script at {0}' -f $moduleFastBootstrapUri)
 
@@ -810,7 +808,7 @@ try
                             }
                             else
                             {
-                                $modulesToSave += ('{0}[{1}]' -f $requiredModule.Name, $requiredModuleVersion)
+                                $modulesToSave += ('{0}:[{1}]' -f $requiredModule.Name, $requiredModuleVersion)
                             }
                         }
                         else
@@ -829,7 +827,7 @@ try
                                 else
                                 {
                                     # Assuming the version is a fixed version.
-                                    $modulesToSave += ('{0}[{1}]' -f $requiredModule.Name, $requiredModule.Value)
+                                    $modulesToSave += ('{0}:[{1}]' -f $requiredModule.Name, $requiredModule.Value)
                                 }
                             }
                         }

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -236,7 +236,7 @@ if ($UseModuleFast -and -not (Get-Module -Name 'ModuleFast'))
             Write-Information -MessageData 'ModuleFast is configured to use latest released version.' -InformationAction 'Continue'
         }
 
-        $moduleFastBootstrapUri = 'bit.ly/modulefastmain' # cSpell: disable-line
+        $moduleFastBootstrapUri = 'bit.ly/modulefast' # cSpell: disable-line
 
         Write-Debug -Message ('Using bootstrap script at {0}' -f $moduleFastBootstrapUri)
 

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -786,7 +786,7 @@ try
                         else
                         {
                             # Handle different nuget version operators already present.
-                            if ($requiredModule.Value -match '[:|[|(|,|>|<|=]')
+                            if ($requiredModule.Value -match '[!|:|[|(|,|>|<|=]')
                             {
                                 $modulesToSave += ('{0}{1}' -f $requiredModule.Name, $requiredModule.Value)
                             }

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -55,9 +55,11 @@
         in its GitHub repository. The parameter UseModuleFast must also be set to
         true.
 
-    .PARAMETER PSResourceGet
-        Specifies to use ModuleFast instead of PowerShellGet to resolve dependencies
-        faster.
+    .PARAMETER UsePSResourceGet
+        Specifies to use the new PSResourceGet module instead of the (now legacy) PowerShellGet module.
+
+    .PARAMETER PSResourceGetVersion
+        String specifying the module version for PSResourceGet if the `UsePSResourceGet` switch is utilized.
 
     .NOTES
         Load defaults for parameters values from Resolve-Dependency.psd1 if not
@@ -124,6 +126,10 @@ param
     $ModuleFastBleedingEdge,
 
     [Parameter()]
+    [System.String]
+    $ModuleFastVersion,
+
+    [Parameter()]
     [System.Management.Automation.SwitchParameter]
     $UsePSResourceGet,
 
@@ -187,25 +193,26 @@ catch
     Write-Warning -Message "Error attempting to import Bootstrap's default parameters from '$resolveDependencyConfigPath': $($_.Exception.Message)."
 }
 
-# Handles when both ModuleFast and PSResourceGet is configured or/and passed as parameter.
+# Handle when both ModuleFast and PSResourceGet is configured or/and passed as parameter.
 if ($UseModuleFast -and $UsePSResourceGet)
 {
     Write-Information -MessageData 'Both ModuleFast and PSResourceGet is configured or/and passed as parameter.' -InformationAction 'Continue'
 
-    if ($PSVersionTable.PSVersion -ge '7.2')
+    if ($PSVersionTable.PSVersion -ge '7.3')
     {
         $UsePSResourceGet = $false
 
-        Write-Information -MessageData 'PowerShell 7.2 or higher being used, prefer ModuleFast over PSResourceGet.' -InformationAction 'Continue'
+        Write-Information -MessageData 'PowerShell 7.3 or higher being used, prefer ModuleFast over PSResourceGet.' -InformationAction 'Continue'
     }
     else
     {
         $UseModuleFast = $false
 
-        Write-Information -MessageData 'Older PowerShell or Windows PowerShell being used, prefer PSResourceGet since ModuleFast is not supported on this version of PowerShell.' -InformationAction 'Continue'
+        Write-Information -MessageData 'Windows PowerShell or PowerShell <=7.2 is being used, prefer PSResourceGet since ModuleFast is not supported on this version of PowerShell.' -InformationAction 'Continue'
     }
 }
 
+# Only bootstrao ModuleFast if it is not already imported.
 if ($UseModuleFast -and -not (Get-Module -Name 'ModuleFast'))
 {
     try
@@ -217,6 +224,16 @@ if ($UseModuleFast -and -not (Get-Module -Name 'ModuleFast'))
             Write-Information -MessageData 'ModuleFast is configured to use Bleeding Edge (directly from ModuleFast''s main branch).' -InformationAction 'Continue'
 
             $moduleFastBootstrapScriptBlockParameters.UseMain = $true
+        }
+        elseif($ModuleFastVersion)
+        {
+            Write-Information -MessageData ('ModuleFast is configured to use version {0}.' -f $ModuleFastVersion) -InformationAction 'Continue'
+
+            $moduleFastBootstrapScriptBlockParameters.Release = $ModuleFastVersion
+        }
+        else
+        {
+            Write-Information -MessageData 'ModuleFast is configured to use latest released version.' -InformationAction 'Continue'
         }
 
         $moduleFastBootstrapUri = 'bit.ly/modulefastmain' # cSpell: disable-line
@@ -236,9 +253,10 @@ if ($UseModuleFast -and -not (Get-Module -Name 'ModuleFast'))
     }
     catch
     {
-        Write-Warning -Message ('ModuleFast could not be bootstrapped. Reverting to PowerShellGet. Error: {0}' -f $_.Exception.Message)
+        Write-Warning -Message ('ModuleFast could not be bootstrapped. Reverting to PSResourceGet. Error: {0}' -f $_.Exception.Message)
 
         $UseModuleFast = $false
+        $UsePSResourceGet = $true
     }
 }
 
@@ -249,7 +267,7 @@ if ($UsePSResourceGet)
     # If PSResourceGet was used prior it will be locked and we can't replace it.
     if ((Test-Path -Path "$PSDependTarget/$psResourceGetModuleName" -PathType 'Container') -and (Get-Module -Name $psResourceGetModuleName))
     {
-        Write-Information -MessageData ('{0} is already saved and loaded into the session. To refresh the module open a new session and resolve dependencies again.' -f $psResourceGetModuleName) -InformationAction 'Continue'
+        Write-Information -MessageData ('{0} is already bootstrapped and imported into the session. If there is a need to refresh the module, open a new session and resolve dependencies again.' -f $psResourceGetModuleName) -InformationAction 'Continue'
     }
     else
     {
@@ -261,12 +279,11 @@ if ($UsePSResourceGet)
         {
             if (-not $PSResourceGetVersion)
             {
-                # Default version to use if non is specified in parameter or in configuration.
-                $PSResourceGetVersion = '0.9.0-rc1'
+                # Default version to use if none is passed in parameter or specified in configuration.
+                $PSResourceGetVersion = '1.0.1'
             }
 
             $invokeWebRequestParameters = @{
-                # TODO: This should be hardcoded to a stable release in the future.
                 # TODO: Should support proxy parameters passed to the script.
                 Uri         = "https://www.powershellgallery.com/api/v2/package/$psResourceGetModuleName/$PSResourceGetVersion"
                 OutFile     = "$PSDependTarget/$psResourceGetModuleName.nupkg" # cSpell: ignore nupkg
@@ -362,6 +379,7 @@ if ($UsePSResourceGet)
     }
 }
 
+# Check if legacy PowerShellGet and PSDepend must be bootstrapped.
 if (-not ($UseModuleFast -or $UsePSResourceGet))
 {
     if ($PSVersionTable.PSVersion.Major -le 5)
@@ -488,6 +506,7 @@ if (-not ($UseModuleFast -or $UsePSResourceGet))
 
 try
 {
+    # Check if legacy PowerShellGet and PSDepend must be used.
     if (-not ($UseModuleFast -or $UsePSResourceGet))
     {
         Write-Progress -Activity 'Bootstrap:' -PercentComplete 25 -CurrentOperation 'Checking PowerShellGet'
@@ -709,30 +728,137 @@ try
             $requiredModules = $requiredModules.GetEnumerator() |
                 Where-Object -FilterScript { $_.Name -ne 'PSDependOptions' }
 
-            $modulesToSave = @(
-                'PSDepend' # Always include PSDepend for backward compatibility.
-            )
-
-            <#
-                TODO: When a new version of ModuleFast is released this can be moved
-                      down (refactored) into the logic for PSResourceGet as it is then
-                      no longer needed for ModuleFast. The ModuleFast logic for next
-                      version is the logic inside `ModuleFastBleedingEdge` code-blocks.
-            #>
-            if ($UsePSResourceGet -or ($UseModuleFast -and -not $ModuleFastBleedingEdge))
+            if ($UseModuleFast)
             {
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking ModuleFast'
+
+                Write-Progress -Activity 'ModuleFast:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
+
+                $modulesToSave = @(
+                    'PSDepend'  # Always include PSDepend for backward compatibility.
+                )
+
+                if ($WithYAML)
+                {
+                    $modulesToSave += 'PowerShell-Yaml'
+                }
+
+                foreach ($requiredModule in $requiredModules)
+                {
+                    # If the RequiredModules.psd1 entry is an Hashtable then special handling is needed.
+                    if ($requiredModule.Value -is [System.Collections.Hashtable])
+                    {
+                        if (-not $requiredModule.Value.Version)
+                        {
+                            $requiredModuleVersion = 'latest'
+                        }
+                        else
+                        {
+                            $requiredModuleVersion = $requiredModule.Value.Version
+                        }
+
+                        if ($requiredModuleVersion -eq 'latest')
+                        {
+                            $moduleNameSuffix = ''
+
+                            if ($requiredModule.Value.Parameters.AllowPrerelease -eq $true)
+                            {
+                                <#
+                                    Adding '!' to the module name indicate to ModuleFast
+                                    that is should also evaluate pre-releases.
+                                #>
+                                $moduleNameSuffix = '!'
+                            }
+
+                            $modulesToSave += ('{0}{1}' -f $requiredModule.Name, $moduleNameSuffix)
+                        }
+                        else
+                        {
+                            $modulesToSave += ('{0}:[{1}]' -f $requiredModule.Name, $requiredModuleVersion)
+                        }
+                    }
+                    else
+                    {
+                        if ($requiredModule.Value -eq 'latest')
+                        {
+                            $modulesToSave += $requiredModule.Name
+                        }
+                        else
+                        {
+                            # Handle different nuget version operators already present.
+                            if ($requiredModule.Value -match '[:|[|(|,|>|<|=]')
+                            {
+                                $modulesToSave += ('{0}{1}' -f $requiredModule.Name, $requiredModule.Value)
+                            }
+                            else
+                            {
+                                # Assuming the version is a fixed version.
+                                $modulesToSave += ('{0}:[{1}]' -f $requiredModule.Name, $requiredModule.Value)
+                            }
+                        }
+                    }
+                }
+
+                Write-Debug -Message ("Required modules to retrieve plan for:`n{0}" -f ($modulesToSave | Out-String))
+
+                $installModuleFastParameters = @{
+                    Destination          = $PSDependTarget
+                    DestinationOnly      = $true
+                    NoPSModulePathUpdate = $true
+                    NoProfileUpdate      = $true
+                    Update               = $true
+                    Confirm              = $false
+                }
+
+                $moduleFastPlan = Install-ModuleFast -Specification $modulesToSave -Plan @installModuleFastParameters
+
+                Write-Debug -Message ("Missing modules that need to be saved:`n{0}" -f ($moduleFastPlan | Out-String))
+
+                if ($moduleFastPlan)
+                {
+                    # Clear all modules in plan from the current session so they can be fetched again.
+                    $moduleFastPlan.Name | Get-Module | Remove-Module -Force
+
+                    $moduleFastPlan | Install-ModuleFast @installModuleFastParameters
+                }
+                else
+                {
+                    Write-Verbose -Message 'All required modules were already up to date'
+                }
+
+                Write-Progress -Activity 'ModuleFast:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
+            }
+
+            if ($UsePSResourceGet)
+            {
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking PSResourceGet'
+
+                $modulesToSave = @(
+                    @{
+                        Name = 'PSDepend'  # Always include PSDepend for backward compatibility.
+                    }
+                )
+
+                if ($WithYAML)
+                {
+                    $modulesToSave += @{
+                        Name = 'PowerShell-Yaml'
+                    }
+                }
+
+                # Prepare hashtable that can be concatenated to the Save-PSResource parameters.
                 foreach ($requiredModule in $requiredModules)
                 {
                     # If the RequiredModules.psd1 entry is an Hashtable then special handling is needed.
                     if ($requiredModule.Value -is [System.Collections.Hashtable])
                     {
                         $saveModuleHashtable = @{
-                            ModuleName      = $requiredModule.Name
+                            Name = $requiredModule.Name
                         }
 
                         if ($requiredModule.Value.Version -and $requiredModule.Value.Version -ne 'latest')
                         {
-                            $saveModuleHashtable.RequiredVersion = $requiredModule.Value.Version
+                            $saveModuleHashtable.Version = $requiredModule.Value.Version
                         }
 
                         if ($requiredModule.Value.Parameters.AllowPrerelease -eq $true)
@@ -746,146 +872,25 @@ try
                     {
                         if ($requiredModule.Value -eq 'latest')
                         {
-                            $modulesToSave += $requiredModule.Name
+                            $modulesToSave += @{
+                                Name    = $requiredModule.Name
+                            }
                         }
                         else
                         {
                             $modulesToSave += @{
-                                ModuleName      = $requiredModule.Name
-                                RequiredVersion = $requiredModule.Value
-                            }
-                        }
-                    }
-                }
-            }
-
-            if ($WithYAML -and $modulesToSave -notcontains 'PowerShell-Yaml')
-            {
-                $modulesToSave += 'PowerShell-Yaml'
-            }
-
-            if ($UseModuleFast)
-            {
-                Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking ModuleFast'
-
-                Write-Progress -Activity 'ModuleFast:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
-
-                <#
-                    TODO: When a new version of ModuleFast is released this should
-                          be the default behavior. See also TODO comment above that
-                          need to be refactored.
-                #>
-                if ($ModuleFastBleedingEdge)
-                {
-                    foreach ($requiredModule in $requiredModules)
-                    {
-                        # If the RequiredModules.psd1 entry is an Hashtable then special handling is needed.
-                        if ($requiredModule.Value -is [System.Collections.Hashtable])
-                        {
-                            if (-not $requiredModule.Value.Version)
-                            {
-                                $requiredModuleVersion = 'latest'
-                            }
-                            else
-                            {
-                                $requiredModuleVersion = $requiredModule.Value.Version
-                            }
-
-                            if ($requiredModuleVersion -eq 'latest')
-                            {
-                                $moduleNameSuffix = ''
-
-                                if ($requiredModule.Value.Parameters.AllowPrerelease -eq $true)
-                                {
-                                    <#
-                                        Adding '!' to the module name indicate to ModuleFast
-                                        that is should also evaluate pre-releases.
-                                    #>
-                                    $moduleNameSuffix = '!'
-                                }
-
-                                $modulesToSave += ('{0}{1}' -f $requiredModule.Name, $moduleNameSuffix)
-                            }
-                            else
-                            {
-                                $modulesToSave += ('{0}:[{1}]' -f $requiredModule.Name, $requiredModuleVersion)
-                            }
-                        }
-                        else
-                        {
-                            if ($requiredModule.Value -eq 'latest')
-                            {
-                                $modulesToSave += $requiredModule.Name
-                            }
-                            else
-                            {
-                                # Handle different nuget version operators.
-                                if ($requiredModule.Value -match '[:|[|(|,|>|<|=]')
-                                {
-                                    $modulesToSave += ('{0}{1}' -f $requiredModule.Name, $requiredModule.Value)
-                                }
-                                else
-                                {
-                                    # Assuming the version is a fixed version.
-                                    $modulesToSave += ('{0}:[{1}]' -f $requiredModule.Name, $requiredModule.Value)
-                                }
+                                Name    = $requiredModule.Name
+                                Version = $requiredModule.Value
                             }
                         }
                     }
                 }
 
-                Write-Debug -Message ("Modules required to save:`n{0}" -f ($modulesToSave | Out-String))
-
-                $moduleFastPlan = $modulesToSave | Get-ModuleFastPlan -Update
-
-                Write-Debug -Message ("Modules found missing by Get-ModuleFastPlan:`n{0}" -f ($moduleFastPlan | Out-String))
-
-                if ($moduleFastPlan)
-                {
-                    # Clear all modules in plan from the current session so they can be fetched again.
-                    $moduleFastPlan.Name | Get-Module | Remove-Module -Force
-
-                    $installModuleFastParameters = @{
-                        Destination          = $PSDependTarget
-                        NoPSModulePathUpdate = $true
-                        NoProfileUpdate      = $true
-                        Update               = $true
-                        Confirm              = $false
-                    }
-
-                    <#
-                        TODO: When a new version of ModuleFast is released this should
-                            be the default behavior. See also TODO comment above that
-                            need to be refactored.
-                    #>
-                    if ($ModuleFastBleedingEdge)
-                    {
-                        $installModuleFastParameters.Specification = $modulesToSave
-                    }
-                    else
-                    {
-                        $installModuleFastParameters.ModulesToInstall = $modulesToSave
-                    }
-
-                    Install-ModuleFast @installModuleFastParameters
-                }
-                else
-                {
-                    Write-Verbose -Message 'All modules were already up to date'
-                }
-
-                Write-Progress -Activity 'ModuleFast:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
-            }
-
-            if ($UsePSResourceGet)
-            {
-                Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking PSResourceGet'
+                $percentagePerModule = [System.Math]::Floor(100 / $modulesToSave.Length)
 
                 $progressPercentage = 0
 
                 Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies'
-
-                $percentagePerModule = [System.Math]::Floor(100 / $modulesToSave.Length)
 
                 foreach ($currentModule in $modulesToSave)
                 {
@@ -897,29 +902,13 @@ try
                         Confirm         = $false
                     }
 
-                    if ($currentModule -is [System.Collections.Hashtable])
-                    {
-                        $savePSResourceParameters.Name = $currentModule.ModuleName
-
-                        if ($currentModule.RequiredVersion)
-                        {
-                            $savePSResourceParameters.Version = $currentModule.RequiredVersion
-                        }
-
-                        if ($currentModule.Prerelease)
-                        {
-                            $savePSResourceParameters.Prerelease = $currentModule.Prerelease
-                        }
-                    }
-                    else
-                    {
-                        $savePSResourceParameters.Name = $currentModule
-                    }
+                    # Concatenate the module parameters to the Save-PSResource parameters.
+                    $savePSResourceParameters += $currentModule
 
                     # Modules that Sampler depend on that cannot be refreshed without a new session.
-                    $skipModule = @('powershell-yaml')
+                    $skipModule = @('PowerShell-Yaml')
 
-                    if ($savePSResourceParameters.Name -in $skipModule -and (Get-Module -Name 'powershell-yaml'))
+                    if ($savePSResourceParameters.Name -in $skipModule -and (Get-Module -Name $savePSResourceParameters.Name))
                     {
                         Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies' -Status ('Skipping module {0}' -f $savePSResourceParameters.Name)
 
@@ -960,6 +949,10 @@ try
 
             Write-Progress -Activity 'PSDepend:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
         }
+    }
+    else
+    {
+        Write-Warning -Message "The dependency file '$DependencyFile' could not be found."
     }
 
     Write-Progress -Activity 'Bootstrap:' -PercentComplete 100 -CurrentOperation 'Bootstrap complete' -Completed

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -735,7 +735,7 @@ try
                 Write-Progress -Activity 'ModuleFast:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
 
                 $modulesToSave = @(
-                    'PSDepend'  # Always include PSDepend for backward compatibility.
+                    'PSDepend' # Always include PSDepend for backward compatibility.
                 )
 
                 if ($WithYAML)
@@ -873,7 +873,7 @@ try
                         if ($requiredModule.Value -eq 'latest')
                         {
                             $modulesToSave += @{
-                                Name    = $requiredModule.Name
+                                Name = $requiredModule.Name
                             }
                         }
                         else

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -36,27 +36,40 @@
     WithYAML        = $true # Will also bootstrap PowerShell-Yaml to read other config files
 
     <#
-        Enable ModuleFast to resolve dependencies. Requires PowerShell 7.2 or higher.
-        If this is not configured or set to $false then PowerShellGet and PackageManagement
-        will be used to resolve dependencies.
+        Enable ModuleFast to be the default method of resolving dependencies by setting
+        UseModuleFast to the value $true. ModuleFast requires PowerShell 7.3 or higher.
+        If UseModuleFast is not configured or set to $false then PowerShellGet (or
+        PSResourceGet if enabled) will be used to as the default method of resolving
+        dependencies. You can always use the parameter `-UseModuleFast` of the
+        Resolve-Dependency.ps1 or build.ps1 script even when this is not configured
+        or set to $false.
 
+        You can use ModuleFastVersion to specify a specific version of ModuleFast to use.
+        This will also affect the use of parameter `-UseModuleFast` of the Resolve-Dependency.ps1
+        or build.ps1 script. If ModuleFastVersion is not configured then the latest
+        (non-preview) released version is used.
+
+        ModuleFastBleedingEdge will override ModuleFastVersion and use the absolute latest
+        code from the ModuleFast repository. This is useful if you want to test the absolute
+        latest changes in ModuleFast repository. This is not recommended for production use.
         By enabling ModuleFastBleedingEdge the pipeline can encounter breaking changes or
         problems by code that is merged in the ModuleFast repository, this could affect the
         pipeline negatively. Make sure to use a clean PowerShell session after changing
         the value of ModuleFastBleedingEdge so that ModuleFast uses the correct bootstrap
-        script and correct parameter values. ModuleFastBleedingEdge is disabled by default
-        when using parameter `-UseModuleFast` in the Resolve-Dependency.ps1 or build.ps1
-        script. It can be enabled here so that parameter `-UseModuleFast` use the absolute
-        latest changes in ModuleFast repository.
+        script and correct parameter values. This will also affect the use of parameter
+        `-UseModuleFast` of the Resolve-Dependency.ps1 or build.ps1 script.
     #>
-    #UseModuleFast   = $true
+    #UseModuleFast = $true
+    #ModuleFastVersion = 'v0.1.0-rc1'
     #ModuleFastBleedingEdge = $true
 
-    # Enable PSResourceGet to resolve dependencies. Requires PowerShell 7.2 or higher.
-    # If this is not configured or set to $false then PowerShellGet and PackageManagement
-    # will be used to resolve dependencies.
-    #UsePSResourceGet = $true
-    #PSResourceGetVersion = '1.0.0'
+    <#
+        Enable PSResourceGet to be the default method of resolving dependencies by setting
+        UsePSResourceGet to the value $true. If UsePSResourceGet is not configured or
+        set to $false then PowerShellGet will be used to resolve dependencies.
+    #>
+    UsePSResourceGet = $true
+    PSResourceGetVersion = '1.0.1'
     #UsePowerShellGetCompatibilityModule = $true
     #UsePowerShellGetCompatibilityModuleVersion = '3.0.22-beta22'
 }

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -2,6 +2,10 @@
     <#
         Default parameter values to be loaded by the Resolve-Dependency.ps1 script (unless set in bound parameters
         when calling the script).
+
+        NOTE: To revert to the method PowerShellGet & PSDepend either remove the properties 'UsePSResourceGet' and
+        'UseModuleFast' or set them to $false. Also, in the file RequiredModules.psd1 uncomment the property
+        'PSDependOptions' which is required for PSDepend.
     #>
 
     #PSDependTarget  = './output/modules'

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -44,7 +44,10 @@
         problems by code that is merged in the ModuleFast repository, this could affect the
         pipeline negatively. Make sure to use a clean PowerShell session after changing
         the value of ModuleFastBleedingEdge so that ModuleFast uses the correct bootstrap
-        script and correct parameter values.
+        script and correct parameter values. ModuleFastBleedingEdge is disabled by default
+        when using parameter `-UseModuleFast` in the Resolve-Dependency.ps1 or build.ps1
+        script. It can be enabled here so that parameter `-UseModuleFast` use the absolute
+        latest changes in ModuleFast repository.
     #>
     #UseModuleFast   = $true
     #ModuleFastBleedingEdge = $true

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -35,10 +35,19 @@
     AllowPrerelease = $false
     WithYAML        = $true # Will also bootstrap PowerShell-Yaml to read other config files
 
-    # Enable ModuleFast to resolve dependencies. Requires PowerShell 7.2 or higher.
-    # If this is not configured or set to $false then PowerShellGet and PackageManagement
-    # will be used to resolve dependencies.
+    <#
+        Enable ModuleFast to resolve dependencies. Requires PowerShell 7.2 or higher.
+        If this is not configured or set to $false then PowerShellGet and PackageManagement
+        will be used to resolve dependencies.
+
+        By enabling ModuleFastBleedingEdge the pipeline can encounter breaking changes or
+        problems by code that is merged in the ModuleFast repository, this could affect the
+        pipeline negatively. Make sure to use a clean PowerShell session after changing
+        the value of ModuleFastBleedingEdge so that ModuleFast uses the correct bootstrap
+        script and correct parameter values.
+    #>
     #UseModuleFast   = $true
+    #ModuleFastBleedingEdge = $true
 
     # Enable PSResourceGet to resolve dependencies. Requires PowerShell 7.2 or higher.
     # If this is not configured or set to $false then PowerShellGet and PackageManagement

--- a/Sampler/Templates/Build/RequiredModules.psd1.template
+++ b/Sampler/Templates/Build/RequiredModules.psd1.template
@@ -11,10 +11,10 @@
 <%
     if (-not [System.String]::IsNullOrEmpty($PLASTER_PARAM_CustomRepo)) {
                     # Pull Modules from Custom Repository Name
-"   #         Repository = '$PLASTER_PARAM_CustomRepo'"
+"    #        Repository = '$PLASTER_PARAM_CustomRepo'"
     }
     else {
-"   #         Repository = 'PSGallery'"
+"    #        Repository = 'PSGallery'"
     }
 %>
     #    }

--- a/Sampler/Templates/Build/RequiredModules.psd1.template
+++ b/Sampler/Templates/Build/RequiredModules.psd1.template
@@ -17,8 +17,8 @@
 "   #         Repository = 'PSGallery'"
     }
 %>
-        }
-    }
+    #    }
+    #}
 
     InvokeBuild                 = 'latest'
     PSScriptAnalyzer            = 'latest'

--- a/Sampler/Templates/Build/RequiredModules.psd1.template
+++ b/Sampler/Templates/Build/RequiredModules.psd1.template
@@ -1,15 +1,20 @@
 @{
-    PSDependOptions             = @{
-        AddToPath  = $true
-        Target     = 'output\RequiredModules'
-        Parameters = @{
+    <#
+        This is only required if you need to use the method PowerShellGet & PSDepend
+        It is not required for PSResourceGet or ModuleFast (and will be ignored).
+        See Resolve-Dependency.psd1 on how to enable methods.
+    #>
+    #PSDependOptions             = @{
+    #    AddToPath  = $true
+    #    Target     = 'output\RequiredModules'
+    #    Parameters = @{
 <%
     if (-not [System.String]::IsNullOrEmpty($PLASTER_PARAM_CustomRepo)) {
                     # Pull Modules from Custom Repository Name
-"            Repository = '$PLASTER_PARAM_CustomRepo'"
+"   #         Repository = '$PLASTER_PARAM_CustomRepo'"
     }
     else {
-"            Repository = 'PSGallery'"
+"   #         Repository = 'PSGallery'"
     }
 %>
         }

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -236,7 +236,7 @@ if ($UseModuleFast -and -not (Get-Module -Name 'ModuleFast'))
             Write-Information -MessageData 'ModuleFast is configured to use latest released version.' -InformationAction 'Continue'
         }
 
-        $moduleFastBootstrapUri = 'bit.ly/modulefastmain' # cSpell: disable-line
+        $moduleFastBootstrapUri = 'bit.ly/modulefast' # cSpell: disable-line
 
         Write-Debug -Message ('Using bootstrap script at {0}' -f $moduleFastBootstrapUri)
 

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -735,7 +735,7 @@ try
                 Write-Progress -Activity 'ModuleFast:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
 
                 $modulesToSave = @(
-                    'PSDepend'  # Always include PSDepend for backward compatibility.
+                    'PSDepend' # Always include PSDepend for backward compatibility.
                 )
 
                 if ($WithYAML)
@@ -873,7 +873,7 @@ try
                         if ($requiredModule.Value -eq 'latest')
                         {
                             $modulesToSave += @{
-                                Name    = $requiredModule.Name
+                                Name = $requiredModule.Name
                             }
                         }
                         else

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -50,9 +50,16 @@
         Specifies to use ModuleFast instead of PowerShellGet to resolve dependencies
         faster.
 
-    .PARAMETER PSResourceGet
-        Specifies to use ModuleFast instead of PowerShellGet to resolve dependencies
-        faster.
+    .PARAMETER ModuleFastBleedingEdge
+        Specifies to use ModuleFast code that is in the ModuleFast's main branch
+        in its GitHub repository. The parameter UseModuleFast must also be set to
+        true.
+
+    .PARAMETER UsePSResourceGet
+        Specifies to use the new PSResourceGet module instead of the (now legacy) PowerShellGet module.
+
+    .PARAMETER PSResourceGetVersion
+        String specifying the module version for PSResourceGet if the `UsePSResourceGet` switch is utilized.
 
     .NOTES
         Load defaults for parameters values from Resolve-Dependency.psd1 if not
@@ -113,6 +120,14 @@ param
     [Parameter()]
     [System.Management.Automation.SwitchParameter]
     $UseModuleFast,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $ModuleFastBleedingEdge,
+
+    [Parameter()]
+    [System.String]
+    $ModuleFastVersion,
 
     [Parameter()]
     [System.Management.Automation.SwitchParameter]
@@ -178,54 +193,70 @@ catch
     Write-Warning -Message "Error attempting to import Bootstrap's default parameters from '$resolveDependencyConfigPath': $($_.Exception.Message)."
 }
 
-# Handles when both ModuleFast and PSResourceGet is configured or/and passed as parameter.
+# Handle when both ModuleFast and PSResourceGet is configured or/and passed as parameter.
 if ($UseModuleFast -and $UsePSResourceGet)
 {
     Write-Information -MessageData 'Both ModuleFast and PSResourceGet is configured or/and passed as parameter.' -InformationAction 'Continue'
 
-    if ($PSVersionTable.PSVersion -ge '7.2')
+    if ($PSVersionTable.PSVersion -ge '7.3')
     {
         $UsePSResourceGet = $false
 
-        Write-Information -MessageData 'PowerShell 7.2 or higher being used, prefer ModuleFast over PSResourceGet.' -InformationAction 'Continue'
+        Write-Information -MessageData 'PowerShell 7.3 or higher being used, prefer ModuleFast over PSResourceGet.' -InformationAction 'Continue'
     }
     else
     {
         $UseModuleFast = $false
 
-        Write-Information -MessageData 'Older PowerShell or Windows PowerShell being used, prefer PSResourceGet since ModuleFast is not supported on this version of PowerShell.' -InformationAction 'Continue'
+        Write-Information -MessageData 'Windows PowerShell or PowerShell <=7.2 is being used, prefer PSResourceGet since ModuleFast is not supported on this version of PowerShell.' -InformationAction 'Continue'
     }
 }
 
-if ($UseModuleFast)
+# Only bootstrao ModuleFast if it is not already imported.
+if ($UseModuleFast -and -not (Get-Module -Name 'ModuleFast'))
 {
     try
     {
+        $moduleFastBootstrapScriptBlockParameters = @{}
+
+        if ($ModuleFastBleedingEdge)
+        {
+            Write-Information -MessageData 'ModuleFast is configured to use Bleeding Edge (directly from ModuleFast''s main branch).' -InformationAction 'Continue'
+
+            $moduleFastBootstrapScriptBlockParameters.UseMain = $true
+        }
+        elseif($ModuleFastVersion)
+        {
+            Write-Information -MessageData ('ModuleFast is configured to use version {0}.' -f $ModuleFastVersion) -InformationAction 'Continue'
+
+            $moduleFastBootstrapScriptBlockParameters.Release = $ModuleFastVersion
+        }
+        else
+        {
+            Write-Information -MessageData 'ModuleFast is configured to use latest released version.' -InformationAction 'Continue'
+        }
+
+        $moduleFastBootstrapUri = 'bit.ly/modulefastmain' # cSpell: disable-line
+
+        Write-Debug -Message ('Using bootstrap script at {0}' -f $moduleFastBootstrapUri)
+
         $invokeWebRequestParameters = @{
-            Uri         = 'bit.ly/modulefast' # cSpell: disable-line
+            Uri         = $moduleFastBootstrapUri
             ErrorAction = 'Stop'
         }
 
         $moduleFastBootstrapScript = Invoke-WebRequest @invokeWebRequestParameters
 
-        <#
-            Using this method instead of the one mentioned in the instructions from
-            https://github.com/JustinGrote/ModuleFast to avoid the PSScriptAnalyzer
-            rule PSAvoidUsingInvokeExpression.
-        #>
         $moduleFastBootstrapScriptBlock = [ScriptBlock]::Create($moduleFastBootstrapScript)
 
-        <#
-            We could pass parameters to the bootstrap script when calling Invoke().
-            But currently the default parameter values works just fine.
-        #>
-        $moduleFastBootstrapScriptBlock.Invoke()
+        & $moduleFastBootstrapScriptBlock @moduleFastBootstrapScriptBlockParameters
     }
     catch
     {
-        Write-Warning -Message ('ModuleFast could not be bootstrapped. Reverting to PowerShellGet. Error: {0}' -f $_.Exception.Message)
+        Write-Warning -Message ('ModuleFast could not be bootstrapped. Reverting to PSResourceGet. Error: {0}' -f $_.Exception.Message)
 
         $UseModuleFast = $false
+        $UsePSResourceGet = $true
     }
 }
 
@@ -236,7 +267,7 @@ if ($UsePSResourceGet)
     # If PSResourceGet was used prior it will be locked and we can't replace it.
     if ((Test-Path -Path "$PSDependTarget/$psResourceGetModuleName" -PathType 'Container') -and (Get-Module -Name $psResourceGetModuleName))
     {
-        Write-Information -MessageData ('{0} is already saved and loaded into the session. To refresh the module open a new session and resolve dependencies again.' -f $psResourceGetModuleName) -InformationAction 'Continue'
+        Write-Information -MessageData ('{0} is already bootstrapped and imported into the session. If there is a need to refresh the module, open a new session and resolve dependencies again.' -f $psResourceGetModuleName) -InformationAction 'Continue'
     }
     else
     {
@@ -248,12 +279,11 @@ if ($UsePSResourceGet)
         {
             if (-not $PSResourceGetVersion)
             {
-                # Default version to use if non is specified in parameter or in configuration.
-                $PSResourceGetVersion = '0.9.0-rc1'
+                # Default version to use if none is passed in parameter or specified in configuration.
+                $PSResourceGetVersion = '1.0.1'
             }
 
             $invokeWebRequestParameters = @{
-                # TODO: This should be hardcoded to a stable release in the future.
                 # TODO: Should support proxy parameters passed to the script.
                 Uri         = "https://www.powershellgallery.com/api/v2/package/$psResourceGetModuleName/$PSResourceGetVersion"
                 OutFile     = "$PSDependTarget/$psResourceGetModuleName.nupkg" # cSpell: ignore nupkg
@@ -349,6 +379,7 @@ if ($UsePSResourceGet)
     }
 }
 
+# Check if legacy PowerShellGet and PSDepend must be bootstrapped.
 if (-not ($UseModuleFast -or $UsePSResourceGet))
 {
     if ($PSVersionTable.PSVersion.Major -le 5)
@@ -475,6 +506,7 @@ if (-not ($UseModuleFast -or $UsePSResourceGet))
 
 try
 {
+    # Check if legacy PowerShellGet and PSDepend must be used.
     if (-not ($UseModuleFast -or $UsePSResourceGet))
     {
         Write-Progress -Activity 'Bootstrap:' -PercentComplete 25 -CurrentOperation 'Checking PowerShellGet'
@@ -696,83 +728,102 @@ try
             $requiredModules = $requiredModules.GetEnumerator() |
                 Where-Object -FilterScript { $_.Name -ne 'PSDependOptions' }
 
-            $modulesToSave = @(
-                'PSDepend' # Always include PSDepend for backward compatibility.
-            )
-
-            foreach ($requiredModule in $requiredModules)
-            {
-                # If the RequiredModules.psd1 entry is an Hashtable then special handling is needed.
-                if ($requiredModule.Value -is [System.Collections.Hashtable])
-                {
-                    $saveModuleHashtable = @{
-                        ModuleName      = $requiredModule.Name
-                    }
-
-                    if ($requiredModule.Value.Version -and $requiredModule.Value.Version -ne 'latest')
-                    {
-                        $saveModuleHashtable.RequiredVersion = $requiredModule.Value.Version
-                    }
-
-                    # ModuleFast does no support preview releases yet.
-                    if ($UsePSResourceGet)
-                    {
-                        if ($requiredModule.Value.Parameters.AllowPrerelease -eq $true)
-                        {
-                            $saveModuleHashtable.Prerelease = $true
-                        }
-                    }
-
-                    $modulesToSave += $saveModuleHashtable
-                }
-                else
-                {
-                    if ($requiredModule.Value -eq 'latest')
-                    {
-                        $modulesToSave += $requiredModule.Name
-                    }
-                    else
-                    {
-                        $modulesToSave += @{
-                            ModuleName      = $requiredModule.Name
-                            RequiredVersion = $requiredModule.Value
-                        }
-                    }
-                }
-            }
-
-            if ($WithYAML)
-            {
-                $modulesToSave += 'PowerShell-Yaml'
-            }
-
             if ($UseModuleFast)
             {
                 Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking ModuleFast'
 
                 Write-Progress -Activity 'ModuleFast:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
 
-                $moduleFastPlan = $modulesToSave | Get-ModuleFastPlan
+                $modulesToSave = @(
+                    'PSDepend'  # Always include PSDepend for backward compatibility.
+                )
+
+                if ($WithYAML)
+                {
+                    $modulesToSave += 'PowerShell-Yaml'
+                }
+
+                foreach ($requiredModule in $requiredModules)
+                {
+                    # If the RequiredModules.psd1 entry is an Hashtable then special handling is needed.
+                    if ($requiredModule.Value -is [System.Collections.Hashtable])
+                    {
+                        if (-not $requiredModule.Value.Version)
+                        {
+                            $requiredModuleVersion = 'latest'
+                        }
+                        else
+                        {
+                            $requiredModuleVersion = $requiredModule.Value.Version
+                        }
+
+                        if ($requiredModuleVersion -eq 'latest')
+                        {
+                            $moduleNameSuffix = ''
+
+                            if ($requiredModule.Value.Parameters.AllowPrerelease -eq $true)
+                            {
+                                <#
+                                    Adding '!' to the module name indicate to ModuleFast
+                                    that is should also evaluate pre-releases.
+                                #>
+                                $moduleNameSuffix = '!'
+                            }
+
+                            $modulesToSave += ('{0}{1}' -f $requiredModule.Name, $moduleNameSuffix)
+                        }
+                        else
+                        {
+                            $modulesToSave += ('{0}:[{1}]' -f $requiredModule.Name, $requiredModuleVersion)
+                        }
+                    }
+                    else
+                    {
+                        if ($requiredModule.Value -eq 'latest')
+                        {
+                            $modulesToSave += $requiredModule.Name
+                        }
+                        else
+                        {
+                            # Handle different nuget version operators already present.
+                            if ($requiredModule.Value -match '[!|:|[|(|,|>|<|=]')
+                            {
+                                $modulesToSave += ('{0}{1}' -f $requiredModule.Name, $requiredModule.Value)
+                            }
+                            else
+                            {
+                                # Assuming the version is a fixed version.
+                                $modulesToSave += ('{0}:[{1}]' -f $requiredModule.Name, $requiredModule.Value)
+                            }
+                        }
+                    }
+                }
+
+                Write-Debug -Message ("Required modules to retrieve plan for:`n{0}" -f ($modulesToSave | Out-String))
+
+                $installModuleFastParameters = @{
+                    Destination          = $PSDependTarget
+                    DestinationOnly      = $true
+                    NoPSModulePathUpdate = $true
+                    NoProfileUpdate      = $true
+                    Update               = $true
+                    Confirm              = $false
+                }
+
+                $moduleFastPlan = Install-ModuleFast -Specification $modulesToSave -Plan @installModuleFastParameters
+
+                Write-Debug -Message ("Missing modules that need to be saved:`n{0}" -f ($moduleFastPlan | Out-String))
 
                 if ($moduleFastPlan)
                 {
                     # Clear all modules in plan from the current session so they can be fetched again.
                     $moduleFastPlan.Name | Get-Module | Remove-Module -Force
 
-                    $installModuleFastParameters = @{
-                        ModulesToInstall     = $moduleFastPlan
-                        Destination          = $PSDependTarget
-                        NoPSModulePathUpdate = $true
-                        NoProfileUpdate      = $true
-                        Update               = $true
-                        Confirm              = $false
-                    }
-
-                    Install-ModuleFast @installModuleFastParameters
+                    $moduleFastPlan | Install-ModuleFast @installModuleFastParameters
                 }
                 else
                 {
-                    Write-Verbose -Message 'All modules were already up to date'
+                    Write-Verbose -Message 'All required modules were already up to date'
                 }
 
                 Write-Progress -Activity 'ModuleFast:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
@@ -782,11 +833,64 @@ try
             {
                 Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking PSResourceGet'
 
+                $modulesToSave = @(
+                    @{
+                        Name = 'PSDepend'  # Always include PSDepend for backward compatibility.
+                    }
+                )
+
+                if ($WithYAML)
+                {
+                    $modulesToSave += @{
+                        Name = 'PowerShell-Yaml'
+                    }
+                }
+
+                # Prepare hashtable that can be concatenated to the Save-PSResource parameters.
+                foreach ($requiredModule in $requiredModules)
+                {
+                    # If the RequiredModules.psd1 entry is an Hashtable then special handling is needed.
+                    if ($requiredModule.Value -is [System.Collections.Hashtable])
+                    {
+                        $saveModuleHashtable = @{
+                            Name = $requiredModule.Name
+                        }
+
+                        if ($requiredModule.Value.Version -and $requiredModule.Value.Version -ne 'latest')
+                        {
+                            $saveModuleHashtable.Version = $requiredModule.Value.Version
+                        }
+
+                        if ($requiredModule.Value.Parameters.AllowPrerelease -eq $true)
+                        {
+                            $saveModuleHashtable.Prerelease = $true
+                        }
+
+                        $modulesToSave += $saveModuleHashtable
+                    }
+                    else
+                    {
+                        if ($requiredModule.Value -eq 'latest')
+                        {
+                            $modulesToSave += @{
+                                Name    = $requiredModule.Name
+                            }
+                        }
+                        else
+                        {
+                            $modulesToSave += @{
+                                Name    = $requiredModule.Name
+                                Version = $requiredModule.Value
+                            }
+                        }
+                    }
+                }
+
+                $percentagePerModule = [System.Math]::Floor(100 / $modulesToSave.Length)
+
                 $progressPercentage = 0
 
                 Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies'
-
-                $percentagePerModule = [System.Math]::Floor(100 / $modulesToSave.Length)
 
                 foreach ($currentModule in $modulesToSave)
                 {
@@ -798,29 +902,13 @@ try
                         Confirm         = $false
                     }
 
-                    if ($currentModule -is [System.Collections.Hashtable])
-                    {
-                        $savePSResourceParameters.Name = $currentModule.ModuleName
-
-                        if ($currentModule.RequiredVersion)
-                        {
-                            $savePSResourceParameters.Version = $currentModule.RequiredVersion
-                        }
-
-                        if ($currentModule.Prerelease)
-                        {
-                            $savePSResourceParameters.Prerelease = $currentModule.Prerelease
-                        }
-                    }
-                    else
-                    {
-                        $savePSResourceParameters.Name = $currentModule
-                    }
+                    # Concatenate the module parameters to the Save-PSResource parameters.
+                    $savePSResourceParameters += $currentModule
 
                     # Modules that Sampler depend on that cannot be refreshed without a new session.
-                    $skipModule = @('powershell-yaml')
+                    $skipModule = @('PowerShell-Yaml')
 
-                    if ($savePSResourceParameters.Name -in $skipModule -and (Get-Module -Name 'powershell-yaml'))
+                    if ($savePSResourceParameters.Name -in $skipModule -and (Get-Module -Name $savePSResourceParameters.Name))
                     {
                         Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies' -Status ('Skipping module {0}' -f $savePSResourceParameters.Name)
 
@@ -861,6 +949,10 @@ try
 
             Write-Progress -Activity 'PSDepend:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
         }
+    }
+    else
+    {
+        Write-Warning -Message "The dependency file '$DependencyFile' could not be found."
     }
 
     Write-Progress -Activity 'Bootstrap:' -PercentComplete 100 -CurrentOperation 'Bootstrap complete' -Completed

--- a/Sampler/Templates/Build/Resolve-Dependency.psd1.template
+++ b/Sampler/Templates/Build/Resolve-Dependency.psd1.template
@@ -41,16 +41,41 @@
     AllowPrerelease = $false
     WithYAML        = $true # Will also bootstrap PowerShell-Yaml to read other config files
 
-    # Enable ModuleFast to resolve dependencies. Requires PowerShell 7.2 or higher.
-    # If this is not configured or set to $false then PowerShellGet and PackageManagement
-    # will be used to resolve dependencies.
-    #UseModuleFast   = $true
+    <#
+        Enable ModuleFast to be the default method of resolving dependencies by setting
+        UseModuleFast to the value $true. ModuleFast requires PowerShell 7.3 or higher.
+        If UseModuleFast is not configured or set to $false then PowerShellGet (or
+        PSResourceGet if enabled) will be used to as the default method of resolving
+        dependencies. You can always use the parameter `-UseModuleFast` of the
+        Resolve-Dependency.ps1 or build.ps1 script even when this is not configured
+        or set to $false.
 
-    # Enable PSResourceGet to resolve dependencies. Requires PowerShell 7.2 or higher.
-    # If this is not configured or set to $false then PowerShellGet and PackageManagement
-    # will be used to resolve dependencies.
-    #UsePSResourceGet = $true
-    #PSResourceGetVersion = '1.0.0'
+        You can use ModuleFastVersion to specify a specific version of ModuleFast to use.
+        This will also affect the use of parameter `-UseModuleFast` of the Resolve-Dependency.ps1
+        or build.ps1 script. If ModuleFastVersion is not configured then the latest
+        (non-preview) released version is used.
+
+        ModuleFastBleedingEdge will override ModuleFastVersion and use the absolute latest
+        code from the ModuleFast repository. This is useful if you want to test the absolute
+        latest changes in ModuleFast repository. This is not recommended for production use.
+        By enabling ModuleFastBleedingEdge the pipeline can encounter breaking changes or
+        problems by code that is merged in the ModuleFast repository, this could affect the
+        pipeline negatively. Make sure to use a clean PowerShell session after changing
+        the value of ModuleFastBleedingEdge so that ModuleFast uses the correct bootstrap
+        script and correct parameter values. This will also affect the use of parameter
+        `-UseModuleFast` of the Resolve-Dependency.ps1 or build.ps1 script.
+    #>
+    #UseModuleFast = $true
+    #ModuleFastVersion = 'v0.1.0-rc1'
+    #ModuleFastBleedingEdge = $true
+
+    <#
+        Enable PSResourceGet to be the default method of resolving dependencies by setting
+        UsePSResourceGet to the value $true. If UsePSResourceGet is not configured or
+        set to $false then PowerShellGet will be used to resolve dependencies.
+    #>
+    UsePSResourceGet = $true
+    PSResourceGetVersion = '1.0.1'
     #UsePowerShellGetCompatibilityModule = $true
     #UsePowerShellGetCompatibilityModuleVersion = '3.0.22-beta22'
 }

--- a/build.yaml
+++ b/build.yaml
@@ -18,6 +18,7 @@ Encoding: UTF8
 # Suffix to add to Root module PSM1 after merge (here, the Set-Alias exporting IB tasks)
 suffix: suffix.ps1
 VersionedOutputDirectory: true
+BuiltModuleSubdirectory: builtModule
 
 ####################################################
 #      ModuleBuilder Submodules Configuration      #

--- a/build.yaml
+++ b/build.yaml
@@ -18,7 +18,7 @@ Encoding: UTF8
 # Suffix to add to Root module PSM1 after merge (here, the Set-Alias exporting IB tasks)
 suffix: suffix.ps1
 VersionedOutputDirectory: true
-BuiltModuleSubdirectory: builtModule
+BuiltModuleSubdirectory: module
 
 ####################################################
 #      ModuleBuilder Submodules Configuration      #


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Fixed

- ModuleFast now supports resolving individual pre-release dependencies
  that is part of _RequiredModules.psd1_. This only works when setting the
  parameter value `ModuleFastBleedingEdge` to `$true` in the configuration
  file _Resolve-Dependencies.psd1_. When `ModuleFastBleedingEdge` is enabled
  it is also possible to specify [NuGet version ranges](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges)
  in _RequiredModules.psd1_, although then the file is not compatible with
  PSResourceGet or PSDepend (so no fallback can happen).
- Update PSResourceGet to default to v1.0.1 if no version is passes in parameter
  or specific version is configured.
- Templates was changed to use PSResourceGet as the default method
  of resolving dependencies. It is possible to change to the method
  PowerShellGet & PSDepend by changing the configuration.

Closes #450 
Fixes #445 

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [ ] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [x] Documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/453)
<!-- Reviewable:end -->
