### PR TITLE
Add argument completer for `Build.ps1 -Tasks` to enable tab-expansion of task names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `BuildWorkflow:` block up to the next root-level key and tracks brace
   depth so it correctly handles in-yaml scriptblock values (single- or
   multi-line, including nested braces) without picking up identifiers from
-  inside the scriptblock body. The completer is self-contained and works in a
-  fresh clone before `Resolve-Dependency` has ever run.
+  inside the scriptblock body. The task-discovery regex anchors the captured
+  name to a real word boundary, so identifiers that only happen to appear
+  after the literal text `task ` inside a comment block (for example a
+  `task parameter $foo` description in comment-based help) are no longer
+  surfaced as completion candidates. The completer is self-contained and
+  works in a fresh clone before `Resolve-Dependency` has ever run.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `copilot-instructions.md` documenting build/test/quality commands, the mandatory `./build.ps1` entry point, high-level architecture, key conventions (changelog discipline, `-ErrorAction 'Ignore'` preference, cross-platform/cross-version PS5.1+PS7 support), guidance for running long builds without hanging the agent shell (always tee output to a log file), and how to extract test failures from the Pester NUnit XML and HQRM CliXml result files.
   - Per-area `instructions/*.instructions.md` files for public functions, private functions, Plaster templates, build tasks, and Pester tests.
   - `agents/sampler-maintainer.md` agent definition and the `skills/validate-changes` skill that picks the smallest useful test scope and surfaces XML-based failure diagnostics.
+- Tab-completion for the `-Tasks` parameter of the scaffolded `Build.ps1`.
+  Candidates include the Invoke-Build `?` help token, tasks defined under
+  `./.build/**/*.ps1`, tasks imported from modules under
+  `./output/RequiredModules/**/*.build.ps1`, and workflow aliases declared
+  under `BuildWorkflow:` in `build.yaml`. The completer is self-contained and
+  works in a fresh clone before `Resolve-Dependency` has ever run.
 
 ### Changed
 
@@ -993,7 +999,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed #192 where the `Build-Module` command from module builder returns
-  a rooted path (sometimes). 
+  a rooted path (sometimes).
 
 ## [0.107.0] - 2020-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Per-area `instructions/*.instructions.md` files for public functions, private functions, Plaster templates, build tasks, and Pester tests.
   - `agents/sampler-maintainer.md` agent definition and the `skills/validate-changes` skill that picks the smallest useful test scope and surfaces XML-based failure diagnostics.
 - Tab-completion for the `-Tasks` parameter of the scaffolded `Build.ps1`.
-  Candidates include the Invoke-Build `?` help token, tasks defined under
-  `./.build/**/*.ps1`, tasks imported from modules under
-  `./output/RequiredModules/**/*.build.ps1`, and workflow aliases declared
-  under `BuildWorkflow:` in `build.yaml`. The completer is self-contained and
-  works in a fresh clone before `Resolve-Dependency` has ever run.
+  Candidates include workflow aliases declared under `BuildWorkflow:` in
+  `build.yaml`, tasks defined under `./.build/**/*.ps1`, tasks imported from
+  modules under `./output/RequiredModules/**/*.build.ps1`, and the Invoke-Build
+  `?` help token. Candidates are emitted in YAML / file declaration order
+  (workflow aliases first, then individual tasks). The YAML parser extracts
+  the `BuildWorkflow:` block up to the next root-level key and tracks brace
+  depth so it correctly handles in-yaml scriptblock values (single- or
+  multi-line, including nested braces) without picking up identifiers from
+  inside the scriptblock body. The completer is self-contained and works in a
+  fresh clone before `Resolve-Dependency` has ever run.
 
 ### Changed
 

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDelivery
-next-version: 0.90
+next-version: 0.90.0
 major-version-bump-message: '\s?(breaking|major|breaking\schange)'
 minor-version-bump-message: '(adds?|features?|minor)\b'
 patch-version-bump-message: '\s?(fix|patch)'

