### PR TITLE
Fixed issue with changelog check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added DocGenerator tasks and configuration to `build.yaml` [#468](https://github.com/gaelcolas/Sampler/issues/468).
   - Updated HQRM task to use Pester 5 version.
 - Fix QA tests failing with latest version of DscResource.Test.
+- Fixed issue with changelog check under certain conditions
 
 ### Changed
 

--- a/Sampler/Templates/Sampler/module.tests.ps1.template
+++ b/Sampler/Templates/Sampler/module.tests.ps1.template
@@ -80,12 +80,13 @@ if ($PLASTER_PARAM_UseGit -eq 'true')
             that required files are changed.
         #>
 
+        $filesChanged = @()
         # Only run if there is a remote called origin
         if (((git remote) -match 'origin'))
         {
             $headCommit = &git rev-parse HEAD
             $defaultBranchCommit = &git rev-parse origin/main
-            $filesChanged = (&git @('diff', "$defaultBranchCommit...$headCommit", '--name-only') |
+            $filesChanged += (&git @('diff', "$defaultBranchCommit...$headCommit", '--name-only') |
                 Where-Object { $_ -match "^$escapedGitRelatedModulePath" }) -replace "^$escapedGitRelatedModulePath", ""
         }
 

--- a/tests/QA/module.tests.ps1
+++ b/tests/QA/module.tests.ps1
@@ -60,9 +60,10 @@ Describe 'Changelog Management' -Tag 'Changelog' {
             [bool](&(Get-Process -Id $PID).Path -NoProfile -Command 'git rev-parse --is-inside-work-tree 2>$null'))
     ) {
         # Get the list of changed files compared with branch main
+        $filesChanged = @()
         $headCommit = &git rev-parse HEAD
         $defaultBranchCommit = &git rev-parse origin/main
-        $filesChanged = &git @('diff', "$defaultBranchCommit...$headCommit", '--name-only')
+        $filesChanged += &git @('diff', "$defaultBranchCommit...$headCommit", '--name-only')
         $filesStagedAndUnstaged = &git @('diff', 'HEAD', '--name-only')
 
         $filesChanged += $filesStagedAndUnstaged


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

If only one file is changed, it returns an object instead of an array of object, which means the filesChanged gets mangled and doesn't work correctly in the Should -Contain 'CHANGELOG.md' check

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
