### PR TITLE
Switch image for pipeline build phase

### DIFF
--- a/.build/tasks/release.module.build.ps1
+++ b/.build/tasks/release.module.build.ps1
@@ -297,11 +297,13 @@ task package_module_nupkg {
         {
             # Replace the module by first (path & version) resolved in PSModulePath
             $module = Get-Module -ListAvailable -FullyQualifiedName $module | Select-Object -First 1
+
             if ($Prerelease = $module.PrivateData.PSData.Prerelease)
             {
                 $Prerelease = "-" + $Prerelease
             }
-            Write-Build Yellow ("  Packaging Required Module {0} v{1}{2} from path '{3}'" -f $Module.Name, $Module.Version.ToString(), $Prerelease, $module.ModuleBase))
+
+            Write-Build Yellow ("  Packaging Required Module {0} v{1}{2} from path '{3}'" -f $Module.Name, $Module.Version.ToString(), $Prerelease, $module.ModuleBase)
 
             if ($PublishModuleWhatIf)
             {

--- a/.build/tasks/release.module.build.ps1
+++ b/.build/tasks/release.module.build.ps1
@@ -301,12 +301,14 @@ task package_module_nupkg {
             {
                 $Prerelease = "-" + $Prerelease
             }
-            Write-Build Yellow ("  Packaging Required Module {0} v{1}{2}" -f $Module.Name, $Module.Version.ToString(), $Prerelease)
+            Write-Build Yellow ("  Packaging Required Module {0} v{1}{2} from path '{3}'" -f $Module.Name, $Module.Version.ToString(), $Prerelease, $module.ModuleBase))
 
             if ($PublishModuleWhatIf)
             {
                 $PublishModuleParams['WhatIf'] = $True
             }
+
+            Write-Verbose -Message (Get-Command -Name 'Publish-Module' -ErrorAction SilentlyContinue | Out-String) -Verbose
 
             # Release notes will be used from module manifest
             Publish-Module -Repository output -ErrorAction SilentlyContinue -Path $module.ModuleBase

--- a/.build/tasks/release.module.build.ps1
+++ b/.build/tasks/release.module.build.ps1
@@ -310,8 +310,6 @@ task package_module_nupkg {
                 $PublishModuleParams['WhatIf'] = $True
             }
 
-            Write-Verbose -Message (Get-Command -Name 'Publish-Module' -ErrorAction SilentlyContinue | Out-String) -Verbose
-
             # Release notes will be used from module manifest
             Publish-Module -Repository output -ErrorAction SilentlyContinue -Path $module.ModuleBase
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Now if both ModuleFast and PowerShellGet compatibility module is configured
   PSResourceGet is automatically added as a dependency. This is for example
   needed for publishing built module to the gallery.
+- Fix bug using PSResourceGet on the latest updated build workers in
+  Azure Pipelines.
 
 ## [0.117.0] - 2023-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PowerShellGet & PSDepend by changing the configuration. Also default to
   using PowerShellGet v3 which is a compatibility module that is a wrapper
   for the equivalent command in PSResourceGet.
+- Switch to build worker `windows-latest` for the build phase of the pipeline
+  due to a issue using `Publish-Module` on the latest updated build worker in
+  Azure Pipelines.
 
 ### Fixed
 
@@ -41,8 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Now if both ModuleFast and PowerShellGet compatibility module is configured
   PSResourceGet is automatically added as a dependency. This is for example
   needed for publishing built module to the gallery.
-- Fix bug using PSResourceGet on the latest updated build workers in
-  Azure Pipelines.
 
 ## [0.117.0] - 2023-09-29
 

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -72,7 +72,7 @@
         UsePSResourceGet to the value $true. If UsePSResourceGet is not configured or
         set to $false then PowerShellGet will be used to resolve dependencies.
     #>
-    UsePSResourceGet = $false
+    UsePSResourceGet = $true
     PSResourceGetVersion = '1.0.1'
 
     # PowerShellGet compatibility module only works when using PSResourceGet or ModuleFast.

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -72,7 +72,7 @@
         UsePSResourceGet to the value $true. If UsePSResourceGet is not configured or
         set to $false then PowerShellGet will be used to resolve dependencies.
     #>
-    UsePSResourceGet = $true
+    UsePSResourceGet = $false
     PSResourceGetVersion = '1.0.1'
 
     # PowerShellGet compatibility module only works when using PSResourceGet or ModuleFast.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ stages:
       - job: Package_Module
         displayName: 'Package Module'
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: 'windows-latest'
         steps:
           - pwsh: |
               dotnet tool install --global GitVersion.Tool

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ stages:
             displayName: 'Build & Package Module'
             inputs:
               filePath: './build.ps1'
-              arguments: '-ResolveDependency -tasks pack -Verbose -Debug'
+              arguments: '-ResolveDependency -tasks pack'
               pwsh: true
             env:
               ModuleVersion: $(NuGetVersionV2)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ stages:
             displayName: 'Build & Package Module'
             inputs:
               filePath: './build.ps1'
-              arguments: '-ResolveDependency -tasks pack'
+              arguments: '-ResolveDependency -tasks pack -Verbose -Debug'
               pwsh: true
             env:
               ModuleVersion: $(NuGetVersionV2)


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Fixed
- Switch to build worker `windows-latest` for the build phase of the pipeline
  due to a issue using `Publish-Module` on the latest updated build worker in
  Azure Pipelines.

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [ ] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/464)
<!-- Reviewable:end -->