--- a/Sampler/Templates/Build/build.ps1
+++ b/Sampler/Templates/Build/build.ps1
@@ -100,32 +100,18 @@ param
             $localBuildDir = Join-Path -Path $scriptRoot -ChildPath '.build'
             if (Test-Path -Path $localBuildDir)
             {
-                foreach ($file in Get-ChildItem -Path $localBuildDir -Filter '*.ps1' -Recurse -ErrorAction SilentlyContinue)
-                {
-                    foreach ($line in Get-Content -LiteralPath $file.FullName -ErrorAction SilentlyContinue)
-                    {
-                        if ($line -match $taskRegex)
-                        {
-                            [void] $tasks.Add($Matches[1])
-                        }
-                    }
-                }
+                Get-ChildItem -Path $localBuildDir -Filter '*.ps1' -Recurse -ErrorAction SilentlyContinue |
+                    Select-String -Pattern $taskRegex -ErrorAction SilentlyContinue |
+                    ForEach-Object { [void] $tasks.Add($_.Matches[0].Groups[1].Value) }
             }
 
             # Tasks imported from Sampler and related modules (*.build.ps1 files)
             $modulesDir = Join-Path -Path $scriptRoot -ChildPath 'output/RequiredModules'
             if (Test-Path -Path $modulesDir)
             {
-                foreach ($file in Get-ChildItem -Path $modulesDir -Filter '*.build.ps1' -Recurse -ErrorAction SilentlyContinue)
-                {
-                    foreach ($line in Get-Content -LiteralPath $file.FullName -ErrorAction SilentlyContinue)
-                    {
-                        if ($line -match $taskRegex)
-                        {
-                            [void] $tasks.Add($Matches[1])
-                        }
-                    }
-                }
+                Get-ChildItem -Path $modulesDir -Filter '*.build.ps1' -Recurse -ErrorAction SilentlyContinue |
+                    Select-String -Pattern $taskRegex -ErrorAction SilentlyContinue |
+                    ForEach-Object { [void] $tasks.Add($_.Matches[0].Groups[1].Value) }
             }
 
             # Workflow aliases defined under BuildWorkflow in build.yaml

--- a/Sampler/Templates/Build/build.ps1
+++ b/Sampler/Templates/Build/build.ps1
@@ -75,6 +75,95 @@
 param
 (
     [Parameter(Position = 0)]
+    [ArgumentCompleter({
+            param ($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+            # $PSScriptRoot is not reliable inside an ArgumentCompleter script block;
+            # derive the script root defensively, falling back to the current location.
+            $scriptRoot = if ($PSCommandPath)
+            {
+                Split-Path -Path $PSCommandPath -Parent
+            }
+            else
+            {
+                $PWD.Path
+            }
+
+            $tasks = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+            # Built-in Invoke-Build help token
+            [void] $tasks.Add('?')
+
+            $taskRegex = '^\s*task\s+[''"]?([A-Za-z_][\w\.\-]*)'
+
+            # Tasks defined in the local '.build' directory
+            $localBuildDir = Join-Path -Path $scriptRoot -ChildPath '.build'
+            if (Test-Path -Path $localBuildDir)
+            {
+                foreach ($file in Get-ChildItem -Path $localBuildDir -Filter '*.ps1' -Recurse -ErrorAction SilentlyContinue)
+                {
+                    foreach ($line in Get-Content -LiteralPath $file.FullName -ErrorAction SilentlyContinue)
+                    {
+                        if ($line -match $taskRegex)
+                        {
+                            [void] $tasks.Add($Matches[1])
+                        }
+                    }
+                }
+            }
+
+            # Tasks imported from Sampler and related modules (*.build.ps1 files)
+            $modulesDir = Join-Path -Path $scriptRoot -ChildPath 'output/RequiredModules'
+            if (Test-Path -Path $modulesDir)
+            {
+                foreach ($file in Get-ChildItem -Path $modulesDir -Filter '*.build.ps1' -Recurse -ErrorAction SilentlyContinue)
+                {
+                    foreach ($line in Get-Content -LiteralPath $file.FullName -ErrorAction SilentlyContinue)
+                    {
+                        if ($line -match $taskRegex)
+                        {
+                            [void] $tasks.Add($Matches[1])
+                        }
+                    }
+                }
+            }
+
+            # Workflow aliases defined under BuildWorkflow in build.yaml
+            $buildYaml = Join-Path -Path $scriptRoot -ChildPath 'build.yaml'
+            if (Test-Path -Path $buildYaml)
+            {
+                $inWorkflow = $false
+                foreach ($line in Get-Content -LiteralPath $buildYaml -ErrorAction SilentlyContinue)
+                {
+                    if ($line -match '^BuildWorkflow\s*:')
+                    {
+                        $inWorkflow = $true
+                        continue
+                    }
+
+                    if ($inWorkflow)
+                    {
+                        # Exit the BuildWorkflow block as soon as a new top-level key is encountered
+                        if ($line -match '^\S')
+                        {
+                            break
+                        }
+
+                        if ($line -match '^\s{2}["'']?([^"''\s:#][^:]*?)["'']?\s*:\s*$')
+                        {
+                            [void] $tasks.Add($Matches[1])
+                        }
+                    }
+                }
+            }
+
+            $tasks |
+                Where-Object { $_ -like "$wordToComplete*" } |
+                Sort-Object |
+                ForEach-Object {
+                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+                }
+        })]
     [System.String[]]
     $Tasks = '.',
 

--- a/Sampler/Templates/Build/build.ps1
+++ b/Sampler/Templates/Build/build.ps1
@@ -183,7 +183,16 @@ param
                 }
             }
 
