### PR TITLE
Add `DscResource.Authoring.build.ps1` to Sampler tasks

### DIFF
--- a/.build/tasks/DscResource.Authoring.build.ps1
+++ b/.build/tasks/DscResource.Authoring.build.ps1
@@ -1,0 +1,368 @@
+<#
+    .SYNOPSIS
+        Build task for creating Microsoft DSC adapted resource manifests
+        from a built PowerShell module using the DscResource.Authoring module.
+
+    .DESCRIPTION
+        Provides two Invoke-Build tasks that use the DscResource.Authoring module
+        to generate Microsoft DSC adapted resource manifests from class-based DSC resources
+        found in the built module:
+
+        - Create_DscAdaptedResourceManifests: Creates one
+          `.dsc.adaptedResource.json` file per class-based DSC resource found in
+          the built module and writes them alongside the module manifest.
+
+        - Create_DscResourceManifestsList: Creates a single
+          `.dsc.manifests.json` bundle file that contains every adapted resource
+          manifest and writes it alongside the module manifest.
+
+        Both tasks target the module manifest produced by the ModuleBuilder build
+        step and therefore must run after the module has been built
+        (i.e., after `Build_Module_ModuleBuilder`).
+
+        Configuration for both tasks is read from the `DscResource.Authoring`
+        section of the build configuration file (e.g., `build.yaml`).
+
+    .PARAMETER ProjectName
+        The name of the project being built.
+
+    .PARAMETER SourcePath
+        The path to the source directory of the module.
+
+    .PARAMETER OutputDirectory
+        The base directory for all build output. Defaults to 'output' relative
+        to the build root.
+
+    .PARAMETER BuiltModuleSubdirectory
+        The sub-directory under OutputDirectory where the built module is placed.
+
+    .PARAMETER VersionedOutputDirectory
+        Whether the built module is placed in a versioned sub-directory.
+        Defaults to $true.
+
+    .PARAMETER ModuleVersion
+        The version of the module being built.
+
+    .PARAMETER BuildInfo
+        The build configuration hashtable, typically populated from `build.yaml`.
+
+    .NOTES
+        This task file is intended to be placed in the Sampler module's tasks
+        directory so that it is exported as an alias and loaded via the
+        `ModuleBuildTasks` mechanism in `build.yaml`.
+
+        The DscResource.Authoring module must be available to the build
+        environment before these tasks run. Add it to `RequiredModules.psd1`
+        to ensure it is resolved as a build dependency.
+#>
+
+param
+(
+    [Parameter()]
+    [System.String]
+    $ProjectName = (property ProjectName ''),
+
+    [Parameter()]
+    [System.String]
+    $SourcePath = (property SourcePath ''),
+
+    [Parameter()]
+    [System.String]
+    $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot 'output')),
+
+    [Parameter()]
+    [System.String]
+    $BuiltModuleSubdirectory = (property BuiltModuleSubdirectory ''),
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $VersionedOutputDirectory = (property VersionedOutputDirectory $true),
+
+    [Parameter()]
+    [System.String]
+    $ModuleVersion = (property ModuleVersion ''),
+
+    [Parameter()]
+    [System.Collections.Hashtable]
+    $BuildInfo = (property BuildInfo @{ })
+)
+
+<#
+    .SYNOPSIS
+        Converts property override configuration entries into DscPropertyOverride objects.
+
+    .DESCRIPTION
+        Maps each hashtable entry from the build configuration PropertyOverrides section
+        into a DscPropertyOverride object understood by Update-DscAdaptedResourceManifest.
+        Each entry must contain at least a 'Name' key. Supported optional keys are
+        'Description', 'Title', 'JsonSchema', 'RemoveKeys', and 'Required'.
+
+        This function must only be called after DscResource.Authoring has been imported
+        into the session.
+
+    .PARAMETER OverrideConfig
+        An array of hashtables, each describing one property override.
+
+    .EXAMPLE
+        $overrides = ConvertTo-DscPropertyOverrideFromConfig -OverrideConfig $configEntries
+
+        Converts a list of configuration hashtables into DscPropertyOverride objects.
+#>
+function ConvertTo-DscPropertyOverrideFromConfig
+{
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [object[]]
+        $OverrideConfig
+    )
+
+    $overrides = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($entry in $OverrideConfig)
+    {
+        if (-not $entry.ContainsKey('Name') -or [string]::IsNullOrEmpty($entry['Name']))
+        {
+            Write-Warning 'Skipping a property override entry with a missing or empty Name key.'
+            continue
+        }
+
+        $overrideParams = @{
+            Name = [string] $entry['Name']
+        }
+
+        if ($entry.ContainsKey('Description') -and -not [string]::IsNullOrEmpty($entry['Description']))
+        {
+            $overrideParams['Description'] = [string] $entry['Description']
+        }
+
+        if ($entry.ContainsKey('Title') -and -not [string]::IsNullOrEmpty($entry['Title']))
+        {
+            $overrideParams['Title'] = [string] $entry['Title']
+        }
+
+        if ($entry.ContainsKey('JsonSchema') -and $null -ne $entry['JsonSchema'])
+        {
+            $overrideParams['JsonSchema'] = $entry['JsonSchema']
+        }
+
+        if ($entry.ContainsKey('RemoveKeys') -and $null -ne $entry['RemoveKeys'])
+        {
+            $overrideParams['RemoveKeys'] = @($entry['RemoveKeys'])
+        }
+
+        if ($entry.ContainsKey('Required') -and $null -ne $entry['Required'])
+        {
+            $overrideParams['Required'] = [bool] $entry['Required']
+        }
+
+        $overrides.Add((New-DscPropertyOverride @overrideParams))
+    }
+
+    return , $overrides.ToArray()
+}
+
+<#
+    Synopsis: Creates individual Microsoft DSC adapted resource manifest files
+    (.dsc.adaptedResource.json) for every class-based DSC resource found in
+    the built module.
+
+    One file is created per resource class and written to the root of the
+    built module directory alongside the module manifest (.psd1). The file
+    name follows the pattern `<ModuleName>.<ResourceName>.dsc.adaptedResource.json`.
+
+    Use this task if you want to leverage Microsoft's DSC engine with the PowerShell
+    discovery extension.
+#>
+Task Create_DscAdaptedResourceManifests {
+    # Get the task variables. See https://github.com/gaelcolas/Sampler#task-variables.
+    . Set-SamplerTaskVariable
+
+    "`tBuilt Module Manifest  = '$BuiltModuleManifest'"
+    "`tBuilt Module Base      = '$BuiltModuleBase'"
+
+    if ([System.String]::IsNullOrEmpty($BuiltModuleManifest) -or -not (Test-Path -Path $BuiltModuleManifest))
+    {
+        throw "The built module manifest '$BuiltModuleManifest' could not be found. Make sure the module has been built before running this task."
+    }
+
+    $taskConfig = @{}
+
+    if ($BuildInfo.ContainsKey('DscResource.Authoring') -and
+        $BuildInfo['DscResource.Authoring'].ContainsKey('Create_DscAdaptedResourceManifests'))
+    {
+        $taskConfig = $BuildInfo['DscResource.Authoring']['Create_DscAdaptedResourceManifests']
+    }
+
+    if ($null -eq $taskConfig)
+    {
+        $taskConfig = @{}
+    }
+
+    "`tTask Configuration     = $(if ($taskConfig.Count -gt 0) { $taskConfig | ConvertTo-Json -Depth 5 } else { '(none)' })"
+
+    $fileNamePattern = '{ProjectName}.{ResourceName}.dsc.adaptedResource.json'
+
+    if ($taskConfig.ContainsKey('FileNamePattern') -and -not [System.String]::IsNullOrEmpty($taskConfig['FileNamePattern']))
+    {
+        $fileNamePattern = $taskConfig['FileNamePattern']
+    }
+
+    "`tFile Name Pattern       = '$fileNamePattern'"
+
+    $propertyOverridesConfig = @{}
+
+    if ($taskConfig.ContainsKey('PropertyOverrides') -and $null -ne $taskConfig['PropertyOverrides'])
+    {
+        $propertyOverridesConfig = $taskConfig['PropertyOverrides']
+    }
+
+    Write-Build -Color 'DarkGray' -Text "`tImporting module 'DscResource.Authoring'..."
+
+    Import-Module -Name 'DscResource.Authoring' -ErrorAction 'Stop'
+
+    Write-Build -Color 'DarkGray' -Text "`tGenerating adapted resource manifests from '$BuiltModuleManifest'..."
+
+    $adaptedManifests = New-DscAdaptedResourceManifest -Path $BuiltModuleManifest
+
+    if (-not $adaptedManifests)
+    {
+        Write-Build -Color 'Yellow' -Text "`tNo class-based DSC resources found in '$BuiltModuleManifest'. No manifest files were created."
+
+        return
+    }
+
+    foreach ($manifest in $adaptedManifests)
+    {
+        $resourceName = ($manifest.Type -split '/')[-1]
+
+        if ($propertyOverridesConfig.ContainsKey($resourceName))
+        {
+            Write-Build -Color 'DarkGray' -Text "`tApplying property overrides for '$resourceName'..."
+
+            $overrideList = ConvertTo-DscPropertyOverrideFromConfig -OverrideConfig @($propertyOverridesConfig[$resourceName])
+            $manifest = $manifest | Update-DscAdaptedResourceManifest -PropertyOverride $overrideList
+        }
+
+        $outputFileName = $fileNamePattern -replace '\{ProjectName\}', $ProjectName -replace '\{ResourceName\}', $resourceName
+        $outputFilePath = Join-Path -Path $BuiltModuleBase -ChildPath $outputFileName
+
+        Write-Build -Color 'DarkGray' -Text "`tWriting '$outputFilePath'..."
+
+        $manifest.ToJson() | Set-Content -Path $outputFilePath -Encoding 'UTF8' -Force
+
+        Write-Build -Color 'Green' -Text "`tCreated adapted resource manifest '$outputFileName'."
+    }
+
+    Write-Build -Color 'Green' -Text "`tCreated $(@($adaptedManifests).Count) adapted resource manifest file(s) in '$BuiltModuleBase'."
+}
+
+<#
+    Synopsis: Creates a single Microsoft DSC resource manifests bundle file
+    (.dsc.manifests.json) that contains all adapted resource manifests for
+    every class-based DSC resource found in the built module.
+
+    The bundle file is written to the root of the built module directory
+    alongside the module manifest (.psd1). The output file name can be
+    configured via the `OutputFileName` key under
+    `DscResource.Authoring.Create_DscResourceManifestsList` in the build
+    configuration file. When not specified it defaults to
+    `<ProjectName>.dsc.manifests.json`.
+
+    Use this task if you want to leverage Microsoft's DSC engine with the PowerShell
+    discovery extension.
+#>
+Task Create_DscResourceManifestsList {
+    # Get the task variables. See https://github.com/gaelcolas/Sampler#task-variables.
+    . Set-SamplerTaskVariable
+
+    "`tBuilt Module Manifest  = '$BuiltModuleManifest'"
+    "`tBuilt Module Base      = '$BuiltModuleBase'"
+
+    if ([System.String]::IsNullOrEmpty($BuiltModuleManifest) -or -not (Test-Path -Path $BuiltModuleManifest))
+    {
+        throw "The built module manifest '$BuiltModuleManifest' could not be found. Make sure the module has been built before running this task."
+    }
+
+    $taskConfig = @{}
+
+    if ($BuildInfo.ContainsKey('DscResource.Authoring') -and
+        $BuildInfo['DscResource.Authoring'].ContainsKey('Create_DscResourceManifestsList'))
+    {
+        $taskConfig = $BuildInfo['DscResource.Authoring']['Create_DscResourceManifestsList']
+    }
+
+    if ($null -eq $taskConfig)
+    {
+        $taskConfig = @{}
+    }
+
+    "`tTask Configuration     = $(if ($taskConfig.Count -gt 0) { $taskConfig | ConvertTo-Json -Depth 5 } else { '(none)' })"
+
+    $outputFileName = "$ProjectName.dsc.manifests.json"
+
+    if ($taskConfig.ContainsKey('OutputFileName') -and -not [System.String]::IsNullOrEmpty($taskConfig['OutputFileName']))
+    {
+        $outputFileName = $taskConfig['OutputFileName']
+    }
+
+    "`tOutput File Name       = '$outputFileName'"
+
+    $outputFilePath = Join-Path -Path $BuiltModuleBase -ChildPath $outputFileName
+
+    "`tOutput File Path       = '$outputFilePath'"
+
+    $propertyOverridesConfig = @{}
+
+    if ($taskConfig.ContainsKey('PropertyOverrides') -and $null -ne $taskConfig['PropertyOverrides'])
+    {
+        $propertyOverridesConfig = $taskConfig['PropertyOverrides']
+    }
+
+    Write-Build -Color 'DarkGray' -Text "`tImporting module 'DscResource.Authoring'..."
+
+    Import-Module -Name 'DscResource.Authoring' -ErrorAction 'Stop'
+
+    Write-Build -Color 'DarkGray' -Text "`tGenerating adapted resource manifests from '$BuiltModuleManifest'..."
+
+    $adaptedManifests = New-DscAdaptedResourceManifest -Path $BuiltModuleManifest
+
+    if (-not $adaptedManifests)
+    {
+        Write-Build -Color 'Yellow' -Text "`tNo class-based DSC resources found in '$BuiltModuleManifest'. No manifest list file was created."
+
+        return
+    }
+
+    if ($propertyOverridesConfig.Count -gt 0)
+    {
+        $adaptedManifests = foreach ($manifest in $adaptedManifests)
+        {
+            $resourceName = ($manifest.Type -split '/')[-1]
+
+            if ($propertyOverridesConfig.ContainsKey($resourceName))
+            {
+                Write-Build -Color 'DarkGray' -Text "`tApplying property overrides for '$resourceName'..."
+
+                $overrideList = ConvertTo-DscPropertyOverrideFromConfig -OverrideConfig @($propertyOverridesConfig[$resourceName])
+                $manifest | Update-DscAdaptedResourceManifest -PropertyOverride $overrideList
+            }
+            else
+            {
+                $manifest
+            }
+        }
+    }
+
+    Write-Build -Color 'DarkGray' -Text "`tBuilding manifest list from $(@($adaptedManifests).Count) adapted resource manifest(s)..."
+
+    $manifestList = $adaptedManifests | New-DscResourceManifest
+
+    Write-Build -Color 'DarkGray' -Text "`tWriting '$outputFilePath'..."
+
+    $manifestList.ToJson() | Set-Content -Path $outputFilePath -Encoding 'UTF8' -Force
+
+    Write-Build -Color 'Green' -Text "`tCreated DSC resource manifests list '$outputFileName' with $($manifestList.AdaptedResources.Count) adapted resource(s) in '$BuiltModuleBase'."
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Create_DscAdaptedResourceManifests` and `Create_DscResourceManifestsList` build tasks that use the `DscResource.Authoring` module to generate Microsoft DSC adapted resource manifests from class-based DSC resources found in the built module. Configuration is read from the `DscResource.Authoring:` section in `build.yaml` and supports per-resource property overrides via `PropertyOverrides`.
 - `package_psresource_nupkg` tasks that recursively packs dependencies, ignoring `ExternalDependencies` using `PSResourceGet` module.
 - `New-SampleModule` `Features` parameter now accepts `github`, `vscode`, `codecov`, `azurepipelines`, and `gitversion` to mirror the Plaster template's feature choices.
 - `New-SampleModule` documents the `CustomModule` `ModuleType` and the new `MainGitBranch` parameter.

--- a/tests/Unit/tasks/DscResource.Authoring.build.Tests.ps1
+++ b/tests/Unit/tasks/DscResource.Authoring.build.Tests.ps1
@@ -1,0 +1,507 @@
+BeforeAll {
+    $script:moduleName = 'Sampler'
+
+    # If the module is not found, run the build task 'noop'.
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        # Redirect all streams to $null, except the error stream (stream 2)
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    # Re-import the module using force to get any code changes between runs.
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
+AfterAll {
+    Remove-Module -Name $script:moduleName
+}
+
+Describe 'DscResource.Authoring' {
+    It 'Should have exported the alias correctly' {
+        $taskAlias = Get-Alias -Name 'DscResource.Authoring.build.Sampler.ib.tasks'
+
+        $taskAlias.Name | Should -Be 'DscResource.Authoring.build.Sampler.ib.tasks'
+        $taskAlias.ReferencedCommand | Should -Be 'DscResource.Authoring.build.ps1'
+        $taskAlias.Definition | Should -Match 'Sampler[\/|\\]\d+\.\d+\.\d+[\/|\\]tasks[\/|\\]DscResource\.Authoring\.build\.ps1'
+    }
+}
+
+Describe 'Create_DscAdaptedResourceManifests' {
+    BeforeAll {
+        # Dot-source mocks
+        . $PSScriptRoot/../TestHelpers/MockSetSamplerTaskVariable
+
+        $taskAlias = Get-Alias -Name 'DscResource.Authoring.build.Sampler.ib.tasks'
+
+        $mockTaskParameters = @{
+            OutputDirectory = Join-Path -Path $TestDrive -ChildPath 'output'
+            ProjectName     = 'MyModule'
+        }
+    }
+
+    Context 'When the built module manifest does not exist' {
+        BeforeAll {
+            Mock -CommandName Test-Path -MockWith {
+                return $false
+            } -ParameterFilter {
+                $Path -match 'MyModule\.psd1'
+            }
+
+            Mock -CommandName Import-Module -RemoveParameterValidation 'Name'
+        }
+
+        It 'Should throw the correct error' {
+            {
+                Invoke-Build -Task 'Create_DscAdaptedResourceManifests' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Throw -ExpectedMessage "*could not be found*"
+        }
+    }
+
+    Context 'When the built module contains no class-based DSC resources' {
+        BeforeAll {
+            # Create the built module manifest so Test-Path returns $true.
+            $mockBuiltModuleDir = Join-Path -Path $TestDrive -ChildPath 'output' |
+                Join-Path -ChildPath 'builtModule' |
+                Join-Path -ChildPath 'MyModule' |
+                Join-Path -ChildPath '2.0.0'
+
+            New-Item -Path $mockBuiltModuleDir -ItemType Directory -Force | Out-Null
+            New-Item -Path (Join-Path -Path $mockBuiltModuleDir -ChildPath 'MyModule.psd1') -ItemType File -Force | Out-Null
+
+            Mock -CommandName Import-Module -RemoveParameterValidation 'Name'
+
+            Mock -CommandName New-DscAdaptedResourceManifest -MockWith {
+                return $null
+            }
+        }
+
+        It 'Should run the build task without throwing' {
+            {
+                Invoke-Build -Task 'Create_DscAdaptedResourceManifests' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+        }
+
+        It 'Should not write any manifest files' {
+            Mock -CommandName Set-Content
+
+            Invoke-Build -Task 'Create_DscAdaptedResourceManifests' -File $taskAlias.Definition @mockTaskParameters
+
+            Should -Invoke -CommandName Set-Content -Exactly -Times 0 -Scope It
+        }
+    }
+
+    Context 'When the built module contains class-based DSC resources with no task configuration' {
+        BeforeAll {
+            # Create the built module manifest so Test-Path returns $true.
+            $mockBuiltModuleDir = Join-Path -Path $TestDrive -ChildPath 'output' |
+                Join-Path -ChildPath 'builtModule' |
+                Join-Path -ChildPath 'MyModule' |
+                Join-Path -ChildPath '2.0.0'
+
+            New-Item -Path $mockBuiltModuleDir -ItemType Directory -Force | Out-Null
+            New-Item -Path (Join-Path -Path $mockBuiltModuleDir -ChildPath 'MyModule.psd1') -ItemType File -Force | Out-Null
+
+            $mockAdaptedManifest = [PSCustomObject] @{
+                Type = 'MyModule/MyResource'
+            }
+
+            $mockAdaptedManifest | Add-Member -MemberType ScriptMethod -Name 'ToJson' -Value {
+                return '{"type":"MyModule/MyResource"}'
+            }
+
+            Mock -CommandName Import-Module -RemoveParameterValidation 'Name'
+
+            Mock -CommandName New-DscAdaptedResourceManifest -MockWith {
+                return @($mockAdaptedManifest)
+            }
+
+            Mock -CommandName Set-Content
+        }
+
+        It 'Should run the build task without throwing' {
+            {
+                Invoke-Build -Task 'Create_DscAdaptedResourceManifests' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+        }
+
+        It 'Should write one adapted resource manifest file using the default file name pattern' {
+            Invoke-Build -Task 'Create_DscAdaptedResourceManifests' -File $taskAlias.Definition @mockTaskParameters
+
+            Should -Invoke -CommandName Set-Content -ParameterFilter {
+                $Path -match 'MyModule\.MyResource\.dsc\.adaptedResource\.json'
+            } -Exactly -Times 1 -Scope It
+        }
+    }
+
+    Context 'When the task is configured with a custom FileNamePattern' {
+        BeforeAll {
+            # Create the built module manifest so Test-Path returns $true.
+            $mockBuiltModuleDir = Join-Path -Path $TestDrive -ChildPath 'output' |
+                Join-Path -ChildPath 'builtModule' |
+                Join-Path -ChildPath 'MyModule' |
+                Join-Path -ChildPath '2.0.0'
+
+            New-Item -Path $mockBuiltModuleDir -ItemType Directory -Force | Out-Null
+            New-Item -Path (Join-Path -Path $mockBuiltModuleDir -ChildPath 'MyModule.psd1') -ItemType File -Force | Out-Null
+
+            $mockAdaptedManifest = [PSCustomObject] @{
+                Type = 'MyModule/MyResource'
+            }
+
+            $mockAdaptedManifest | Add-Member -MemberType ScriptMethod -Name 'ToJson' -Value {
+                return '{"type":"MyModule/MyResource"}'
+            }
+
+            Mock -CommandName Import-Module -RemoveParameterValidation 'Name'
+
+            Mock -CommandName New-DscAdaptedResourceManifest -MockWith {
+                return @($mockAdaptedManifest)
+            }
+
+            Mock -CommandName Set-Content
+
+            $mockTaskParametersWithConfig = $mockTaskParameters + @{
+                BuildInfo = @{
+                    'DscResource.Authoring' = @{
+                        Create_DscAdaptedResourceManifests = @{
+                            FileNamePattern = '{ResourceName}.custom.json'
+                        }
+                    }
+                }
+            }
+        }
+
+        It 'Should write the adapted resource manifest file using the configured file name pattern' {
+            Invoke-Build -Task 'Create_DscAdaptedResourceManifests' -File $taskAlias.Definition @mockTaskParametersWithConfig
+
+            Should -Invoke -CommandName Set-Content -ParameterFilter {
+                $Path -match 'MyResource\.custom\.json'
+            } -Exactly -Times 1 -Scope It
+        }
+    }
+
+    Context 'When the task is configured with PropertyOverrides for a resource' {
+        BeforeAll {
+            # Create the built module manifest so Test-Path returns $true.
+            $mockBuiltModuleDir = Join-Path -Path $TestDrive -ChildPath 'output' |
+                Join-Path -ChildPath 'builtModule' |
+                Join-Path -ChildPath 'MyModule' |
+                Join-Path -ChildPath '2.0.0'
+
+            New-Item -Path $mockBuiltModuleDir -ItemType Directory -Force | Out-Null
+            New-Item -Path (Join-Path -Path $mockBuiltModuleDir -ChildPath 'MyModule.psd1') -ItemType File -Force | Out-Null
+
+            $mockAdaptedManifest = [PSCustomObject] @{
+                Type = 'MyModule/MyResource'
+            }
+
+            $mockAdaptedManifest | Add-Member -MemberType ScriptMethod -Name 'ToJson' -Value {
+                return '{"type":"MyModule/MyResource"}'
+            }
+
+            $mockUpdatedManifest = [PSCustomObject] @{
+                Type = 'MyModule/MyResource'
+            }
+
+            $mockUpdatedManifest | Add-Member -MemberType ScriptMethod -Name 'ToJson' -Value {
+                return '{"type":"MyModule/MyResource","updated":true}'
+            }
+
+            Mock -CommandName Import-Module -RemoveParameterValidation 'Name'
+
+            Mock -CommandName New-DscAdaptedResourceManifest -MockWith {
+                return @($mockAdaptedManifest)
+            }
+
+            Mock -CommandName New-DscPropertyOverride -MockWith {
+                return [PSCustomObject] @{ Name = 'Ensure' }
+            }
+
+            Mock -CommandName Update-DscAdaptedResourceManifest -MockWith {
+                return $mockUpdatedManifest
+            }
+
+            Mock -CommandName Set-Content
+
+            $mockTaskParametersWithOverrides = $mockTaskParameters + @{
+                BuildInfo = @{
+                    'DscResource.Authoring' = @{
+                        Create_DscAdaptedResourceManifests = @{
+                            PropertyOverrides = @{
+                                MyResource = @(
+                                    @{
+                                        Name        = 'Ensure'
+                                        Description = 'Whether the resource should exist.'
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        It 'Should run the build task without throwing' {
+            {
+                Invoke-Build -Task 'Create_DscAdaptedResourceManifests' -File $taskAlias.Definition @mockTaskParametersWithOverrides
+            } | Should -Not -Throw
+        }
+
+        It 'Should apply property overrides and write the adapted resource manifest' {
+            Invoke-Build -Task 'Create_DscAdaptedResourceManifests' -File $taskAlias.Definition @mockTaskParametersWithOverrides
+
+            Should -Invoke -CommandName Update-DscAdaptedResourceManifest -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Set-Content -Exactly -Times 1 -Scope It
+        }
+    }
+}
+
+Describe 'Create_DscResourceManifestsList' {
+    BeforeAll {
+        # Dot-source mocks
+        . $PSScriptRoot/../TestHelpers/MockSetSamplerTaskVariable
+
+        $taskAlias = Get-Alias -Name 'DscResource.Authoring.build.Sampler.ib.tasks'
+
+        $mockTaskParameters = @{
+            OutputDirectory = Join-Path -Path $TestDrive -ChildPath 'output'
+            ProjectName     = 'MyModule'
+        }
+    }
+
+    Context 'When the built module manifest does not exist' {
+        BeforeAll {
+            Mock -CommandName Test-Path -MockWith {
+                return $false
+            } -ParameterFilter {
+                $Path -match 'MyModule\.psd1'
+            }
+
+            Mock -CommandName Import-Module -RemoveParameterValidation 'Name'
+        }
+
+        It 'Should throw the correct error' {
+            {
+                Invoke-Build -Task 'Create_DscResourceManifestsList' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Throw -ExpectedMessage "*could not be found*"
+        }
+    }
+
+    Context 'When the built module contains no class-based DSC resources' {
+        BeforeAll {
+            # Create the built module manifest so Test-Path returns $true.
+            $mockBuiltModuleDir = Join-Path -Path $TestDrive -ChildPath 'output' |
+                Join-Path -ChildPath 'builtModule' |
+                Join-Path -ChildPath 'MyModule' |
+                Join-Path -ChildPath '2.0.0'
+
+            New-Item -Path $mockBuiltModuleDir -ItemType Directory -Force | Out-Null
+            New-Item -Path (Join-Path -Path $mockBuiltModuleDir -ChildPath 'MyModule.psd1') -ItemType File -Force | Out-Null
+
+            Mock -CommandName Import-Module -RemoveParameterValidation 'Name'
+
+            Mock -CommandName New-DscAdaptedResourceManifest -MockWith {
+                return $null
+            }
+        }
+
+        It 'Should run the build task without throwing' {
+            {
+                Invoke-Build -Task 'Create_DscResourceManifestsList' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+        }
+
+        It 'Should not write the manifests list file' {
+            Mock -CommandName Set-Content
+
+            Invoke-Build -Task 'Create_DscResourceManifestsList' -File $taskAlias.Definition @mockTaskParameters
+
+            Should -Invoke -CommandName Set-Content -Exactly -Times 0 -Scope It
+        }
+    }
+
+    Context 'When the built module contains class-based DSC resources with no task configuration' {
+        BeforeAll {
+            # Create the built module manifest so Test-Path returns $true.
+            $mockBuiltModuleDir = Join-Path -Path $TestDrive -ChildPath 'output' |
+                Join-Path -ChildPath 'builtModule' |
+                Join-Path -ChildPath 'MyModule' |
+                Join-Path -ChildPath '2.0.0'
+
+            New-Item -Path $mockBuiltModuleDir -ItemType Directory -Force | Out-Null
+            New-Item -Path (Join-Path -Path $mockBuiltModuleDir -ChildPath 'MyModule.psd1') -ItemType File -Force | Out-Null
+
+            $mockAdaptedManifest = [PSCustomObject] @{
+                Type = 'MyModule/MyResource'
+            }
+
+            $mockManifestList = [PSCustomObject] @{
+                AdaptedResources = @($mockAdaptedManifest)
+            }
+
+            $mockManifestList | Add-Member -MemberType ScriptMethod -Name 'ToJson' -Value {
+                return '{"adaptedResources":[{"type":"MyModule/MyResource"}]}'
+            }
+
+            Mock -CommandName Import-Module -RemoveParameterValidation 'Name'
+
+            Mock -CommandName New-DscAdaptedResourceManifest -MockWith {
+                return @($mockAdaptedManifest)
+            }
+
+            Mock -CommandName New-DscResourceManifest -MockWith {
+                return $mockManifestList
+            }
+
+            Mock -CommandName Set-Content
+        }
+
+        It 'Should run the build task without throwing' {
+            {
+                Invoke-Build -Task 'Create_DscResourceManifestsList' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+        }
+
+        It 'Should write a single manifests list file using the default output file name' {
+            Invoke-Build -Task 'Create_DscResourceManifestsList' -File $taskAlias.Definition @mockTaskParameters
+
+            Should -Invoke -CommandName Set-Content -ParameterFilter {
+                $Path -match 'MyModule\.dsc\.manifests\.json'
+            } -Exactly -Times 1 -Scope It
+        }
+    }
+
+    Context 'When the task is configured with a custom OutputFileName' {
+        BeforeAll {
+            # Create the built module manifest so Test-Path returns $true.
+            $mockBuiltModuleDir = Join-Path -Path $TestDrive -ChildPath 'output' |
+                Join-Path -ChildPath 'builtModule' |
+                Join-Path -ChildPath 'MyModule' |
+                Join-Path -ChildPath '2.0.0'
+
+            New-Item -Path $mockBuiltModuleDir -ItemType Directory -Force | Out-Null
+            New-Item -Path (Join-Path -Path $mockBuiltModuleDir -ChildPath 'MyModule.psd1') -ItemType File -Force | Out-Null
+
+            $mockAdaptedManifest = [PSCustomObject] @{
+                Type = 'MyModule/MyResource'
+            }
+
+            $mockManifestList = [PSCustomObject] @{
+                AdaptedResources = @($mockAdaptedManifest)
+            }
+
+            $mockManifestList | Add-Member -MemberType ScriptMethod -Name 'ToJson' -Value {
+                return '{"adaptedResources":[{"type":"MyModule/MyResource"}]}'
+            }
+
+            Mock -CommandName Import-Module -RemoveParameterValidation 'Name'
+
+            Mock -CommandName New-DscAdaptedResourceManifest -MockWith {
+                return @($mockAdaptedManifest)
+            }
+
+            Mock -CommandName New-DscResourceManifest -MockWith {
+                return $mockManifestList
+            }
+
+            Mock -CommandName Set-Content
+
+            $mockTaskParametersWithConfig = $mockTaskParameters + @{
+                BuildInfo = @{
+                    'DscResource.Authoring' = @{
+                        Create_DscResourceManifestsList = @{
+                            OutputFileName = 'custom.dsc.manifests.json'
+                        }
+                    }
+                }
+            }
+        }
+
+        It 'Should write the manifests list file using the configured output file name' {
+            Invoke-Build -Task 'Create_DscResourceManifestsList' -File $taskAlias.Definition @mockTaskParametersWithConfig
+
+            Should -Invoke -CommandName Set-Content -ParameterFilter {
+                $Path -match 'custom\.dsc\.manifests\.json'
+            } -Exactly -Times 1 -Scope It
+        }
+    }
+
+    Context 'When the task is configured with PropertyOverrides for a resource' {
+        BeforeAll {
+            # Create the built module manifest so Test-Path returns $true.
+            $mockBuiltModuleDir = Join-Path -Path $TestDrive -ChildPath 'output' |
+                Join-Path -ChildPath 'builtModule' |
+                Join-Path -ChildPath 'MyModule' |
+                Join-Path -ChildPath '2.0.0'
+
+            New-Item -Path $mockBuiltModuleDir -ItemType Directory -Force | Out-Null
+            New-Item -Path (Join-Path -Path $mockBuiltModuleDir -ChildPath 'MyModule.psd1') -ItemType File -Force | Out-Null
+
+            $mockAdaptedManifest = [PSCustomObject] @{
+                Type = 'MyModule/MyResource'
+            }
+
+            $mockUpdatedManifest = [PSCustomObject] @{
+                Type = 'MyModule/MyResource'
+            }
+
+            $mockManifestList = [PSCustomObject] @{
+                AdaptedResources = @($mockUpdatedManifest)
+            }
+
+            $mockManifestList | Add-Member -MemberType ScriptMethod -Name 'ToJson' -Value {
+                return '{"adaptedResources":[{"type":"MyModule/MyResource","updated":true}]}'
+            }
+
+            Mock -CommandName Import-Module -RemoveParameterValidation 'Name'
+
+            Mock -CommandName New-DscAdaptedResourceManifest -MockWith {
+                return @($mockAdaptedManifest)
+            }
+
+            Mock -CommandName New-DscPropertyOverride -MockWith {
+                return [PSCustomObject] @{ Name = 'Ensure' }
+            }
+
+            Mock -CommandName Update-DscAdaptedResourceManifest -MockWith {
+                return $mockUpdatedManifest
+            }
+
+            Mock -CommandName New-DscResourceManifest -MockWith {
+                return $mockManifestList
+            }
+
+            Mock -CommandName Set-Content
+
+            $mockTaskParametersWithOverrides = $mockTaskParameters + @{
+                BuildInfo = @{
+                    'DscResource.Authoring' = @{
+                        Create_DscResourceManifestsList = @{
+                            PropertyOverrides = @{
+                                MyResource = @(
+                                    @{
+                                        Name        = 'Ensure'
+                                        Description = 'Whether the resource should exist.'
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        It 'Should run the build task without throwing' {
+            {
+                Invoke-Build -Task 'Create_DscResourceManifestsList' -File $taskAlias.Definition @mockTaskParametersWithOverrides
+            } | Should -Not -Throw
+        }
+
+        It 'Should apply property overrides and write the manifests list file' {
+            Invoke-Build -Task 'Create_DscResourceManifestsList' -File $taskAlias.Definition @mockTaskParametersWithOverrides
+
+            Should -Invoke -CommandName Update-DscAdaptedResourceManifest -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Set-Content -Exactly -Times 1 -Scope It
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

Adds a new `DscResource.Authoring.build.ps1` to the Sampler `tasks/` directory. This ships two new `Invoke-Build` tasks to help generated adapted resource manifests from the already-built module artifact.
 
The two tasks explained. Firstly, the `Create_DscAdaptedResourceManifests`:

1. Call `New-DscAdaptedResouceManifest` against the built module manifest.
2. Writes one `*.dsc.adaptedResoruce.json` file per class-based DSC resources

The tasks support two properties to override: `FileNamePattern` and `PropertyOverrides`

 The `Create_DscResourceManifestsList` is nearly identical, but bundles everything together in a `*.dsc.manifests.json` file via `New-DscResourceManifset`.

An example tested with a real module (`SqlServerDsc`) on overriding properties in `build.yaml`:

```yaml
####################################################
#        DscResource.Authoring Configuration       #
####################################################
DscResource.Authoring:
  Create_DscAdaptedResourceManifests:
    # Optional: Output file name pattern. Use {ProjectName} and {ResourceName}
    # as placeholders. Defaults to:
    # '{ProjectName}.{ResourceName}.dsc.adaptedResource.json'
    # FileNamePattern: '{ProjectName}.{ResourceName}.dsc.adaptedResource.json'
    #
    # Optional: Per-resource property schema overrides applied after manifest
    # generation. Each key is a resource class name; the value is a list of
    # property override entries. Each entry requires a 'Name' key and supports
    # 'Description', 'Title', 'JsonSchema', 'RemoveKeys', and 'Required'.
    # PropertyOverrides:
    #   SqlAudit:
    #     - Name: Ensure
    #       Description: 'Whether the audit should be present or absent.'
    #   SqlPermission:
    #     - Name: Permission
    #       RemoveKeys:
    #         - type
    #         - enum
    #       JsonSchema:
    #         anyOf:
    #           - type: string
    #             enum: [Present, Absent]
    PropertyOverrides:
      SqlAudit:
        - Name: Ensure
          Description: 'Whether the SQL Server Audit should exist (Present) or be removed (Absent).'
        - Name: MaximumFileSize
          Description: 'The maximum size in units (Megabyte, Gigabyte, or Terabyte) of the audit file.'
          JsonSchema:
            minimum: 0
            maximum: 2147483647
        - Name: OnFailure
          Description: 'The action to take when the audit log write fails. Valid values are Continue, FailOperation, or Shutdown.'
  Create_DscResourceManifestsList:
    # Optional: The file name for the DSC resource manifests bundle. Defaults
    # to '<ProjectName>.dsc.manifests.json' when not specified.
    OutputFileName: 'SqlServerDsc.dsc.manifests.json'
    #
    # Optional: Per-resource property schema overrides applied after manifest
    # generation. Each key is a resource class name; the value is a list of
    # property override entries. Each entry requires a 'Name' key and supports
    # 'Description', 'Title', 'JsonSchema', 'RemoveKeys', and 'Required'.
    # PropertyOverrides:
    #   SqlAudit:
    #     - Name: Ensure
    #       Description: 'Whether the audit should be present or absent.'
    #   SqlPermission:
    #     - Name: Permission
    #       RemoveKeys:
    #         - type
    #         - enum
    #       JsonSchema:
    #         anyOf:
    #           - type: string
    #             enum: [Present, Absent]
```

Fixes #570 

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/571)
<!-- Reviewable:end -->
