### PR TITLE
Refactor Azure Pipelines to support runtime parameters and matrix job…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Get-SamplerProjectBuildInfo` and updated Pester build tasks to use its `BuildType`/`HasBuiltOutput` project model directly instead of Pester-specific setup/import/identity wrapper functions.
 - Pinned `ModuleBuilder` to `3.1.8` in `RequiredModules.psd1` because newer versions break Sampler task alias registration during tests.
 - Temporarily skip the `SimpleModule` integration tests that depend on building the sample module on Windows PowerShell 5.1 while `ModuleBuilder` 3.2 is broken there.
+- Change azure-pipelines.yml to support runtime parameters for running only selected platforms. Refactored the jobs to matrix jobs so it is not hardcoded jobs
 
 ### Fixed
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,16 +16,16 @@ parameters:
     type: object
     default:
       WINDOWS_PWSH7:
-        JOB_VMIMAGE: 'windows-latest'
+        vmImage: 'windows-latest'
         PWSH: true
       WINDOWS_PWSH5:
-        JOB_VMIMAGE: 'windows-latest'
+        vmImage: 'windows-latest'
         PWSH: false
       UBUNTU_PWSH7:
-        JOB_VMIMAGE: 'ubuntu-latest'
+        vmImage: 'ubuntu-latest'
         PWSH: true
       MACOS_PWSH7:
-        JOB_VMIMAGE: 'macos-latest'
+        vmImage: 'macos-latest'
         PWSH: true
 
 variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,23 @@ trigger:
     exclude:
     - "*-*"
 
+parameters:
+  - name: PlatformMatrix
+    type: object
+    default:
+      WINDOWS_PWSH7:
+        JOB_VMIMAGE: 'windows-latest'
+        PWSH: true
+      WINDOWS_PWSH5:
+        JOB_VMIMAGE: 'windows-latest'
+        PWSH: false
+      UBUNTU_PWSH7:
+        JOB_VMIMAGE: 'ubuntu-latest'
+        PWSH: true
+      MACOS_PWSH7:
+        JOB_VMIMAGE: 'macos-latest'
+        PWSH: true
+
 variables:
   buildFolderName: output
   buildArtifactName: output
@@ -56,14 +73,16 @@ stages:
   - stage: Test
     dependsOn: Build
     jobs:
-      - job: test_linux
-        displayName: 'Linux'
+      - job: Test
+        strategy:
+          matrix:
+            ${{ parameters.PlatformMatrix }}
         timeoutInMinutes: 0
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: $[ variables['vmImage'] ]
         steps:
           - task: DownloadPipelineArtifact@2
-            displayName: 'Download Build Artifact'
+            displayName: 'Download Pipeline Artifact'
             inputs:
               buildType: 'current'
               artifactName: $(buildArtifactName)
@@ -74,145 +93,33 @@ stages:
             inputs:
               filePath: './build.ps1'
               arguments: '-tasks test'
+              pwsh: $(PWSH)
           - task: PublishTestResults@2
             displayName: 'Publish Test Results'
             condition: succeededOrFailed()
             inputs:
               testResultsFormat: 'NUnit'
               testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Linux'
+              testRunTitle: $(vmImage)
           - task: PublishPipelineArtifact@1
             displayName: 'Publish Test Artifact'
             condition: succeededOrFailed()
             inputs:
               targetPath: '$(buildFolderName)/$(testResultFolderName)/'
-              artifactName: 'CodeCoverageLinux_$(System.JobAttempt)'
-              parallel: true
-
-      - job: test_windows_core
-        displayName: 'Windows (PowerShell Core)'
-        timeoutInMinutes: 0
-        pool:
-          vmImage: 'windows-latest'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Build Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Tests'
-            inputs:
-              filePath: './build.ps1'
-              arguments: '-tasks test'
-              pwsh: true
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Windows Server Core (PowerShell Core)'
-          - task: PublishPipelineArtifact@1
-            displayName: 'Publish Test Artifact'
-            condition: succeededOrFailed()
-            inputs:
-              targetPath: '$(buildFolderName)/$(testResultFolderName)/'
-              artifactName: 'CodeCoverageWinPS7_$(System.JobAttempt)'
-              parallel: true
-
-      - job: test_windows_ps
-        displayName: 'Windows (Windows PowerShell)'
-        timeoutInMinutes: 0
-        pool:
-          vmImage: 'windows-latest'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Build Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Tests'
-            inputs:
-              filePath: './build.ps1'
-              arguments: '-tasks test'
-              pwsh: false
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Windows Server Core (Windows PowerShell)'
-          - task: PublishPipelineArtifact@1
-            displayName: 'Publish Test Artifact'
-            condition: succeededOrFailed()
-            inputs:
-              targetPath: '$(buildFolderName)/$(testResultFolderName)/'
-              artifactName: 'CodeCoverageWinPS51_$(System.JobAttempt)'
-              parallel: true
-
-      - job: test_macos
-        displayName: 'macOS'
-        timeoutInMinutes: 0
-        pool:
-          vmImage: 'macos-latest'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Build Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Tests'
-            inputs:
-              filePath: './build.ps1'
-              arguments: '-tasks test'
-              pwsh: true
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'MacOS'
-          - task: PublishPipelineArtifact@1
-            displayName: 'Publish Test Artifact'
-            condition: succeededOrFailed()
-            inputs:
-              targetPath: '$(buildFolderName)/$(testResultFolderName)/'
-              artifactName: 'CodeCoverageMacOS_$(System.JobAttempt)'
+              artifactName: 'CodeCoverage$(vmImage)_$(System.JobAttempt)'
               parallel: true
 
       - job: Test_Integration
         displayName: 'Integration'
         strategy:
           matrix:
-            WINDOWS_PWSH7:
-              JOB_VMIMAGE: 'windows-latest'
-              PWSH: true
-            WINDOWS_PWSH5:
-              JOB_VMIMAGE: 'windows-latest'
-              PWSH: false
-            UBUNTU_PWSH7:
-              JOB_VMIMAGE: 'ubuntu-latest'
-              PWSH: true
-            MACOS_PWSH7:
-              JOB_VMIMAGE: 'macos-latest'
-              PWSH: true
+            ${{ parameters.PlatformMatrix }}
         pool:
-          vmImage: $(JOB_VMIMAGE)
+          vmImage: $[ variables['vmImage'] ]
         timeoutInMinutes: 0
         steps:
           - task: DownloadPipelineArtifact@2
-            displayName: 'Download Build Artifact'
+            displayName: 'Download Pipeline Artifact'
             inputs:
               buildType: 'current'
               artifactName: $(buildArtifactName)
@@ -235,10 +142,7 @@ stages:
       - job: Code_Coverage
         displayName: 'Publish Code Coverage'
         dependsOn:
-          - test_macos
-          - test_linux
-          - test_windows_core
-          - test_windows_ps
+          - Test
         condition: succeededOrFailed()
         pool:
           vmImage: 'ubuntu-latest'
@@ -251,35 +155,20 @@ stages:
             name: dscBuildVariable
             displayName: 'Set Environment Variables'
           - task: DownloadPipelineArtifact@2
-            displayName: 'Download Build Artifact'
+            displayName: 'Download Pipeline Artifact'
             inputs:
               buildType: 'current'
               artifactName: $(buildArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Test Artifact macOS'
-            inputs:
-              buildType: 'current'
-              artifactName: 'CodeCoverageMacOS_$(System.JobAttempt)'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Test Artifact Linux'
-            inputs:
-              buildType: 'current'
-              artifactName: 'CodeCoverageLinux_$(System.JobAttempt)'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Test Artifact Windows (PS 5.1)'
-            inputs:
-              buildType: 'current'
-              artifactName: 'CodeCoverageWinPS51_$(System.JobAttempt)'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Test Artifact Windows (PS7)'
-            inputs:
-              buildType: 'current'
-              artifactName: 'CodeCoverageWinPS7_$(System.JobAttempt)'
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
+
+          # Dynamic download of test artifacts based on matrix
+          - ${{ each platform in parameters.PlatformMatrix }}:
+            - task: DownloadPipelineArtifact@2
+              displayName: 'Download Test Artifact ${{ platform.Key }}'
+              inputs:
+                buildType: 'current'
+                artifactName: 'CodeCoverage${{ platform.Value.vmImage }}_$(System.JobAttempt)'
+                targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
           - task: PowerShell@2
             name: merge
             displayName: 'Merge Code Coverage files'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,18 +15,22 @@ parameters:
   - name: PlatformMatrix
     type: object
     default:
-      WINDOWS_PWSH7:
+      Windows_PWSH7:
         vmImage: 'windows-latest'
-        PWSH: true
-      WINDOWS_PWSH5:
+        UsePWSH: true
+        PlatformName: 'Windows_PWSH7'
+      Windows_PWSH5:
         vmImage: 'windows-latest'
-        PWSH: false
-      UBUNTU_PWSH7:
+        UsePWSH: false
+        PlatformName: 'Windows_PWSH5'
+      Ubuntu_PWSH7:
         vmImage: 'ubuntu-latest'
-        PWSH: true
-      MACOS_PWSH7:
+        UsePWSH: true
+        PlatformName: 'Ubuntu_PWSH7'
+      MacOS_PWSH7:
         vmImage: 'macos-latest'
-        PWSH: true
+        UsePWSH: true
+        PlatformName: 'MacOS_PWSH7'
 
 variables:
   buildFolderName: output
@@ -93,7 +97,7 @@ stages:
             inputs:
               filePath: './build.ps1'
               arguments: '-tasks test'
-              pwsh: $(PWSH)
+              pwsh: $(UsePWSH)
           - task: PublishTestResults@2
             displayName: 'Publish Test Results'
             condition: succeededOrFailed()
@@ -106,7 +110,7 @@ stages:
             condition: succeededOrFailed()
             inputs:
               targetPath: '$(buildFolderName)/$(testResultFolderName)/'
-              artifactName: 'CodeCoverage$(vmImage)_$(System.JobAttempt)'
+              artifactName: 'CodeCoverage_$(PlatformName)_$(System.JobAttempt)'
               parallel: true
 
       - job: Test_Integration
@@ -130,7 +134,7 @@ stages:
             inputs:
               filePath: './build.ps1'
               arguments: "-Tasks test -CodeCoverageThreshold 0 -PesterPath 'tests/Integration'"
-              pwsh: $(PWSH)
+              pwsh: $(UsePWSH)
           - task: PublishTestResults@2
             displayName: 'Publish Test Results'
             condition: succeededOrFailed()
@@ -167,7 +171,7 @@ stages:
               displayName: 'Download Test Artifact ${{ platform.Key }}'
               inputs:
                 buildType: 'current'
-                artifactName: 'CodeCoverage${{ platform.Value.vmImage }}_$(System.JobAttempt)'
+                artifactName: 'CodeCoverage_${{ platform.Value.PlatformName }}_$(System.JobAttempt)'
                 targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
           - task: PowerShell@2
             name: merge


### PR DESCRIPTION
# Pull Request


## Pull Request (PR) description
Removed a lot of static and redundant jobs for test and codecoverage handling. This is the design I have used in my own pipelines, and it seems it would be usefull here as well. Before I have seen a valid build run and the maintainers accept the design, I will keep the pipeline template changes out of this PR

### Changed
- Change azure-pipelines.yml to support runtime parameters for running only selected platforms. Refactored the jobs to matrix jobs so it is not hardcoded jobs

## Task list
- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/574)
<!-- Reviewable:end -->
