### PR TITLE
Rename `Get-BuildVersion` to `Get-SamplerBuildVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Renamed function `Get-BuildVersion` to `Get-SamplerBuildVersion` to maintain
+  consistency with the module's naming convention and updated all references
+  throughout the codebase ([issue #520](https://github.com/gaelcolas/Sampler/issues/520)).
+
 ### Fixed
 
 - Fixed issue with localization string testing with new version of the HQRM

--- a/Sampler/Public/Get-SamplerBuildVersion.ps1
+++ b/Sampler/Public/Get-SamplerBuildVersion.ps1
@@ -16,10 +16,10 @@
         Provide the Version to be splitted and do not rely on GitVersion or the Module's manifest.
 
     .EXAMPLE
-        Get-BuildVersion -ModuleManifestPath source\MyModule.psd1
+        Get-SamplerBuildVersion -ModuleManifestPath source\MyModule.psd1
 
 #>
-function Get-BuildVersion
+function Get-SamplerBuildVersion
 {
     [CmdletBinding()]
     [OutputType([System.String])]

--- a/Sampler/scripts/Set-SamplerTaskVariable.ps1
+++ b/Sampler/scripts/Set-SamplerTaskVariable.ps1
@@ -144,7 +144,7 @@ if ($AsNewBuild.IsPresent -or $isChocolateyPackage)
         will fetched from GitVersion if it is installed. If GitVersion is _not_
         installed the version is fetched from the module manifest in SourcePath.
     #>
-    $ModuleVersion = Get-BuildVersion @getBuildVersionParameters
+    $ModuleVersion = Get-SamplerBuildVersion @getBuildVersionParameters
 
     "`tModule Version             = '$ModuleVersion'"
 }

--- a/tests/Integration/Tasks/Set-SamplerTaskVariable.Tests.ps1
+++ b/tests/Integration/Tasks/Set-SamplerTaskVariable.Tests.ps1
@@ -69,7 +69,7 @@ Describe 'Set-SamplerTaskVariable' {
                 return (Join-Path -Path $TestDrive -ChildPath 'MyProject/source')
             }
 
-            Mock -CommandName Get-BuildVersion -MockWith {
+            Mock -CommandName Get-SamplerBuildVersion -MockWith {
                 return '1.0.0-preview'
             }
         }

--- a/tests/Unit/Public/Get-SamplerBuildVersion.tests.ps1
+++ b/tests/Unit/Public/Get-SamplerBuildVersion.tests.ps1
@@ -24,11 +24,11 @@ AfterAll {
     Remove-Module -Name $script:moduleName
 }
 