-            $taskRegex = '^\s*task\s+[''"]?([A-Za-z_][\w\.\-]*)'
+            # Match an Invoke-Build task declaration:
+            #   task <Name> ...
+            # The lookahead anchors the end of the captured name to a real
+            # word-boundary so we don't truncate longer identifiers (e.g.
+            # 'parameter' inside a comment) into spurious matches like
+            # 'paramete'. What may follow a real task name:
+            #   * optional whitespace then a syntax char  ({  (  ,  @  -  #  '  "  )
+            #   * mandatory whitespace then a word char   (next Job string)
+            #   * end-of-line                             (rare but legal)
+            $taskRegex = '^\s*task\s+[''"]?(?<name>[A-Za-z_][\w\.\-]*)[''"]?(?=\s*[{(,@\-#''"]|\s+\w|\s*$)'
 
             # 2. Tasks defined in the local '.build' directory.
             $localBuildDir = Join-Path -Path $scriptRoot -ChildPath '.build'
@@ -192,7 +201,7 @@ param
                 Get-ChildItem -Path $localBuildDir -Filter '*.ps1' -Recurse -ErrorAction Ignore |
                     Select-String -Pattern $taskRegex -ErrorAction Ignore |
                     ForEach-Object {
-                        $name = $_.Matches[0].Groups[1].Value
+                        $name = $_.Matches[0].Groups['name'].Value
 
                         if ($name -and -not $tasks.Contains($name))
                         {
@@ -208,7 +217,7 @@ param
                 Get-ChildItem -Path $modulesDir -Filter '*.build.ps1' -Recurse -ErrorAction Ignore |
                     Select-String -Pattern $taskRegex -ErrorAction Ignore |
                     ForEach-Object {
-                        $name = $_.Matches[0].Groups[1].Value
+                        $name = $_.Matches[0].Groups['name'].Value
 
                         if ($name -and -not $tasks.Contains($name))
                         {

--- a/Sampler/Templates/Build/build.ps1
+++ b/Sampler/Templates/Build/build.ps1
@@ -76,7 +76,23 @@ param
 (
     [Parameter(Position = 0)]
     [ArgumentCompleter({
-            param ($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+            param
+            (
+                [Parameter()]
+                $commandName,
+
+                [Parameter()]
+                $parameterName,
+
+                [Parameter()]
+                $wordToComplete,
+
+                [Parameter()]
+                $commandAst,
+
+                [Parameter()]
+                $fakeBoundParameters
+            )
 
             # $PSScriptRoot is not reliable inside an ArgumentCompleter script block;
             # derive the script root defensively, falling back to the current location.
@@ -89,63 +105,127 @@ param
                 $PWD.Path
             }
 
-            $tasks = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            # Use an ordered hashtable so YAML / file declaration order is preserved
+            # (case-insensitive deduplication via Contains lookup).
+            $tasks = [ordered] @{ }
 
-            # Built-in Invoke-Build help token
-            [void] $tasks.Add('?')
-
-            $taskRegex = '^\s*task\s+[''"]?([A-Za-z_][\w\.\-]*)'
-
-            # Tasks defined in the local '.build' directory
-            $localBuildDir = Join-Path -Path $scriptRoot -ChildPath '.build'
-            if (Test-Path -Path $localBuildDir)
-            {
-                Get-ChildItem -Path $localBuildDir -Filter '*.ps1' -Recurse -ErrorAction SilentlyContinue |
-                    Select-String -Pattern $taskRegex -ErrorAction SilentlyContinue |
-                    ForEach-Object { [void] $tasks.Add($_.Matches[0].Groups[1].Value) }
-            }
-
-            # Tasks imported from Sampler and related modules (*.build.ps1 files)
-            $modulesDir = Join-Path -Path $scriptRoot -ChildPath 'output/RequiredModules'
-            if (Test-Path -Path $modulesDir)
-            {
-                Get-ChildItem -Path $modulesDir -Filter '*.build.ps1' -Recurse -ErrorAction SilentlyContinue |
-                    Select-String -Pattern $taskRegex -ErrorAction SilentlyContinue |
-                    ForEach-Object { [void] $tasks.Add($_.Matches[0].Groups[1].Value) }
-            }
-
-            # Workflow aliases defined under BuildWorkflow in build.yaml
+            # 1. Workflow aliases declared under BuildWorkflow in build.yaml.
+            #    These are the high-level entry points users typically tab-complete
+            #    to (build, docs, pack, ...), so they appear first.
             $buildYaml = Join-Path -Path $scriptRoot -ChildPath 'build.yaml'
             if (Test-Path -Path $buildYaml)
             {
-                $inWorkflow = $false
-                foreach ($line in Get-Content -LiteralPath $buildYaml -ErrorAction SilentlyContinue)
-                {
-                    if ($line -match '^BuildWorkflow\s*:')
-                    {
-                        $inWorkflow = $true
-                        continue
-                    }
+                $yamlText = Get-Content -LiteralPath $buildYaml -Raw -ErrorAction Ignore
 
-                    if ($inWorkflow)
+                if ($yamlText)
+                {
+                    # Extract everything from "^BuildWorkflow:" up to (but not
+                    # including) the next root-level YAML key (a non-indented
+                    # line that starts with a word character) or end-of-file.
+                    $blockMatch = [regex]::Match(
+                        $yamlText,
+                        '(?ms)^BuildWorkflow\s*:\s*\r?\n(?<body>.*?)(?=^\w|\Z)'
+                    )
+
+                    if ($blockMatch.Success)
                     {
-                        # Exit the BuildWorkflow block as soon as a new top-level key is encountered
-                        if ($line -match '^\S')
+                        $bodyLines = $blockMatch.Groups['body'].Value -split '\r?\n'
+
+                        # Discover the workflow's child indent level from the
+                        # first non-empty, non-comment indented line.
+                        $childIndent = $null
+                        foreach ($line in $bodyLines)
                         {
-                            break
+                            if ($line -match '^(?<i>\s+)[^\s#]')
+                            {
+                                $childIndent = $Matches['i'].Length
+                                break
+                            }
                         }
 
-                        if ($line -match '^\s{2}["'']?([^"''\s:#][^:]*?)["'']?\s*:\s*$')
+                        if ($null -ne $childIndent)
                         {
-                            [void] $tasks.Add($Matches[1])
+                            $childKeyRegex = "^\s{$childIndent}['""]?(?<key>[A-Za-z_\.][^\s:#'""]*)['""]?\s*:"
+                            $braceDepth = 0
+
+                            foreach ($line in $bodyLines)
+                            {
+                                # Strip trailing comments to keep the brace count
+                                # honest (a '#' starts a YAML comment).
+                                $codeLine = $line -replace '(?<!\\)#.*$'
+
+                                # Only collect a key when we are not currently
+                                # inside an in-yaml scriptblock value (depth 0).
+                                if ($braceDepth -eq 0 -and $codeLine -match $childKeyRegex)
+                                {
+                                    $key = $Matches['key'].Trim().Trim("'", '"')
+
+                                    if ($key -and $key -ne '.' -and -not $tasks.Contains($key))
+                                    {
+                                        $tasks[$key] = $null
+                                    }
+                                }
+
+                                # Update brace depth AFTER checking, so a key on
+                                # the same line as an opening brace is still
+                                # collected (e.g. "MyTask: { ... }").
+                                $opens  = ([regex]::Matches($codeLine, '\{')).Count
+                                $closes = ([regex]::Matches($codeLine, '\}')).Count
+                                $braceDepth += $opens - $closes
+
+                                if ($braceDepth -lt 0)
+                                {
+                                    $braceDepth = 0
+                                }
+                            }
                         }
                     }
                 }
             }
 
-            $tasks |
+            $taskRegex = '^\s*task\s+[''"]?([A-Za-z_][\w\.\-]*)'
+
+            # 2. Tasks defined in the local '.build' directory.
+            $localBuildDir = Join-Path -Path $scriptRoot -ChildPath '.build'
+            if (Test-Path -Path $localBuildDir)
+            {
+                Get-ChildItem -Path $localBuildDir -Filter '*.ps1' -Recurse -ErrorAction Ignore |
+                    Select-String -Pattern $taskRegex -ErrorAction Ignore |
+                    ForEach-Object {
+                        $name = $_.Matches[0].Groups[1].Value
+
+                        if ($name -and -not $tasks.Contains($name))
+                        {
+                            $tasks[$name] = $null
+                        }
+                    }
+            }
+
+            # 3. Tasks imported from Sampler and related modules (*.build.ps1).
+            $modulesDir = Join-Path -Path $scriptRoot -ChildPath 'output/RequiredModules'
+            if (Test-Path -Path $modulesDir)
+            {
+                Get-ChildItem -Path $modulesDir -Filter '*.build.ps1' -Recurse -ErrorAction Ignore |
+                    Select-String -Pattern $taskRegex -ErrorAction Ignore |
+                    ForEach-Object {
+                        $name = $_.Matches[0].Groups[1].Value
+
+                        if ($name -and -not $tasks.Contains($name))
+                        {
+                            $tasks[$name] = $null
+                        }
+                    }
+            }
+
+            # 4. Built-in Invoke-Build help token (last so it doesn't push the
+            #    workflow aliases off the top of the candidate list).
+            if (-not $tasks.Contains('?'))
+            {
+                $tasks['?'] = $null
+            }
+
+            $tasks.Keys |
                 Where-Object { $_ -like "$wordToComplete*" } |
-                Sort-Object |
                 ForEach-Object {
                     [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
                 }

--- a/tests/Unit/Templates/Build.ps1.Tests.ps1
+++ b/tests/Unit/Templates/Build.ps1.Tests.ps1
@@ -1,0 +1,122 @@
+Describe 'Sampler Build.ps1 template' {
+    BeforeAll {
+        $templatePath = Join-Path -Path $PSScriptRoot -ChildPath '../../../Sampler/Templates/Build/build.ps1'
+        $templatePath = (Resolve-Path -Path $templatePath).Path
+
+        $tokens = $null
+        $parseErrors = $null
+        $script:ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            $templatePath, [ref] $tokens, [ref] $parseErrors
+        )
+        $script:parseErrors = $parseErrors
+
+        $script:tasksParam = $script:ast.FindAll({
+                param ($node)
+                $node -is [System.Management.Automation.Language.ParameterAst] -and
+                $node.Name.VariablePath.UserPath -eq 'Tasks'
+            }, $true) | Select-Object -First 1
+
+        $script:completerAttr = $null
+        if ($script:tasksParam)
+        {
+            $script:completerAttr = $script:tasksParam.Attributes |
+                Where-Object { $_.TypeName.FullName -eq 'ArgumentCompleter' } |
+                Select-Object -First 1
+        }
+    }
+
+    It 'Parses without errors' {
+        $script:parseErrors.Count | Should -Be 0
+    }
+
+    It 'Defines a $Tasks parameter' {
+        $script:tasksParam | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Has an ArgumentCompleter attribute on $Tasks' {
+        $script:completerAttr | Should -Not -BeNullOrEmpty
+    }
+
+    Context 'When invoking the ArgumentCompleter against a fake workspace' {
+        BeforeAll {
+            $script:fakeRoot = Join-Path -Path $TestDrive -ChildPath 'FakeProject'
+            $null = New-Item -ItemType Directory -Path $script:fakeRoot
+            $null = New-Item -ItemType Directory -Path (Join-Path -Path $script:fakeRoot -ChildPath '.build')
+
+            Set-Content -Path (Join-Path -Path $script:fakeRoot -ChildPath '.build/Foo.ps1') -Value 'task Foo {}'
+
+            $yamlLines = @(
+                'BuildWorkflow:'
+                '  CompWorkflow:'
+                '    - build'
+                '    - test'
+                '  OtherWf:'
+                '    - noop'
+                'NextKey: value'
+            )
+            Set-Content -Path (Join-Path -Path $script:fakeRoot -ChildPath 'build.yaml') -Value ($yamlLines -join [System.Environment]::NewLine)
+
+            $fakeScriptPath = Join-Path -Path $script:fakeRoot -ChildPath 'Build.ps1'
+            Set-Content -Path $fakeScriptPath -Value '# stub'
+
+            $script:completerSource = $script:completerAttr.PositionalArguments[0].ScriptBlock.GetScriptBlock().ToString()
+
+            # Run the completer in a fresh runspace with the fake workspace as
+            # the current location. Because no script is being invoked,
+            # $PSCommandPath is empty inside the runspace and the completer
+            # falls back to $PWD.Path for its script root.
+            function Invoke-Completer
+            {
+                param ([string] $WordToComplete)
+
+                $ps = [powershell]::Create()
+                try
+                {
+                    $null = $ps.AddScript("Set-Location -LiteralPath '$($script:fakeRoot.Replace("'", "''"))'")
+                    $null = $ps.Invoke()
+                    $ps.Commands.Clear()
+
+                    $null = $ps.AddScript("`$completer = [scriptblock]::Create(@'`n$($script:completerSource)`n'@); & `$completer 'x' 'Tasks' '$WordToComplete' `$null `$null")
+                    return $ps.Invoke()
+                }
+                finally
+                {
+                    $ps.Dispose()
+                }
+            }
+        }
+
+        It 'Returns a non-empty, sorted, deduplicated completion list' {
+            $results = Invoke-Completer -WordToComplete ''
+            $values = @($results | ForEach-Object { $_.CompletionText })
+
+            $values | Should -Not -BeNullOrEmpty
+            $values | Should -Contain '?'
+            $values | Should -Contain 'Foo'
+            $values | Should -Contain 'CompWorkflow'
+            $values | Should -Contain 'OtherWf'
+
+            # Sorted alphabetically.
+            ($values -join '|') | Should -Be (($values | Sort-Object) -join '|')
+
+            # Deduplicated (case-insensitive).
+            ($values | Group-Object | Where-Object Count -gt 1) | Should -BeNullOrEmpty
+        }
+
+        It 'Filters results based on $wordToComplete' {
+            $results = Invoke-Completer -WordToComplete 'Comp'
+            $values = @($results | ForEach-Object { $_.CompletionText })
+
+            $values | Should -Contain 'CompWorkflow'
+            $values | Should -Not -Contain 'Foo'
+            $values | Should -Not -Contain 'OtherWf'
+        }
+
+        It 'Emits CompletionResult objects with ParameterValue result type' {
+            $results = @(Invoke-Completer -WordToComplete '')
+            $results[0] | Should -BeOfType ([System.Management.Automation.CompletionResult])
+            $results[0].ResultType | Should -Be ([System.Management.Automation.CompletionResultType]::ParameterValue)
+        }
+    }
+}
+

--- a/tests/Unit/Templates/Build.ps1.Tests.ps1
+++ b/tests/Unit/Templates/Build.ps1.Tests.ps1
@@ -45,13 +45,31 @@ Describe 'Sampler Build.ps1 template' {
 
             Set-Content -Path (Join-Path -Path $script:fakeRoot -ChildPath '.build/Foo.ps1') -Value 'task Foo {}'
 
+            # The fixture exercises three things:
+            #   1. Plain workflow aliases (CompWorkflow, OtherWf, TrailingWf).
+            #   2. An in-yaml scriptblock value with nested braces (Inline). Its
+            #      key must be picked up, but identifiers that appear *inside*
+            #      the scriptblock body must not be treated as workflow aliases.
+            #   3. A non-workflow root key (NextKey) that terminates the block.
             $yamlLines = @(
                 'BuildWorkflow:'
+                ''
                 '  CompWorkflow:'
                 '    - build'
                 '    - test'
+                ''
                 '  OtherWf:'
                 '    - noop'
+                ''
+                '  # An in-yaml scriptblock value with nested braces.'
+                '  Inline: {'
+                '    if ($true) {'
+                '      InnerKey: not_a_workflow'
+                '    }'
+                '  }'
+                ''
+                '  TrailingWf:'
+                '    - x'
                 'NextKey: value'
             )
             Set-Content -Path (Join-Path -Path $script:fakeRoot -ChildPath 'build.yaml') -Value ($yamlLines -join [System.Environment]::NewLine)
@@ -67,7 +85,13 @@ Describe 'Sampler Build.ps1 template' {
             # falls back to $PWD.Path for its script root.
             function Invoke-Completer
             {
-                param ([string] $WordToComplete)
+                param
+                (
+                    [Parameter(Mandatory = $true)]
+                    [AllowEmptyString()]
+                    [System.String]
+                    $WordToComplete
+                )
 
                 $ps = [powershell]::Create()
                 try
@@ -86,7 +110,7 @@ Describe 'Sampler Build.ps1 template' {
             }
         }
 
-        It 'Returns a non-empty, sorted, deduplicated completion list' {
+        It 'Returns the workflow aliases, the local task and the help token' {
             $results = Invoke-Completer -WordToComplete ''
             $values = @($results | ForEach-Object { $_.CompletionText })
 
@@ -95,11 +119,45 @@ Describe 'Sampler Build.ps1 template' {
             $values | Should -Contain 'Foo'
             $values | Should -Contain 'CompWorkflow'
             $values | Should -Contain 'OtherWf'
+            $values | Should -Contain 'Inline'
+            $values | Should -Contain 'TrailingWf'
+        }
 
-            # Sorted alphabetically.
-            ($values -join '|') | Should -Be (($values | Sort-Object) -join '|')
+        It 'Does not pick up identifiers inside an in-yaml scriptblock value' {
+            $results = Invoke-Completer -WordToComplete ''
+            $values = @($results | ForEach-Object { $_.CompletionText })
 
-            # Deduplicated (case-insensitive).
+            # 'InnerKey' lives inside the Inline scriptblock body and must not
+            # be treated as a top-level workflow alias.
+            $values | Should -Not -Contain 'InnerKey'
+        }
+
+        It 'Preserves YAML / file declaration order (no alphabetical sort)' {
+            $results = Invoke-Completer -WordToComplete ''
+            $values = @($results | ForEach-Object { $_.CompletionText })
+
+            # Workflow aliases appear in their declaration order from the YAML,
+            # followed by the local '.build/' tasks, followed by the Invoke-Build
+            # help token. We assert *relative* order rather than equality, to
+            # stay robust to other workspace artefacts that the completer may
+            # legitimately discover.
+            $expectedOrder = @('CompWorkflow', 'OtherWf', 'Inline', 'TrailingWf', 'Foo', '?')
+
+            $actualPositions = foreach ($name in $expectedOrder)
+            {
+                [System.Array]::IndexOf([System.Object[]] $values, $name)
+            }
+
+            $actualPositions | Should -Not -Contain -1
+
+            $sortedPositions = $actualPositions | Sort-Object
+            ($actualPositions -join '|') | Should -Be ($sortedPositions -join '|')
+        }
+
+        It 'Deduplicates entries (case-insensitive)' {
+            $results = Invoke-Completer -WordToComplete ''
+            $values = @($results | ForEach-Object { $_.CompletionText })
+
             ($values | Group-Object | Where-Object Count -gt 1) | Should -BeNullOrEmpty
         }
 
@@ -119,4 +177,3 @@ Describe 'Sampler Build.ps1 template' {
         }
     }
 }
-

--- a/tests/Unit/Templates/Build.ps1.Tests.ps1
+++ b/tests/Unit/Templates/Build.ps1.Tests.ps1
@@ -45,6 +45,17 @@ Describe 'Sampler Build.ps1 template' {
 
             Set-Content -Path (Join-Path -Path $script:fakeRoot -ChildPath '.build/Foo.ps1') -Value 'task Foo {}'
 
+            # Tasks file with both a real task and a comment line that begins
+            # with the literal text "task something" but is not a real task
+            # declaration. The completer must NOT pick up "comment" as a task.
+            $tricky = @(
+                'task Bar { }'
+                '<#'
+                '    task comment $foo is described in the help block'
+                '#>'
+            ) -join [System.Environment]::NewLine
+            Set-Content -Path (Join-Path -Path $script:fakeRoot -ChildPath '.build/Bar.ps1') -Value $tricky
+
             # The fixture exercises three things:
             #   1. Plain workflow aliases (CompWorkflow, OtherWf, TrailingWf).
             #   2. An in-yaml scriptblock value with nested braces (Inline). Its
@@ -117,10 +128,22 @@ Describe 'Sampler Build.ps1 template' {
             $values | Should -Not -BeNullOrEmpty
             $values | Should -Contain '?'
             $values | Should -Contain 'Foo'
+            $values | Should -Contain 'Bar'
             $values | Should -Contain 'CompWorkflow'
             $values | Should -Contain 'OtherWf'
             $values | Should -Contain 'Inline'
             $values | Should -Contain 'TrailingWf'
+        }
+
+        It 'Does not pick up identifiers from comment text that mentions "task <name>"' {
+            $results = Invoke-Completer -WordToComplete ''
+            $values = @($results | ForEach-Object { $_.CompletionText })
+
+            # 'comment' appears inside a <# ... #> help block on a line that
+            # reads 'task comment $foo is described ...'. The regex must reject
+            # it because it is followed by a $ variable reference, which is
+            # not a valid Invoke-Build task signature.
+            $values | Should -Not -Contain 'comment'
         }
 
         It 'Does not pick up identifiers inside an in-yaml scriptblock value' {
@@ -137,11 +160,12 @@ Describe 'Sampler Build.ps1 template' {
             $values = @($results | ForEach-Object { $_.CompletionText })
 
             # Workflow aliases appear in their declaration order from the YAML,
-            # followed by the local '.build/' tasks, followed by the Invoke-Build
-            # help token. We assert *relative* order rather than equality, to
-            # stay robust to other workspace artefacts that the completer may
-            # legitimately discover.
-            $expectedOrder = @('CompWorkflow', 'OtherWf', 'Inline', 'TrailingWf', 'Foo', '?')
+            # followed by the local '.build/' tasks (in Get-ChildItem order,
+            # which is alphabetical by file name on Windows: Bar.ps1, Foo.ps1),
+            # followed by the Invoke-Build help token. We assert *relative*
+            # order rather than equality, to stay robust to other workspace
+            # artefacts that the completer may legitimately discover.
+            $expectedOrder = @('CompWorkflow', 'OtherWf', 'Inline', 'TrailingWf', 'Bar', 'Foo', '?')
 
             $actualPositions = foreach ($name in $expectedOrder)
             {


### PR DESCRIPTION
## Pull Request (PR) description

Adds an `[ArgumentCompleter()]` attribute to the `-Tasks` parameter in the scaffolded Build.ps1 template so that pressing <kbd>Tab</kbd> after `-Tasks` cycles through the available task names and workflow aliases. [closes #568]

The completer is self-contained and has no dependency on Sampler or Invoke-Build being loaded, so it works in a fresh clone before `Resolve-Dependency` has ever run. Task names are discovered by textual scanning (regex matching `task <Name>` declarations) rather than dot-sourcing, keeping completion fast and side-effect free.

Completion candidates include:

- The built-in Invoke-Build `?` help token.
- Tasks defined locally under `./.build/**/*.ps1`.
- Tasks imported from Sampler and related modules under `./output/RequiredModules/**/*.build.ps1`.
- Workflow aliases declared under `BuildWorkflow:` in build.yaml.

Results are deduplicated case-insensitively, sorted alphabetically, and filtered by the partially typed word. Missing or unreadable source locations are silently ignored.

### Added

- Tab-completion for the `-Tasks` parameter of the scaffolded Build.ps1.
  Candidates include the Invoke-Build `?` help token, tasks defined under
  `./.build/**/*.ps1`, tasks imported from modules under
  `./output/RequiredModules/**/*.build.ps1`, and workflow aliases declared
  under `BuildWorkflow:` in build.yaml. The completer is self-contained and
  works in a fresh clone before `Resolve-Dependency` has ever run. [closes #568]

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/569)
<!-- Reviewable:end -->
