### PR TITLE
Fix bug when `$ChocolateyBuildOutput` is null or empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Now the tasks work when using `Set-SamplerTaskVariable` with tasks that
+  do not have the parameter `ChocolateyBuildOutput`.
+
 ## [0.117.0] - 2023-09-29
 
 ### Added

--- a/Sampler/scripts/Set-SamplerTaskVariable.ps1
+++ b/Sampler/scripts/Set-SamplerTaskVariable.ps1
@@ -91,7 +91,7 @@ $ReleaseNotesPath = Get-SamplerAbsolutePath -Path $ReleaseNotesPath -RelativeTo 
     2 . If it set in build.yaml we use it
     3 . If it set nowhere, we used an empty value
 #>
-if (-not [string]::IsNullOrEmpty($BuiltModuleSubDirectory))
+if (-not [System.String]::IsNullOrEmpty($BuiltModuleSubDirectory))
 {
     $BuiltModuleSubdirectory = Get-SamplerAbsolutePath -Path $BuiltModuleSubDirectory -RelativeTo $OutputDirectory
 }
@@ -106,10 +106,15 @@ else {
 
 "`tBuilt Module Subdirectory  = '$BuiltModuleSubdirectory'"
 
-$ChocolateyBuildOutput = Get-SamplerAbsolutePath -Path $ChocolateyBuildOutput -RelativeTo $OutputDirectory
+$isChocolateyPackage = $false
 
-# If this returns $true then the task Build_Chocolatey_Package created the folder
-$isChocolateyPackage = Test-Path -Path $ChocolateyBuildOutput
+if (-not [System.String]::IsNullOrEmpty($ChocolateyBuildOutput))
+{
+    $ChocolateyBuildOutput = Get-SamplerAbsolutePath -Path $ChocolateyBuildOutput -RelativeTo $OutputDirectory
+
+    # If this returns $true then the task Build_Chocolatey_Package created the folder
+    $isChocolateyPackage = Test-Path -Path $ChocolateyBuildOutput
+}
 
 if ($isChocolateyPackage)
 {


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

After a few hours debugging in DscResource.DocGenerator I found that it was this bug that cause the other variables not to be set to correct values, or no mocks was hit as I was expecting. 🙂 Now off to holiday celebration. 🎄 

### Fixed

- Now the tasks work when using `Set-SamplerTaskVariable` with tasks that
  do not have the parameter `ChocolateyBuildOutput`.

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/454)
<!-- Reviewable:end -->
