### PR TITLE
Fixes #519: Use fully-qualified call for `Expand-Archive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Using full-qualified call for `Expand-Archive` ([#519](https://github.com/gaelcolas/Sampler/issues/519)).
+
 ## [0.118.3] - 2025-04-29
 
 ### Changed

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -345,7 +345,7 @@ if ($UsePSResourceGet)
                 Force           = $true
             }
 
-            Expand-Archive @expandArchiveParameters
+            Microsoft.PowerShell.Archive\Expand-Archive @expandArchiveParameters
 
             Remove-Item -Path $psResourceGetZipArchivePath
 

--- a/Sampler/Templates/Build/Resolve-Dependency.ps1
+++ b/Sampler/Templates/Build/Resolve-Dependency.ps1
@@ -345,7 +345,7 @@ if ($UsePSResourceGet)
                 Force           = $true
             }
 
-            Expand-Archive @expandArchiveParameters
+            Microsoft.PowerShell.Archive\Expand-Archive @expandArchiveParameters
 
             Remove-Item -Path $psResourceGetZipArchivePath
 


### PR DESCRIPTION
# Pull Request

This fixes #519 by using a full-qualified call to `Expand-Archive`.

## Pull Request (PR) description

### Fixed
- Using full-qualified call for `Expand-Archive` ([#519](https://github.com/gaelcolas/Sampler/issues/519)).

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/524)
<!-- Reviewable:end -->
