### PR TITLE
[DO NOT MERGE] Pester 6.0.0 release candidate update

### DIFF
--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -14,7 +14,10 @@
 
     InvokeBuild                 = 'latest'
     PSScriptAnalyzer            = 'latest'
-    Pester                      = 'latest'
+    Pester                      = @{
+        Version    = '6.0.0-rc1'
+        Parameters = @{ AllowPrerelease = $true }
+    }
     Plaster                     = 'latest'
     ModuleBuilder               = '3.1.8'
     MarkdownLinkCheck           = 'latest'

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -15,7 +15,7 @@
     InvokeBuild                 = 'latest'
     PSScriptAnalyzer            = 'latest'
     Pester                      = @{
-        Version    = '6.0.0-rc1'
+        Version    = '6.0.0-rc4'
         Parameters = @{ AllowPrerelease = $true }
     }
     Plaster                     = 'latest'


### PR DESCRIPTION
Hi — Pester 6.0.0 is almost ready, and before I release it I'm trying it out
against real-world Pester v5 test suites.

This PR updates Pester to the 6.0.0 release candidate and makes the changes
needed for your tests to run on it. I opened it to learn two things:

- whether migrating from v5 to v6 is straightforward, and
- where v6 breaks or behaves differently, so I can fix those things before the
  final release instead of after.

You don't need to merge this, and I'd suggest you don't — it's only meant to
show what a v6 update would involve and to give me feedback. Please leave it
open, though: if more release candidates come out I'll push those updates here
too, and I'll close it myself afterwards.

This PR was co-authored by GitHub Copilot. If you'd rather not receive
AI-assisted PRs, just close it and I won't open one for the next release.

Thanks for the CI time this run used, and for maintaining a suite I could test
against.

— Jakub & Copilot

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/577)
<!-- Reviewable:end -->