-Describe 'Get-BuildVersion' {
+Describe 'Get-SamplerBuildVersion' {
     Context 'When a value for parameter ModuleVersion is passed' {
         Context 'When passing a module version' {
             It 'Should return the correct module version' {
-                $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive -ModuleVersion '2.1.3'
+                $result = Sampler\Get-SamplerBuildVersion -ModuleManifestPath $TestDrive -ModuleVersion '2.1.3'
 
                 $result | Should -Be '2.1.3'
             }
@@ -36,7 +36,7 @@ Describe 'Get-BuildVersion' {
 
         Context 'When passing a preview module version' {
             It 'Should return the correct module version' {
-                $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive -ModuleVersion '2.1.3-preview0023'
+                $result = Sampler\Get-SamplerBuildVersion -ModuleManifestPath $TestDrive -ModuleVersion '2.1.3-preview0023'
 
                 $result | Should -Be '2.1.3-preview0023'
             }
@@ -64,7 +64,7 @@ Describe 'Get-BuildVersion' {
                 }
 
                 It 'Should return the correct module version' {
-                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive -ModuleVersion ''
+                    $result = Sampler\Get-SamplerBuildVersion -ModuleManifestPath $TestDrive -ModuleVersion ''
 
                     $result | Should -Be '2.1.3'
                 }
@@ -85,7 +85,7 @@ Describe 'Get-BuildVersion' {
                 }
 
                 It 'Should return the correct module version' {
-                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive -ModuleVersion ''
+                    $result = Sampler\Get-SamplerBuildVersion -ModuleManifestPath $TestDrive -ModuleVersion ''
 
                     $result | Should -Be '2.1.3-preview0023'
                 }
@@ -121,7 +121,7 @@ Describe 'Get-BuildVersion' {
                 }
 
                 It 'Should return the correct module version' {
-                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive -ModuleVersion ''
+                    $result = Sampler\Get-SamplerBuildVersion -ModuleManifestPath $TestDrive -ModuleVersion ''
 
                     $result | Should -Be '2.1.3'
                 }
@@ -135,7 +135,7 @@ Describe 'Get-BuildVersion' {
                 }
 
                 It 'Should return the correct module version' {
-                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive -ModuleVersion ''
+                    $result = Sampler\Get-SamplerBuildVersion -ModuleManifestPath $TestDrive -ModuleVersion ''
 
                     $result | Should -Be '2.1.3-preview0023'
                 }
@@ -164,7 +164,7 @@ Describe 'Get-BuildVersion' {
                 }
 
                 It 'Should return the correct module version' {
-                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive
+                    $result = Sampler\Get-SamplerBuildVersion -ModuleManifestPath $TestDrive
 
                     $result | Should -Be '2.1.3'
                 }
@@ -185,7 +185,7 @@ Describe 'Get-BuildVersion' {
                 }
 
                 It 'Should return the correct module version' {
-                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive
+                    $result = Sampler\Get-SamplerBuildVersion -ModuleManifestPath $TestDrive
 
                     $result | Should -Be '2.1.3-preview0023'
                 }
@@ -221,7 +221,7 @@ Describe 'Get-BuildVersion' {
                 }
 
                 It 'Should return the correct module version' {
-                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive
+                    $result = Sampler\Get-SamplerBuildVersion -ModuleManifestPath $TestDrive
 
                     $result | Should -Be '2.1.3'
                 }
@@ -235,7 +235,7 @@ Describe 'Get-BuildVersion' {
                 }
 
                 It 'Should return the correct module version' {
-                    $result = Sampler\Get-BuildVersion -ModuleManifestPath $TestDrive
+                    $result = Sampler\Get-SamplerBuildVersion -ModuleManifestPath $TestDrive
 
                     $result | Should -Be '2.1.3-preview0023'
                 }
@@ -254,7 +254,7 @@ Describe 'Get-BuildVersion' {
             It 'Should throw the correct error' {
                 $mockErrorMessage = "Could not determine the module version because neither GitVersion or a module manifest was present. Please provide the ModuleVersion parameter manually in the file build.yaml with the property 'SemVer:'."
 
-                { Sampler\Get-BuildVersion -ModuleManifestPath $null } | Should -Throw -ExpectedMessage $mockErrorMessage
+                { Sampler\Get-SamplerBuildVersion -ModuleManifestPath $null } | Should -Throw -ExpectedMessage $mockErrorMessage
             }
         }
 
@@ -262,7 +262,7 @@ Describe 'Get-BuildVersion' {
             It 'Should throw the correct error' {
                 $mockErrorMessage = "Could not determine the module version because neither GitVersion or a module manifest was present. Please provide the ModuleVersion parameter manually in the file build.yaml with the property 'SemVer:'."
 
-                { Sampler\Get-BuildVersion -ModuleManifestPath '' } | Should -Throw -ExpectedMessage $mockErrorMessage
+                { Sampler\Get-SamplerBuildVersion -ModuleManifestPath '' } | Should -Throw -ExpectedMessage $mockErrorMessage
             }
         }
     }

--- a/tests/Unit/TestHelpers/MockSetSamplerTaskVariable.ps1
+++ b/tests/Unit/TestHelpers/MockSetSamplerTaskVariable.ps1
@@ -154,6 +154,6 @@ Mock -CommandName Get-Item -MockWith {
 }
 
 # This is only used when calling Set-SamplerTaskVariable with parameter -AsNewBuild
-Mock -CommandName Get-BuildVersion -MockWith {
+Mock -CommandName Get-SamplerBuildVersion -MockWith {
     return '2.0.0'
 }

--- a/tests/Unit/scripts/Set-SamplerTaskVariable.Tests.ps1
+++ b/tests/Unit/scripts/Set-SamplerTaskVariable.Tests.ps1
@@ -57,7 +57,7 @@ Describe 'Set-SamplerTaskVariable' {
                 return (Join-Path -Path $TestDrive -ChildPath (Join-Path -Path 'source' -ChildPath 'MyModule.psd1'))
             }
 
-            Mock -CommandName Get-BuildVersion -MockWith {
+            Mock -CommandName Get-SamplerBuildVersion -MockWith {
                 return '2.0.0'
             }
         }
@@ -109,7 +109,7 @@ Describe 'Set-SamplerTaskVariable' {
                 return $true
             }
 
-            Mock -CommandName Get-BuildVersion -MockWith {
+            Mock -CommandName Get-SamplerBuildVersion -MockWith {
                 return '2.0.0'
             }
         }


### PR DESCRIPTION

# Pull Request

## Pull Request (PR) description

### Changed
- Renamed function `Get-BuildVersion` to `Get-SamplerBuildVersion` to maintain
  consistency with the module's naming convention and updated all references
  throughout the codebase. ([issue #520](https://github.com/gaelcolas/Sampler/issues/520)).

Fixes #520

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
