### PR TITLE
Fixed a variable scoping issue preventing Pester tests to be invoked after the first build (#523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Using full-qualified call for `Expand-Archive` ([#519](https://github.com/gaelcolas/Sampler/issues/519)).
-- Fixed a variable scoping issue preventing Pester tests to be invoked after the first build ([#523](https://github.com/gaelcolas/Sampler/issues/523)).
+- Fixed a variable scoping issue preventing Pester tests to be invoked after the
+  first build ([#523](https://github.com/gaelcolas/Sampler/issues/523)).
 
 ## [0.118.3] - 2025-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Using full-qualified call for `Expand-Archive` ([#519](https://github.com/gaelcolas/Sampler/issues/519)).
+- Fixed a variable scoping issue preventing Pester tests to be invoked after the first build ([#523](https://github.com/gaelcolas/Sampler/issues/523)).
 
 ## [0.118.3] - 2025-04-29
 

--- a/Sampler/Templates/Build/build.ps1
+++ b/Sampler/Templates/Build/build.ps1
@@ -296,14 +296,17 @@ process
 
                     foreach ($TaskToExport in $BuildInfo['ModuleBuildTasks'].($module))
                     {
-                        $loadedModule.ExportedAliases.GetEnumerator().Where{
-                            Write-Host -Object "`t Loading $($_.Key)..." -ForegroundColor DarkGray
-
+                        $aliasTasks = $loadedModule.ExportedAliases.GetEnumerator().Where{
                             # Using -like to support wildcard.
                             $_.Key -like $TaskToExport
-                        }.ForEach{
+                        }
+
+                        foreach ($aliasTask in $aliasTasks)
+                        {
+                            Write-Host -Object "`t Loading $($aliasTask.Key)..." -ForegroundColor DarkGray
+
                             # Dot-sourcing the Tasks via their exported aliases.
-                            . (Get-Alias $_.Key)
+                            . (Get-Alias $aliasTask.Key)
                         }
                     }
                 }

--- a/build.ps1
+++ b/build.ps1
@@ -305,14 +305,17 @@ process
 
                     foreach ($TaskToExport in $BuildInfo['ModuleBuildTasks'].($module))
                     {
-                        $loadedModule.ExportedAliases.GetEnumerator().Where{
-                            Write-Host -Object "`t Loading $($_.Key)..." -ForegroundColor DarkGray
-
+                        $aliasTasks = $loadedModule.ExportedAliases.GetEnumerator().Where{
                             # Using -like to support wildcard.
                             $_.Key -like $TaskToExport
-                        }.ForEach{
+                        }
+
+                        foreach ($aliasTask in $aliasTasks)
+                        {
+                            Write-Host -Object "`t Loading $($aliasTask.Key)..." -ForegroundColor DarkGray
+
                             # Dot-sourcing the Tasks via their exported aliases.
-                            . (Get-Alias $_.Key)
+                            . (Get-Alias $aliasTask.Key)
                         }
                     }
                 }


### PR DESCRIPTION
… tests are invoked correctly

# Pull Request

Fixed a variable scoping issue preventing Pester tests to be invoked after the first build. InvokeBuild uses the `$_` variable when resolving properties. When the build runs a second time, this leads to InvokeBuild reading the variable value from the wrong scope. More details in #523.

## Pull Request (PR) description

### Fixed
- Fixed a variable scoping issue preventing Pester tests to be invoked after the first build ([#523](https://github.com/gaelcolas/Sampler/issues/523)).

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
