### PR TITLE
Allow use of GitVersion 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned GitVersion to v5 in the pipeline since v6 is not yet supported, also
   updated templates to pin GitVersion v5. Workaround for issue [#477](https://github.com/gaelcolas/Sampler/issues/477).
 - Fix issue template in repository and Plaster template ([issue #483](https://github.com/gaelcolas/Sampler/issues/483)).
+- Allow use of GitVersion 5 and 6 in pipeline and Get-BuildVersion. Fixes [#477](https://github.com/gaelcolas/Sampler/issues/477)
 
 ## [0.118.1] - 2024-07-20
 

--- a/Sampler/Public/Get-BuildVersion.ps1
+++ b/Sampler/Public/Get-BuildVersion.ps1
@@ -51,7 +51,15 @@ function Get-BuildVersion
         {
             Write-Verbose -Message 'Using the version from GitVersion.'
 
-            $ModuleVersion = (gitversion | ConvertFrom-Json -ErrorAction 'Stop').NuGetVersionV2
+            $gitVersionObject = (gitversion | ConvertFrom-Json -ErrorAction 'Stop')
+
+            $ModuleVersion = '{0}' -f $gitVersionObject.MajorMinorPatch
+
+            if (-not [System.String]::IsNullOrEmpty($gitVersionObject.PreReleaseLabelWithDash))
+            {
+                $ModuleVersion = '{0}{1}{2:D4}' -f $gitVersionObject.MajorMinorPatch, $gitVersionObject.PreReleaseLabelWithDash, [System.Int32]$gitVersionObject.PreReleaseNumber
+            }
+
         }
         elseif (-not [System.String]::IsNullOrEmpty($ModuleManifestPath))
         {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,13 +27,15 @@ stages:
           vmImage: 'windows-latest'
         steps:
           - pwsh: |
-              dotnet tool install --global GitVersion.Tool --version 5.*
+              dotnet tool install --global GitVersion.Tool
               $gitVersionObject = dotnet-gitversion | ConvertFrom-Json
               $gitVersionObject.PSObject.Properties.ForEach{
                   Write-Host -Object "Setting Task Variable '$($_.Name)' with value '$($_.Value)'."
                   Write-Host -Object "##vso[task.setvariable variable=$($_.Name);]$($_.Value)"
               }
+              ##vso[task.setvariable variable=NuGetVersionV2;]$('{0}{1}{2:D4}' -f $gitVersionObject.MajorMinorPatch, $gitVersionObject.PreReleaseLabelWithDash, $gitVersionObject.PreReleaseNumber)
               Write-Host -Object "##vso[build.updatebuildnumber]$($gitVersionObject.FullSemVer)"
+
             displayName: Calculate ModuleVersion (GitVersion)
           - task: PowerShell@2
             name: package

--- a/tests/Unit/Public/Get-BuildVersion.tests.ps1
+++ b/tests/Unit/Public/Get-BuildVersion.tests.ps1
@@ -5,7 +5,7 @@ BeforeAll {
     if (-not (Get-Module -Name $script:moduleName -ListAvailable))
     {
         # Redirect all streams to $null, except the error stream (stream 2)
-        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+        & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
     }
 
     # Re-import the module using force to get any code changes between runs.
@@ -54,7 +54,7 @@ Describe 'Get-BuildVersion' {
                     Mock -CommandName Import-PowerShellDataFile -MockWith {
                         return @{
                             ModuleVersion = '2.1.3'
-                            PrivateData = @{
+                            PrivateData   = @{
                                 PSData = @{
                                     Prerelease = ''
                                 }
@@ -75,7 +75,7 @@ Describe 'Get-BuildVersion' {
                     Mock -CommandName Import-PowerShellDataFile -MockWith {
                         return @{
                             ModuleVersion = '2.1.3'
-                            PrivateData = @{
+                            PrivateData   = @{
                                 PSData = @{
                                     Prerelease = 'preview0023'
                                 }
@@ -116,7 +116,7 @@ Describe 'Get-BuildVersion' {
             Context 'When passing a module version' {
                 BeforeAll {
                     Mock -CommandName gitversion -MockWith {
-                        return '{"NuGetVersionV2": "2.1.3"}'
+                        return '{"MajorMinorPatch": "2.1.3"}'
                     }
                 }
 
@@ -130,7 +130,7 @@ Describe 'Get-BuildVersion' {
             Context 'When passing a preview module version' {
                 BeforeAll {
                     Mock -CommandName gitversion -MockWith {
-                        return '{"NuGetVersionV2": "2.1.3-preview0023"}'
+                        return '{"MajorMinorPatch": "2.1.3","PreReleaseLabelWithDash": "-preview","PreReleaseNumber": "23"}'
                     }
                 }
 
@@ -154,7 +154,7 @@ Describe 'Get-BuildVersion' {
                     Mock -CommandName Import-PowerShellDataFile -MockWith {
                         return @{
                             ModuleVersion = '2.1.3'
-                            PrivateData = @{
+                            PrivateData   = @{
                                 PSData = @{
                                     Prerelease = ''
                                 }
@@ -175,7 +175,7 @@ Describe 'Get-BuildVersion' {
                     Mock -CommandName Import-PowerShellDataFile -MockWith {
                         return @{
                             ModuleVersion = '2.1.3'
-                            PrivateData = @{
+                            PrivateData   = @{
                                 PSData = @{
                                     Prerelease = 'preview0023'
                                 }
@@ -216,7 +216,7 @@ Describe 'Get-BuildVersion' {
             Context 'When passing a module version' {
                 BeforeAll {
                     Mock -CommandName gitversion -MockWith {
-                        return '{"NuGetVersionV2": "2.1.3"}'
+                        return '{"MajorMinorPatch": "2.1.3"}'
                     }
                 }
 
@@ -230,7 +230,7 @@ Describe 'Get-BuildVersion' {
             Context 'When passing a preview module version' {
                 BeforeAll {
                     Mock -CommandName gitversion -MockWith {
-                        return '{"NuGetVersionV2": "2.1.3-preview0023"}'
+                        return '{"MajorMinorPatch": "2.1.3","PreReleaseLabelWithDash": "-preview","PreReleaseNumber": "23"}'
                     }
                 }
 


### PR DESCRIPTION
# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Prepend the title with the [BREAKING CHANGE] if relevant,
    i.e. [BREAKING CHANGE] Add security descriptor property

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.
-->

## Pull Request (PR) description

<!--
    Replace this comment block with a description of your PR to provide context.
    Please be describe the intent and link issue where the problem has been discussed.
    try to link the issue that it fixes by providing the verb and ref: [fix|close #18]

    After the description, please concisely list the changes as per keepachangelog.com
    This **should** duplicate what you've updated in the changelog file.

### Added
- for new features [closes #15]
### Changed
- for changes in existing functionality.
### Deprecated
- for soon-to-be removed features.
### Security
- in case of vulnerabilities.
### Fixed
- for any bug fixes. [fix #52]
### Removed
- for now removed features.
-->

Remove use of NuGetVersionV2 from GitVersion output as this is has been removed in V6. Properties used are available in V5 and V6.

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
