### PR TITLE
Docs: add optional reproducibility helpers (run manifest + folder compare)

### DIFF
--- a/Tools/Repro/README.md
+++ b/Tools/Repro/README.md
@@ -1,0 +1,35 @@
+# Reproducibility helpers (optional)
+
+Small, additive helpers for capturing run metadata and comparing output folders.
+
+## New-RunManifest.ps1
+
+Writes `manifest.json` to an output directory (tool/run id/inputs + host info + optional git metadata).
+
+Example:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File Tools/Repro/New-RunManifest.ps1 `
+  -OutDir "./out/run_001" `
+  -ToolName "Sampler" `
+  -RunId "run_001" `
+  -Inputs @{ task="build"; configuration="Release" } `
+  -RepoPath "./"
+```
+
+## Compare-RunFolders.ps1
+
+Compares two folders using SHA256 + size per file and writes `compare_report.json` + `compare_report.md`.
+
+Example:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File Tools/Repro/Compare-RunFolders.ps1 `
+  -A "./out/run_001" `
+  -B "./out/run_002" `
+  -OutDir "./out/compare_001_002"
+```
+
+---
+
+Related: https://github.com/vgplatformproject


### PR DESCRIPTION
This PR adds **optional**, **additive** reproducibility helpers under Tools/Repro/:

- New-RunManifest.ps1: writes a small manifest.json per run (tool/run id/inputs + host info + optional git metadata).
- Compare-RunFolders.ps1: compares two output folders via SHA256+size and produces compare_report.json + compare_report.md.
- README.md: usage examples.

These helpers help detect silent drift and make baseline comparisons repeatable, without changing existing tasks or workflows.

Related (provenance): https://github.com/vgplatformproject

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/556)
<!-- Reviewable:end -->
