### PR TITLE
Fixes a scoping issue preventing running Pester tests (#527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using full-qualified call for `Expand-Archive` ([#519](https://github.com/gaelcolas/Sampler/issues/519)).
 - Fixed a variable scoping issue preventing Pester tests to be invoked after the
   first build ([#523](https://github.com/gaelcolas/Sampler/issues/523)).
+- Fixed another variable scoping issue preventing Pester tests to be invoked
+- after the first build ([#527](https://github.com/gaelcolas/Sampler/issues/527)).
 
 ## [0.118.3] - 2025-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a variable scoping issue preventing Pester tests to be invoked after the
   first build ([#523](https://github.com/gaelcolas/Sampler/issues/523)).
 - Fixed another variable scoping issue preventing Pester tests to be invoked
-- after the first build ([#527](https://github.com/gaelcolas/Sampler/issues/527)).
+  after the first build ([#527](https://github.com/gaelcolas/Sampler/issues/527)).
 
 ## [0.118.3] - 2025-04-29
 

--- a/Sampler/Templates/Build/build.ps1
+++ b/Sampler/Templates/Build/build.ps1
@@ -320,12 +320,13 @@ process
         }
 
         # Loading Build Tasks defined in the .build/ folder (will override the ones imported above if same task name).
-        Get-ChildItem -Path '.build/' -Recurse -Include '*.ps1' -ErrorAction Ignore |
-            ForEach-Object {
-                "Importing file $($_.BaseName)" | Write-Verbose
+        $taskFiles = Get-ChildItem -Path '.build/' -Recurse -Include '*.ps1' -ErrorAction Ignore
+        foreach ($taskFile in $taskFiles)
+        {
+            "Importing file $($taskFile.BaseName)" | Write-Verbose
 
-                . $_.FullName
-            }
+            . $taskFile.FullName
+        }
 
         # Synopsis: Empty task, useful to test the bootstrap process.
         task noop { }

--- a/build.ps1
+++ b/build.ps1
@@ -329,12 +329,13 @@ process
         }
 
         # Loading Build Tasks defined in the .build/ folder (will override the ones imported above if same task name).
-        Get-ChildItem -Path '.build/' -Recurse -Include '*.ps1' -ErrorAction Ignore |
-            ForEach-Object {
-                "Importing file $($_.BaseName)" | Write-Verbose
+        $taskFiles = Get-ChildItem -Path '.build/' -Recurse -Include '*.ps1' -ErrorAction Ignore
+        foreach ($taskFile in $taskFiles)
+        {
+            "Importing file $($taskFile.BaseName)" | Write-Verbose
 
-                . $_.FullName
-            }
+            . $taskFile.FullName
+        }
 
         # Synopsis: Empty task, useful to test the bootstrap process.
         task noop { }


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Fixed
- Fixed another variable scoping issue preventing Pester tests to be invoked after the first build ([#527](https://github.com/gaelcolas/Sampler/issues/527)).

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
