### PR TITLE
style: Typo in build.ps1. Standardized usage or Write-* cmdlets.

### DIFF
--- a/.build/tasks/Build-Module.ModuleBuilder.build.ps1
+++ b/.build/tasks/Build-Module.ModuleBuilder.build.ps1
@@ -418,7 +418,7 @@ Task Build_DscResourcesToExport_ModuleBuilder {
     {
         if (-not $ModuleInfo.ContainsKey('DscResourcesToExport'))
         {
-            Write-Error "Cannot add 'DscResourcesToExport' to the module manifest because the key is not present. Please add it manually to the '*.psd1' file in the source."
+            Write-Error -Message "Cannot add 'DscResourcesToExport' to the module manifest because the key is not present. Please add it manually to the '*.psd1' file in the source."
         }
 
         Write-Build -Color Green -Text "Updating the Module Manifest's DscResourcesToExport key..."

--- a/.build/tasks/GuestConfig.build.ps1
+++ b/.build/tasks/GuestConfig.build.ps1
@@ -159,7 +159,7 @@ task build_guestconfiguration_packages {
             {
                 # Write non-terminating errors that are not "A second CIM class definition for .... was found..."
                 $false
-                Write-Error $_ -ErrorAction Continue
+                Write-Error -Message $_ -ErrorAction Continue
             }
             else
             {

--- a/.build/tasks/JaCoCo.coverage.build.ps1
+++ b/.build/tasks/JaCoCo.coverage.build.ps1
@@ -201,13 +201,13 @@ function Start-CodeCoverageMerge
 
     if (Confirm-CodeCoverageFileFormat -CodeCovFile $targetDocument)
     {
-        Write-Verbose "Successfully imported $($firstFile.Name) as a baseline"
+        Write-Verbose -Message "Successfully imported $($firstFile.Name) as a baseline"
 
         $merged = 0
         foreach ($file in $otherFiles)
         {
             [xml]$mergeDocument = Get-Content -Path $file.FullName -Raw
-            Write-Verbose "Merging $($file.Name) into baseline"
+            Write-Verbose -Message "Merging $($file.Name) into baseline"
             if (Confirm-CodeCoverageFileFormat -CodeCovFile $mergeDocument)
             {
                 $targetDocument = Merge-JaCoCoReport -OriginalDocument $targetDocument -MergeDocument $mergeDocument
@@ -215,11 +215,11 @@ function Start-CodeCoverageMerge
             }
             else
             {
-                Write-Verbose "The following code coverage file is not using the JaCoCo format: $($file.Name)"
+                Write-Verbose -Message "The following code coverage file is not using the JaCoCo format: $($file.Name)"
             }
         }
 
-        Write-Verbose "Merge completed: Successfully merged $merged files into the baseline"
+        Write-Verbose -Message "Merge completed: Successfully merged $merged files into the baseline"
 
         $targetDocument = Update-JaCoCoStatistic -Document $targetDocument
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   first build ([#523](https://github.com/gaelcolas/Sampler/issues/523)).
 - Fixed another variable scoping issue preventing Pester tests to be invoked
   after the first build ([#527](https://github.com/gaelcolas/Sampler/issues/527)).
+- Fixed typo in build.ps1 and added missing descriptions to parameters.
+
+### Changed
+
+- The use of Write-* cmdlets has been standardized to a consistent style with named parameters (-Message and -Object).
 
 ## [0.118.3] - 2025-04-29
 

--- a/Sampler/Public/Add-Sample.ps1
+++ b/Sampler/Public/Add-Sample.ps1
@@ -213,7 +213,7 @@ function Add-Sample
         }
         catch
         {
-            Write-Warning "Error processing Dynamic Parameters. $($_.Exception.Message)"
+            Write-Warning -Message "Error processing Dynamic Parameters. $($_.Exception.Message)"
         }
         finally
         {

--- a/Sampler/Public/Get-Psm1SchemaName.ps1
+++ b/Sampler/Public/Get-Psm1SchemaName.ps1
@@ -39,11 +39,11 @@ function Get-Psm1SchemaName
 
         if ($configurations.Count -ne 1)
         {
-            Write-Error "It is expected to find only 1 configuration in the file '$Path' but found $($configurations.Count)"
+            Write-Error -Message "It is expected to find only 1 configuration in the file '$Path' but found $($configurations.Count)"
         }
         else
         {
-            Write-Verbose "Found Configuration '$($configurations[0].InstanceName)'"
+            Write-Verbose -Message "Found Configuration '$($configurations[0].InstanceName)'"
             $configurations[0].InstanceName.Value
         }
     }

--- a/Sampler/Public/New-SamplerPipeline.ps1
+++ b/Sampler/Public/New-SamplerPipeline.ps1
@@ -195,7 +195,7 @@ function New-SamplerPipeline
         }
         catch
         {
-            Write-Warning "Error processing Dynamic Parameters. $($_.Exception.Message)"
+            Write-Warning -Message "Error processing Dynamic Parameters. $($_.Exception.Message)"
         }
         finally
         {

--- a/Sampler/Public/Set-SamplerPSModulePath.ps1
+++ b/Sampler/Public/Set-SamplerPSModulePath.ps1
@@ -102,62 +102,62 @@ function Set-SamplerPSModulePath
     $newModulePath = $newModulePath -split $pathSeparator |
         Select-Object -Unique |
             Where-Object { $_ }
-    Write-Verbose "`t...The 'PSModulePath' has $($newModulePath.Count) paths"
-    Write-Debug "The 'PSModulePath' is '$newModulePath'"
+    Write-Verbose -Message "`t...The 'PSModulePath' has $($newModulePath.Count) paths"
+    Write-Debug -Message "The 'PSModulePath' is '$newModulePath'"
 
     if ($RemovePersonal)
     {
         $newModulePath = $newModulePath -notmatch '.+Documents.(Windows)?PowerShell.Modules'
-        Write-Verbose "`t...Removing Personal from 'PSModulePath'"
+        Write-Verbose -Message "`t...Removing Personal from 'PSModulePath'"
     }
 
     if ($RemoveProgramFiles)
     {
         $newModulePath = $newModulePath -notmatch '.+Program Files.(Windows)?PowerShell.(7.)?Modules'
-        Write-Verbose "`t...Removing Program Files from 'PSModulePath'"
+        Write-Verbose -Message "`t...Removing Program Files from 'PSModulePath'"
     }
 
     if ($RemoveWindows)
     {
         $newModulePath = $newModulePath -ne 'C:\Windows\system32\WindowsPowerShell\v1.0\Modules'
-        Write-Warning "It is not recommended to remove the Windows 'PSModulePath'"
-        Write-Verbose "`t...Removing Windows from 'PSModulePath'"
+        Write-Warning -Message "It is not recommended to remove the Windows 'PSModulePath'"
+        Write-Verbose -Message "`t...Removing Windows from 'PSModulePath'"
     }
-    Write-Verbose "`t...The 'PSModulePath' has $($newModulePath.Count) paths"
-    Write-Debug "The 'PSModulePath' is '$newModulePath'"
+    Write-Verbose -Message "`t...The 'PSModulePath' has $($newModulePath.Count) paths"
+    Write-Debug -Message "The 'PSModulePath' is '$newModulePath'"
 
     if ($RequiredModulesDirectory)
     {
         if ($newModulePath -contains $RequiredModulesDirectory)
         {
-            Write-Verbose "`t...Removing RequiredModulesDirectory from 'PSModulePath'"
+            Write-Verbose -Message "`t...Removing RequiredModulesDirectory from 'PSModulePath'"
             $newModulePath = $newModulePath -ne $RequiredModulesDirectory
         }
-        Write-Verbose "`t...Adding 'RequiredModulesDirectory' to 'PSModulePath'"
+        Write-Verbose -Message "`t...Adding 'RequiredModulesDirectory' to 'PSModulePath'"
         $newModulePath = @($RequiredModulesDirectory) + $newModulePath
     }
     else
     {
-        Write-Warning "The parameter 'RequiredModulesDirectory' is not set"
+        Write-Warning -Message "The parameter 'RequiredModulesDirectory' is not set"
     }
 
     if ($BuiltModuleSubdirectory)
     {
         if ($newModulePath -contains $BuiltModuleSubdirectory)
         {
-            Write-Verbose "`t...Removing BuiltModuleSubdirectory from 'PSModulePath'"
+            Write-Verbose -Message "`t...Removing BuiltModuleSubdirectory from 'PSModulePath'"
             $newModulePath = $newModulePath -ne $BuiltModuleSubdirectory
         }
-        Write-Verbose "`t...Adding 'BuiltModuleSubdirectory' to 'PSModulePath'"
+        Write-Verbose -Message "`t...Adding 'BuiltModuleSubdirectory' to 'PSModulePath'"
         $newModulePath = @($BuiltModuleSubdirectory) + $newModulePath
     }
     else
     {
-        Write-Warning "The parameter 'BuiltModuleSubdirectory' is not set"
+        Write-Warning -Message "The parameter 'BuiltModuleSubdirectory' is not set"
     }
 
     $newModulePath = $newModulePath -join $pathSeparator
-    Write-Verbose "`t...Writing '`$env:PSModulePath' variable"
+    Write-Verbose -Message "`t...Writing '`$env:PSModulePath' variable"
 
     if ($PSCmdlet.ShouldProcess($env:PSModulePath, "Set PSModulePath to '$newModulePath'"))
     {

--- a/Sampler/Public/Update-JaCoCoStatistic.ps1
+++ b/Sampler/Public/Update-JaCoCoStatistic.ps1
@@ -43,7 +43,7 @@ function Update-JaCoCoStatistic
         $Document
     )
 
-    Write-Verbose "Start updating statistics!"
+    Write-Verbose -Message "Start updating statistics!"
 
     $totalInstructionCovered = 0
     $totalInstructionMissed = 0
@@ -56,7 +56,7 @@ function Update-JaCoCoStatistic
 
     foreach ($oPackage in $Document.report.package)
     {
-        Write-Verbose "Processing package $($oPackage.name)"
+        Write-Verbose -Message "Processing package $($oPackage.name)"
 
         $packageInstructionCovered = 0
         $packageInstructionMissed = 0
@@ -76,7 +76,7 @@ function Update-JaCoCoStatistic
             $classMethodCovered = 0
             $classMethodMissed = 0
 
-            Write-Verbose "  Processing sourcefile $($oPackageClass.sourcefilename)"
+            Write-Verbose -Message "  Processing sourcefile $($oPackageClass.sourcefilename)"
             $oPackageSourcefile = $oPackage.sourcefile | Where-Object -FilterScript { $_.Name -eq $oPackageClass.sourcefilename }
 
             for ($i = 0; $i -lt ([array]($oPackageClass.method)).Count; $i++)
@@ -93,7 +93,7 @@ function Update-JaCoCoStatistic
                 if ($i -ne ($currentMethod.Count - 1))
                 {
                     $end   = $currentMethod[$i+1].Line
-                    Write-Verbose "    Processing method: $($currentMethod[$i].Name)"
+                    Write-Verbose -Message "    Processing method: $($currentMethod[$i].Name)"
                     [array]$coll = $oPackageSourcefile.line | Where-Object {
                         [int]$_.nr -ge $start -and [int]$_.nr -lt $end
                     }
@@ -111,7 +111,7 @@ function Update-JaCoCoStatistic
                 }
                 else
                 {
-                    Write-Verbose "    Processing method: $($currentMethod[$i].Name)"
+                    Write-Verbose -Message "    Processing method: $($currentMethod[$i].Name)"
                     [array]$coll = $oPackageSourcefile.line | Where-Object {
                         [int]$_.nr -ge $start
                     }
@@ -159,12 +159,12 @@ function Update-JaCoCoStatistic
                 $counterMethod.missed = [string]$methodMissed
 
 
-                Write-Verbose "      Method Instruction Covered : $methodInstructionCovered"
-                Write-Verbose "      Method Instruction Missed  : $methodInstructionMissed"
-                Write-Verbose "      Method Line Covered        : $methodLineCovered"
-                Write-Verbose "      Method Line Missed         : $methodLineMissed"
-                Write-Verbose "      Method Covered             : $methodCovered"
-                Write-Verbose "      Method Missed              : $methodMissed"
+                Write-Verbose -Message "      Method Instruction Covered : $methodInstructionCovered"
+                Write-Verbose -Message "      Method Instruction Missed  : $methodInstructionMissed"
+                Write-Verbose -Message "      Method Line Covered        : $methodLineCovered"
+                Write-Verbose -Message "      Method Line Missed         : $methodLineMissed"
+                Write-Verbose -Message "      Method Covered             : $methodCovered"
+                Write-Verbose -Message "      Method Missed              : $methodMissed"
             }
 
             $packageInstructionCovered += $classInstructionCovered
@@ -225,12 +225,12 @@ function Update-JaCoCoStatistic
             $counterMethod.covered = [string]$classClassCovered
             $counterMethod.missed = [string]$classClassMissed
 
-            Write-Verbose "      Class Instruction Covered  : $classInstructionCovered"
-            Write-Verbose "      Class Instruction Missed   : $classInstructionMissed"
-            Write-Verbose "      Class Line Covered         : $classLineCovered"
-            Write-Verbose "      Class Line Missed          : $classLineMissed"
-            Write-Verbose "      Class Method Covered       : $classMethodCovered"
-            Write-Verbose "      Class Method Missed        : $classMethodMissed"
+            Write-Verbose -Message "      Class Instruction Covered  : $classInstructionCovered"
+            Write-Verbose -Message "      Class Instruction Missed   : $classInstructionMissed"
+            Write-Verbose -Message "      Class Line Covered         : $classLineCovered"
+            Write-Verbose -Message "      Class Line Missed          : $classLineMissed"
+            Write-Verbose -Message "      Class Method Covered       : $classMethodCovered"
+            Write-Verbose -Message "      Class Method Missed        : $classMethodMissed"
         }
 
         $totalInstructionCovered += $packageInstructionCovered
@@ -259,14 +259,14 @@ function Update-JaCoCoStatistic
         $counterClass.covered = [string]$packageClassCovered
         $counterClass.missed = [string]$packageClassMissed
 
-        Write-Verbose "  Package Instruction Covered: $packageInstructionCovered"
-        Write-Verbose "  Package Instruction Missed : $packageInstructionMissed"
-        Write-Verbose "  Package Line Covered       : $packageLineCovered"
-        Write-Verbose "  Package Line Missed        : $packageLineMissed"
-        Write-Verbose "  Package Method Covered     : $packageMethodCovered"
-        Write-Verbose "  Package Method Missed      : $packageMethodMissed"
-        Write-Verbose "  Package Class Covered      : $packageClassCovered"
-        Write-Verbose "  Package Class Missed       : $packageClassMissed"
+        Write-Verbose -Message "  Package Instruction Covered: $packageInstructionCovered"
+        Write-Verbose -Message "  Package Instruction Missed : $packageInstructionMissed"
+        Write-Verbose -Message "  Package Line Covered       : $packageLineCovered"
+        Write-Verbose -Message "  Package Line Missed        : $packageLineMissed"
+        Write-Verbose -Message "  Package Method Covered     : $packageMethodCovered"
+        Write-Verbose -Message "  Package Method Missed      : $packageMethodMissed"
+        Write-Verbose -Message "  Package Class Covered      : $packageClassCovered"
+        Write-Verbose -Message "  Package Class Missed       : $packageClassMissed"
     }
 
     #Update Total stats
@@ -286,20 +286,20 @@ function Update-JaCoCoStatistic
     $counterClass.covered = [string]$totalClassCovered
     $counterClass.missed = [string]$totalClassMissed
 
-    Write-Verbose "----------------------------------------"
-    Write-Verbose " Totals"
-    Write-Verbose "----------------------------------------"
-    Write-Verbose "  Total Instruction Covered : $totalInstructionCovered"
-    Write-Verbose "  Total Instruction Missed  : $totalInstructionMissed"
-    Write-Verbose "  Total Line Covered        : $totalLineCovered"
-    Write-Verbose "  Total Line Missed         : $totalLineMissed"
-    Write-Verbose "  Total Method Covered      : $totalMethodCovered"
-    Write-Verbose "  Total Method Missed       : $totalMethodMissed"
-    Write-Verbose "  Total Class Covered       : $totalClassCovered"
-    Write-Verbose "  Total Class Missed        : $totalClassMissed"
-    Write-Verbose "----------------------------------------"
+    Write-Verbose -Message "----------------------------------------"
+    Write-Verbose -Message " Totals"
+    Write-Verbose -Message "----------------------------------------"
+    Write-Verbose -Message "  Total Instruction Covered : $totalInstructionCovered"
+    Write-Verbose -Message "  Total Instruction Missed  : $totalInstructionMissed"
+    Write-Verbose -Message "  Total Line Covered        : $totalLineCovered"
+    Write-Verbose -Message "  Total Line Missed         : $totalLineMissed"
+    Write-Verbose -Message "  Total Method Covered      : $totalMethodCovered"
+    Write-Verbose -Message "  Total Method Missed       : $totalMethodMissed"
+    Write-Verbose -Message "  Total Class Covered       : $totalClassCovered"
+    Write-Verbose -Message "  Total Class Missed        : $totalClassMissed"
+    Write-Verbose -Message "----------------------------------------"
 
-    Write-Verbose "Completed merging files and updating statistics!"
+    Write-Verbose -Message "Completed merging files and updating statistics!"
 
     return $Document
 }

--- a/Sampler/Sampler.psm1
+++ b/Sampler/Sampler.psm1
@@ -22,7 +22,7 @@ foreach ($import in @($Public + $Private))
 {
     try
     {
-        Write-Verbose "Importing $($Import.FullName)"
+        Write-Verbose -Message "Importing $($Import.FullName)"
         . $import.FullName
     }
     catch

--- a/Sampler/Templates/Build/build.ps1
+++ b/Sampler/Templates/Build/build.ps1
@@ -497,7 +497,7 @@ begin
             {
                 $paramValue = $MyInvocation.BoundParameters.Item($cmdParameter)
 
-                Write-Debug " adding  $cmdParameter :: $paramValue [from user-provided parameters to Build.ps1]"
+                Write-Debug -Message " adding  $cmdParameter :: $paramValue [from user-provided parameters to Build.ps1]"
 
                 $resolveDependencyParams.Add($cmdParameter, $paramValue)
             }
@@ -508,7 +508,7 @@ begin
 
                 if ($paramValue)
                 {
-                    Write-Debug " adding  $cmdParameter :: $paramValue [from default Build.ps1 variable]"
+                    Write-Debug -Message " adding  $cmdParameter :: $paramValue [from default Build.ps1 variable]"
 
                     $resolveDependencyParams.Add($cmdParameter, $paramValue)
                 }

--- a/Sampler/Templates/ChocolateyPackage/myPackage/tools/chocolateyinstall.ps1
+++ b/Sampler/Templates/ChocolateyPackage/myPackage/tools/chocolateyinstall.ps1
@@ -141,7 +141,7 @@ Install-ChocolateyPackage @packageArgs # https://chocolatey.org/docs/helpers-ins
 ## [DEPRECATING] PORTABLE EXAMPLE
 #$binRoot = Get-BinRoot
 #$installDir = Join-Path $binRoot "$packageName"
-#Write-Host "Adding `'$installDir`' to the path and the current shell path"
+#Write-Host -Object "Adding `'$installDir`' to the path and the current shell path"
 #Install-ChocolateyPath "$installDir"
 #$env:Path = "$($env:Path);$installDir"
 

--- a/Sampler/Templates/ChocolateyPackage/myPackage/tools/chocolateyuninstall.ps1
+++ b/Sampler/Templates/ChocolateyPackage/myPackage/tools/chocolateyuninstall.ps1
@@ -73,7 +73,7 @@ if ($key.Count -eq 1)
 }
 elseif ($key.Count -eq 0)
 {
-    Write-Warning "$packageName has already been uninstalled by other means."
+    Write-Warning -Message "$packageName has already been uninstalled by other means."
 }
 elseif ($key.Count -gt 1)
 {

--- a/Sampler/Templates/PublicFunction/Get-Something.ps1.template
+++ b/Sampler/Templates/PublicFunction/Get-Something.ps1.template
@@ -35,7 +35,7 @@ function <%= $PLASTER_PARAM_PublicFunctionName %>
     {
         if ($pscmdlet.ShouldProcess($Data))
         {
-            Write-Verbose ('Returning the data: {0}' -f $Data)
+            Write-Verbose -Message ('Returning the data: {0}' -f $Data)
 <%
             if ($PLASTER_PARAM_PrivateFunctionName)
             {
@@ -49,7 +49,7 @@ function <%= $PLASTER_PARAM_PublicFunctionName %>
         }
         else
         {
-            Write-Verbose 'oh dear'
+            Write-Verbose -Message 'oh dear'
         }
     }
 }

--- a/Sampler/Templates/Sampler/Get-Something.ps1
+++ b/Sampler/Templates/Sampler/Get-Something.ps1
@@ -30,12 +30,12 @@ function Get-Something
     {
         if ($pscmdlet.ShouldProcess($Data))
         {
-            Write-Verbose ('Returning the data: {0}' -f $Data)
+            Write-Verbose -Message ('Returning the data: {0}' -f $Data)
             Get-PrivateFunction -PrivateData $Data
         }
         else
         {
-            Write-Verbose 'oh dear'
+            Write-Verbose -Message 'oh dear'
         }
     }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,7 @@
         The default value is '' (empty string).
 
     .PARAMETER BuildConfig
-        Not yet written.
+        Path to a file with configuration. Supported extensions : psd1, yaml, yml, json, jsonc
 
     .PARAMETER OutputDirectory
         Specifies the folder to build the artefact into. The default value is 'output'.
@@ -22,7 +22,7 @@
     .PARAMETER RequiredModulesDirectory
         Can be a path (relative to $PSScriptRoot or absolute) to tell Resolve-Dependency
         and PSDepend where to save the required modules. It is also possible to use
-        'CurrentUser' och 'AllUsers' to install missing dependencies. You can override
+        'CurrentUser' or 'AllUsers' to install missing dependencies. You can override
         the value for PSDepend in the Build.psd1 build manifest. The default value is
         'output/RequiredModules'.
 
@@ -49,13 +49,13 @@
         used in the DscResource.Test.build.ps1 tasks.
 
     .PARAMETER ResolveDependency
-        Not yet written.
+        Resolve missing dependencies.
 
     .PARAMETER BuildInfo
         The build info object from ModuleBuilder. Defaults to an empty hashtable.
 
     .PARAMETER AutoRestore
-        Not yet written.
+        Specifies to restore the required modules by running build.ps1 with ResolveDependency switch and empty task `noop`.
 
     .PARAMETER UseModuleFast
         Specifies to use ModuleFast instead of PowerShellGet to resolve dependencies
@@ -506,7 +506,7 @@ begin
             {
                 $paramValue = $MyInvocation.BoundParameters.Item($cmdParameter)
 
-                Write-Debug " adding  $cmdParameter :: $paramValue [from user-provided parameters to Build.ps1]"
+                Write-Debug -Message " adding  $cmdParameter :: $paramValue [from user-provided parameters to Build.ps1]"
 
                 $resolveDependencyParams.Add($cmdParameter, $paramValue)
             }
@@ -517,7 +517,7 @@ begin
 
                 if ($paramValue)
                 {
-                    Write-Debug " adding  $cmdParameter :: $paramValue [from default Build.ps1 variable]"
+                    Write-Debug -Message " adding  $cmdParameter :: $paramValue [from default Build.ps1 variable]"
 
                     $resolveDependencyParams.Add($cmdParameter, $paramValue)
                 }

--- a/tests/Integration/Tasks/Set-SamplerTaskVariable.Tests.ps1
+++ b/tests/Integration/Tasks/Set-SamplerTaskVariable.Tests.ps1
@@ -97,7 +97,7 @@ Describe 'Set-SamplerTaskVariable' {
             #>
             $result = . Sampler\Set-SamplerTaskVariable -AsNewBuild
 
-            Write-Debug ($result | Out-String) -Verbose
+            Write-Debug -Message ($result | Out-String) -Verbose
 
             $result | Should -Contain "`tProject Name               = 'MyProject'"
             $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
@@ -120,7 +120,7 @@ Describe 'Set-SamplerTaskVariable' {
             It 'Should return the expected output' {
                 $result = . Sampler\Set-SamplerTaskVariable -AsNewBuild
 
-                Write-Debug ($result | Out-String) -Verbose
+                Write-Debug -Message ($result | Out-String) -Verbose
 
                 $result | Should -Contain "`tProject Name               = 'MyProject'"
                 $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
@@ -150,7 +150,7 @@ Describe 'Set-SamplerTaskVariable' {
             It 'Should return the expected output' {
                 $result = . Sampler\Set-SamplerTaskVariable -AsNewBuild -Verbose
 
-                Write-Debug ($result | Out-String) -Verbose
+                Write-Debug -Message ($result | Out-String) -Verbose
 
                 $result | Should -Contain "`tProject Name               = 'MyProject'"
                 $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
@@ -180,7 +180,7 @@ Describe 'Set-SamplerTaskVariable' {
             It 'Should return the expected output' {
                 $result = . Sampler\Set-SamplerTaskVariable -AsNewBuild
 
-                Write-Debug ($result | Out-String) -Verbose
+                Write-Debug -Message ($result | Out-String) -Verbose
 
                 $result | Should -Contain "`tProject Name               = 'MyProject'"
                 $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
@@ -289,7 +289,7 @@ Describe 'Set-SamplerTaskVariable' {
             #>
             $result = . Sampler\Set-SamplerTaskVariable
 
-            Write-Debug ($result | Out-String) -Verbose
+            Write-Debug -Message ($result | Out-String) -Verbose
 
             $result | Should -Contain "`tProject Name               = 'MyProject'"
             $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
@@ -327,7 +327,7 @@ Describe 'Set-SamplerTaskVariable' {
                 #>
                 $result = . Sampler\Set-SamplerTaskVariable
 
-                Write-Debug ($result | Out-String) -Verbose
+                Write-Debug -Message ($result | Out-String) -Verbose
 
                 $result | Should -Contain "`tProject Name               = 'MyProject'"
                 $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
@@ -372,7 +372,7 @@ Describe 'Set-SamplerTaskVariable' {
                 #>
                 $result = . Sampler\Set-SamplerTaskVariable -Verbose
 
-                Write-Debug ($result | Out-String) -Verbose
+                Write-Debug -Message ($result | Out-String) -Verbose
 
                 $result | Should -Contain "`tProject Name               = 'MyProject'"
                 $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))
@@ -417,7 +417,7 @@ Describe 'Set-SamplerTaskVariable' {
                 #>
                 $result = . Sampler\Set-SamplerTaskVariable
 
-                Write-Debug ($result | Out-String) -Verbose
+                Write-Debug -Message ($result | Out-String) -Verbose
 
                 $result | Should -Contain "`tProject Name               = 'MyProject'"
                 $result | Should -Contain ("`tSource Path                = '{0}'" -f (Join-Path -Path $TestDrive -ChildPath 'MyProject/source'))


### PR DESCRIPTION
# Pull Request
At first, I attempted to [make changes](https://github.com/dsccommunity/DnsServerDsc/pull/289) directly in the [DnsServerDsc](https://github.com/dsccommunity/DnsServerDsc) repository, but it was suggested that fixing the issues in the original Sampler module would be more appropriate.

While preparing the PR to address the errors and missing parameter descriptions, I also noticed some inconsistencies in the usage of -Message and -Object parameters in Write-* cmdlets.
I hope this improvement will be well-received.

## Pull Request (PR) description

### Changed
- The use of Write-* cmdlets has been standardized to a consistent style with named parameters (-Message and -Object).

### Fixed
- Fixed typo in build.ps1 and added missing descriptions to parameters.

## Task list

- [ ] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
