### PR TITLE
set sampler task variable artifact context

### DIFF
--- a/.build/tasks/Build-Module.ModuleBuilder.build.ps1
+++ b/.build/tasks/Build-Module.ModuleBuilder.build.ps1
@@ -102,7 +102,9 @@ Task Build_ModuleOutput_ModuleBuilder {
 
     $sourceModuleInfo = Get-SamplerModuleInfo -ModuleManifestPath $moduleManifestPath
 
-    if ($sourceModuleInfo.AliasesToExport)
+    $sourceAliasesToExport = $sourceModuleInfo.AliasesToExport
+
+    if ($sourceAliasesToExport)
     {
         if (Split-Path -IsAbsolute -Path $BuiltModule.RootModule)
         {
@@ -113,7 +115,28 @@ Task Build_ModuleOutput_ModuleBuilder {
             $builtModuleManifestPath = Join-Path -Path $BuiltModule.ModuleBase -ChildPath ('{0}.psd1' -f $ProjectName)
         }
 
-        Update-ModuleManifest -Path $builtModuleManifestPath -AliasesToExport $sourceModuleInfo.AliasesToExport
+        $builtManifestData = Import-PowerShellDataFile -Path $builtModuleManifestPath -ErrorAction 'Stop'
+        $builtAliasesToExport = @($builtManifestData.AliasesToExport)
+
+        <#
+            Propagate AliasesToExport from the source manifest when:
+            - Source defines a concrete alias list (not a wildcard): always propagate so
+              that explicit aliases are not lost.
+            - Source uses the wildcard '*' but ModuleBuilder resolved nothing (wrote @()):
+              aliases are registered dynamically (e.g. in suffix.ps1) and ModuleBuilder
+              cannot enumerate them statically; restore '*' so they remain visible.
+
+            Do NOT overwrite a concrete list that ModuleBuilder already resolved with '*'
+            from the source manifest, as that would undo ModuleBuilder's enumeration work.
+        #>
+        $shouldUpdate =
+            ($sourceAliasesToExport -ne '*') -or
+            ($builtAliasesToExport.Count -eq 0)
+
+        if ($shouldUpdate)
+        {
+            Update-ModuleManifest -Path $builtModuleManifestPath -AliasesToExport $sourceAliasesToExport
+        }
     }
 
     # if we built the PSM1 on Windows with a BOM, re-write without BOM

--- a/tests/Unit/tasks/Build-Module.ModuleBuilder.build.Tests.ps1
+++ b/tests/Unit/tasks/Build-Module.ModuleBuilder.build.Tests.ps1
@@ -89,12 +89,6 @@ Describe 'Build_ModuleOutput_ModuleBuilder' {
             $Path -match 'ReleaseNotes.md'
         }
 
-        Mock -CommandName Get-SamplerModuleInfo -RemoveParameterValidation 'ModuleManifestPath' -MockWith {
-            return @{
-                AliasesToExport = '*'
-            }
-        }
-
         Mock -CommandName Update-ModuleManifest
 
         Mock -CommandName Get-Content -ParameterFilter {
@@ -114,13 +108,79 @@ Describe 'Build_ModuleOutput_ModuleBuilder' {
         }
     }
 
-    It 'Should run the build task without throwing' {
-        {
-            Invoke-Build -Task 'Build_ModuleOutput_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
-        } | Should -Not -Throw
+    Context 'When source manifest has AliasesToExport set to wildcard and ModuleBuilder resolved no aliases' {
+        BeforeAll {
+            Mock -CommandName Get-SamplerModuleInfo -RemoveParameterValidation 'ModuleManifestPath' -MockWith {
+                return @{
+                    AliasesToExport = '*'
+                }
+            }
 
-        Should -Invoke -CommandName Update-ModuleManifest -Exactly -Times 1 -Scope It -ParameterFilter {
-            $AliasesToExport -eq '*'
+            Mock -CommandName Import-PowerShellDataFile -RemoveParameterValidation 'Path' -MockWith {
+                return @{
+                    AliasesToExport = @()
+                }
+            }
+        }
+
+        It 'Should run the build task without throwing and restore the wildcard so dynamically registered aliases remain visible' {
+            {
+                Invoke-Build -Task 'Build_ModuleOutput_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Invoke -CommandName Update-ModuleManifest -Exactly -Times 1 -Scope It -ParameterFilter {
+                $AliasesToExport -eq '*'
+            }
+        }
+    }
+
+    Context 'When source manifest has AliasesToExport set to wildcard and ModuleBuilder resolved a concrete alias list' {
+        BeforeAll {
+            Mock -CommandName Get-SamplerModuleInfo -RemoveParameterValidation 'ModuleManifestPath' -MockWith {
+                return @{
+                    AliasesToExport = '*'
+                }
+            }
+
+            Mock -CommandName Import-PowerShellDataFile -RemoveParameterValidation 'Path' -MockWith {
+                return @{
+                    AliasesToExport = @('Get-Foo', 'Set-Foo')
+                }
+            }
+        }
+
+        It 'Should run the build task without throwing and not override the concrete alias list resolved by ModuleBuilder' {
+            {
+                Invoke-Build -Task 'Build_ModuleOutput_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Not -Invoke -CommandName Update-ModuleManifest -Scope It
+        }
+    }
+
+    Context 'When source manifest has a concrete AliasesToExport list' {
+        BeforeAll {
+            Mock -CommandName Get-SamplerModuleInfo -RemoveParameterValidation 'ModuleManifestPath' -MockWith {
+                return @{
+                    AliasesToExport = @('Get-Foo', 'Set-Foo')
+                }
+            }
+
+            Mock -CommandName Import-PowerShellDataFile -RemoveParameterValidation 'Path' -MockWith {
+                return @{
+                    AliasesToExport = @()
+                }
+            }
+        }
+
+        It 'Should run the build task without throwing and propagate the concrete alias list' {
+            {
+                Invoke-Build -Task 'Build_ModuleOutput_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Invoke -CommandName Update-ModuleManifest -Exactly -Times 1 -Scope It -ParameterFilter {
+                $AliasesToExport -contains 'Get-Foo' -and $AliasesToExport -contains 'Set-Foo'
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements to the build and packaging pipeline, with a focus on clarifying the distinction between source kind and artifact context, enforcing fast failure when module artifacts are missing, and improving documentation and guidance around these concepts. The changes also update task logic for explicit artifact context handling and enhance version resolution behavior for both module and non-module repositories.

**Key changes:**

### Build and Packaging Logic

* `Set-SamplerTaskVariable` now uses an explicit `-ArtifactContext` parameter (such as `'Chocolatey'`) for tasks that produce non-default artifacts, rather than inferring artifact type by probing output folders. This clarifies intent and avoids ambiguity when the same source tree produces multiple artifact types. [[1]](diffhunk://#diff-62ee2b59cdcd8df6eedd9e36a56f0468be11c9fb7784b90962c2352e0633f2c6L66-R66) [[2]](diffhunk://#diff-62ee2b59cdcd8df6eedd9e36a56f0468be11c9fb7784b90962c2352e0633f2c6L84-R84) [[3]](diffhunk://#diff-62ee2b59cdcd8df6eedd9e36a56f0468be11c9fb7784b90962c2352e0633f2c6L157-R157) [[4]](diffhunk://#diff-62ee2b59cdcd8df6eedd9e36a56f0468be11c9fb7784b90962c2352e0633f2c6L230-R230) [[5]](diffhunk://#diff-62ee2b59cdcd8df6eedd9e36a56f0468be11c9fb7784b90962c2352e0633f2c6L268-R268) [[6]](diffhunk://#diff-d7cb4c4b615f5a648725c8194e2bdf3cf34c54ba76319c75f8bd3159a3e4045eR57-R65) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L771-R788) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L788-R808) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R820-R827) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R898-R917) [[11]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R123-R125)
* Tasks that operate on a built module artifact now fail fast if the built manifest is missing, instead of silently recomputing module state from source. This ensures more predictable and correct build/test workflows. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R11) [[2]](diffhunk://#diff-cb924a5cd5e0e2c782311b1bed26338366dc9b04a2e206d2c4da88f8850747a0R81-R88) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L788-R808) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R820-R827) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL25-R26)
* For non-module sources, version resolution now falls back in the order: `ModuleVersion`/`SemVer` → `GitVersion` → static version `0.0.1`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR46) [[2]](diffhunk://#diff-d7cb4c4b615f5a648725c8194e2bdf3cf34c54ba76319c75f8bd3159a3e4045eR57-R65) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L886-R935) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R123-R125)

### Task Implementation

* The `Build_ModuleOutput_ModuleBuilder` task now ensures that `AliasesToExport` from the source manifest are carried over to the built module manifest, improving completeness of the build output.
* Pester test tasks (`Fail_Build_If_Pester_Tests_Failed`, `Pester_Run_Times`) now handle cases where `ProjectName` or `ModuleVersion` are missing by falling back to the latest available test result, improving robustness for repository-only and non-module test runs. [[1]](diffhunk://#diff-90db9d34895a5abb25abb502902a45b8c636c2e38c033a1a8b992a5cb66a11f0L456-R468) [[2]](diffhunk://#diff-90db9d34895a5abb25abb502902a45b8c636c2e38c033a1a8b992a5cb66a11f0L1230-R1252)

### Documentation and Guidance

* The README and contributor instructions have been updated to document the separation of source kind and artifact context, clarify version fallback behavior, and provide explicit guidance for module, alternate-artifact, and repository-only pipelines. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R71-R87) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R898-R917) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L886-R935) [[4]](diffhunk://#diff-d7cb4c4b615f5a648725c8194e2bdf3cf34c54ba76319c75f8bd3159a3e4045eR57-R65) [[5]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R123-R125) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL25-R26)
* Test-writing and build-task instructions now emphasize explicit assertion of build/pipeline intent and correct handling of built module artifacts versus source state. [[1]](diffhunk://#diff-cb924a5cd5e0e2c782311b1bed26338366dc9b04a2e206d2c4da88f8850747a0R81-R88) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R11)

These changes improve pipeline reliability, make artifact intent explicit, and provide clearer guidance for both contributors and downstream users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/578)
<!-- Reviewable:end -->
