### PR TITLE
Add workspace local linking of related repos

### DIFF
--- a/.build/tasks/Build-Module.ModuleBuilder.build.ps1
+++ b/.build/tasks/Build-Module.ModuleBuilder.build.ps1
@@ -102,7 +102,9 @@ Task Build_ModuleOutput_ModuleBuilder {
 
     $sourceModuleInfo = Get-SamplerModuleInfo -ModuleManifestPath $moduleManifestPath
 
-    if ($sourceModuleInfo.AliasesToExport)
+    $sourceAliasesToExport = $sourceModuleInfo.AliasesToExport
+
+    if ($sourceAliasesToExport)
     {
         if (Split-Path -IsAbsolute -Path $BuiltModule.RootModule)
         {
@@ -113,7 +115,28 @@ Task Build_ModuleOutput_ModuleBuilder {
             $builtModuleManifestPath = Join-Path -Path $BuiltModule.ModuleBase -ChildPath ('{0}.psd1' -f $ProjectName)
         }
 
-        Update-ModuleManifest -Path $builtModuleManifestPath -AliasesToExport $sourceModuleInfo.AliasesToExport
+        $builtManifestData = Import-PowerShellDataFile -Path $builtModuleManifestPath -ErrorAction 'Stop'
+        $builtAliasesToExport = @($builtManifestData.AliasesToExport)
+
+        <#
+            Propagate AliasesToExport from the source manifest when:
+            - Source defines a concrete alias list (not a wildcard): always propagate so
+              that explicit aliases are not lost.
+            - Source uses the wildcard '*' but ModuleBuilder resolved nothing (wrote @()):
+              aliases are registered dynamically (e.g. in suffix.ps1) and ModuleBuilder
+              cannot enumerate them statically; restore '*' so they remain visible.
+
+            Do NOT overwrite a concrete list that ModuleBuilder already resolved with '*'
+            from the source manifest, as that would undo ModuleBuilder's enumeration work.
+        #>
+        $shouldUpdate =
+            ($sourceAliasesToExport -ne '*') -or
+            ($builtAliasesToExport.Count -eq 0)
+
+        if ($shouldUpdate)
+        {
+            Update-ModuleManifest -Path $builtModuleManifestPath -AliasesToExport $sourceAliasesToExport
+        }
     }
 
     # if we built the PSM1 on Windows with a BOM, re-write without BOM

--- a/.build/tasks/Clean.ModuleBuilder.build.ps1
+++ b/.build/tasks/Clean.ModuleBuilder.build.ps1
@@ -1,12 +1,16 @@
 param (
     # Base directory of all output (default to 'output')
     [Parameter()]
-    [string]
+    [System.String]
     $OutputDirectory = (property OutputDirectory (Join-Path -Path $BuildRoot -ChildPath 'output')),
 
     [Parameter()]
-    [string]
-    $RequiredModulesDirectory = (property RequiredModulesDirectory $(Join-Path -Path $OutputDirectory -ChildPath 'RequiredModules'))
+    [System.String]
+    $RequiredModulesDirectory = (property RequiredModulesDirectory $(Join-Path -Path $OutputDirectory -ChildPath 'RequiredModules')),
+
+    [Parameter()]
+    [System.String]
+    $AgentOutputSubdirectory = (property AgentOutputSubdirectory 'agentic')
 )
 
 # Removes the OutputDirectory\modules (errors if Pester is loaded)
@@ -14,12 +18,18 @@ task CleanAll Clean, CleanModule
 
 # Synopsis: Deleting the content of the Build Output folder, except ./modules
 task Clean {
-    $OutputDirectory =  Get-SamplerAbsolutePath -Path $OutputDirectory -RelativeTo $BuildRoot
-    $FolderToExclude = Split-Path -Leaf -Path $RequiredModulesDirectory
+    $OutputDirectory = Get-SamplerAbsolutePath -Path $OutputDirectory -RelativeTo $BuildRoot
 
-    Write-Build -Color Green "Removing $OutputDirectory\* excluding $FolderToExclude"
+    $foldersToExclude = @(Split-Path -Leaf -Path $RequiredModulesDirectory)
 
-    Get-ChildItem -Path $OutputDirectory -Exclude $FolderToExclude | Remove-Item -Force -Recurse
+    if (-not [System.String]::IsNullOrWhiteSpace($AgentOutputSubdirectory))
+    {
+        $foldersToExclude += $AgentOutputSubdirectory
+    }
+
+    Write-Build -Color Green "Removing $OutputDirectory\* excluding $($foldersToExclude -join ', ')"
+
+    Get-ChildItem -Path $OutputDirectory -Exclude $foldersToExclude | Remove-Item -Force -Recurse
 }
 
 # Synopsis: Removes the Modules from OutputDirectory\Modules folder, might fail if there's an handle on one file.

--- a/.build/tasks/WorkspaceDependencies.build.ps1
+++ b/.build/tasks/WorkspaceDependencies.build.ps1
@@ -1,0 +1,111 @@
+<#
+    .SYNOPSIS
+        Links sibling workspace module build outputs into the local output module path.
+
+    .DESCRIPTION
+        When working in a multi-repo VSCode workspace, this task walks the parent
+        directory (the workspace root), finds each sibling repo's built module
+        output, and creates a symlink (or Windows junction fallback) in the local
+        `output\module\` path so that `PSModulePath` resolution works seamlessly
+        during tests.
+
+        Configure the list of sibling modules via `WorkspaceModules` in `build.yaml`:
+
+        ```yaml
+        WorkspaceModules:
+          - OtherModule
+          - AnotherModule
+        ```
+
+    .PARAMETER OutputDirectory
+        The base directory of all output. Defaults to folder `output` relative to
+        `$BuildRoot`.
+
+    .PARAMETER BuiltModuleSubdirectory
+        The parent path of the module to be built. Defaults to `module`.
+
+    .PARAMETER WorkspaceModules
+        The sibling workspace modules to link into the local output module path.
+        Can also be read from `$BuildInfo['WorkspaceModules']`.
+
+    .PARAMETER BuildInfo
+        The build information hashtable, typically populated from `build.yaml`.
+        Used to read `WorkspaceModules` when not supplied as a parameter.
+#>
+
+param
+(
+    [Parameter()]
+    [System.String]
+    $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot 'output')),
+
+    [Parameter()]
+    [System.String]
+    $BuiltModuleSubdirectory = (property BuiltModuleSubdirectory 'module'),
+
+    [Parameter()]
+    [System.String[]]
+    $WorkspaceModules = (property WorkspaceModules @()),
+
+    [Parameter()]
+    [System.Collections.Hashtable]
+    $BuildInfo = (property BuildInfo @{ })
+)
+
+# Synopsis: Links sibling workspace module build outputs into the local output module path.
+task Link_Local_Workspace_Dependencies {
+    # Get the values for task variables, see https://github.com/gaelcolas/Sampler?tab=readme-ov-file#build-task-variables.
+    . Set-SamplerTaskVariable -AsNewBuild
+
+    if ($WorkspaceModules.Count -eq 0 -and $BuildInfo.ContainsKey('WorkspaceModules'))
+    {
+        $WorkspaceModules = [System.String[]] $BuildInfo['WorkspaceModules']
+    }
+
+    if ($WorkspaceModules.Count -eq 0)
+    {
+        Write-Build -Color 'DarkGray' -Text 'No WorkspaceModules configured. Skipping.'
+        return
+    }
+
+    $workspaceRoot = Split-Path -Path $BuildRoot -Parent
+
+    $linkedModuleRootParams = @{
+        BuildRoot               = $BuildRoot
+        OutputDirectory         = $OutputDirectory
+        BuiltModuleSubdirectory = $BuiltModuleSubdirectory
+    }
+
+    $linkedModuleRoot = Get-SamplerWorkspaceLinkedModuleRoot @linkedModuleRootParams
+
+    if (-not (Test-Path -Path $linkedModuleRoot))
+    {
+        $null = New-Item -Path $linkedModuleRoot -ItemType Directory -Force
+    }
+
+    foreach ($workspaceModule in $WorkspaceModules)
+    {
+        $builtModulePathParams = @{
+            ModuleName    = $workspaceModule
+            WorkspaceRoot = $workspaceRoot
+        }
+
+        $builtModulePath = Get-SamplerWorkspaceBuiltModulePath @builtModulePathParams
+
+        $linkPath = Join-Path -Path $linkedModuleRoot -ChildPath $workspaceModule
+
+        $moduleLinkParams = @{
+            LinkPath   = $linkPath
+            TargetPath = $builtModulePath
+        }
+
+        Write-Build Green ("Linking local workspace dependency '{0}' to '{1}'." -f $workspaceModule, $builtModulePath)
+
+        $linkType = New-SamplerWorkspaceModuleLink @moduleLinkParams
+
+        if ($linkType -eq 'Junction')
+        {
+            Write-Build Yellow ("Symbolic link creation failed for '{0}'. Falling back to a directory junction." -f $workspaceModule)
+        }
+    }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,27 +42,33 @@ Sampler builds and tests are slow (task discovery alone is ~60–120s; a focused
 - **Never wrap the `./build.ps1 ...` invocation in `| Select-Object -Last <N>` (or `| Select-Object -First <N>`, `| Out-String -Stream | Select-Object ...`, etc.) inline.** Those filters force PowerShell to buffer the *entire* output stream before emitting anything, and the wrapping pipeline call appears to hang from the agent's perspective even after the build has finished. Worse, if the build asks for input (it should not, but ResolveDependency prompts can sneak in), the prompt is buried in the buffer and the shell is effectively stuck.
 - **Always tee the output to a log file and then inspect that log file separately**, so the build can stream freely and the agent can poll the log without consuming context with the entire output.
 
-Recommended pattern (works in both sync and async modes):
+Use `output\agentic\` as the log directory. The `Clean` task excludes this folder so logs survive between builds and are never accidentally deleted:
 
 ```powershell
-if (Test-Path output\validate-test.log) { Remove-Item output\validate-test.log -Force }
+$null = New-Item -Path 'output\agentic' -ItemType Directory -Force
 
 ./build.ps1 -Tasks test -PesterPath '<paths>' -CodeCoverageThreshold 0 2>&1 |
-    Tee-Object -FilePath output\validate-test.log
+    Tee-Object -FilePath 'output\agentic\test.log'
 ```
 
 Then, while the build runs (or after it completes), inspect the log without re-running anything:
 
 ```powershell
 # Quick status / tail
-Get-Item   output\validate-test.log | Select-Object Length, LastWriteTime
-Get-Content output\validate-test.log -Tail 20
+Get-Item   output\agentic\test.log | Select-Object Length, LastWriteTime
+Get-Content output\agentic\test.log -Tail 20
 
 # Look for the conventional "Build FAILED" / "Build succeeded" terminator
-Select-String -Path output\validate-test.log -Pattern 'Build (FAILED|succeeded)'
+Select-String -Path output\agentic\test.log -Pattern 'Build (FAILED|succeeded)'
 ```
 
 When running long commands through the `powershell` tool, prefer `mode="async"` with `Tee-Object`, then poll with short `read_powershell` reads or by reading the log file directly. Do not pass `| Select-Object -Last N` as a workaround for wanting a short response — read the log file with `Get-Content -Tail` instead.
+
+**Clean up when done:** Once you have finished investigating a build or test failure, remove the agentic log folder:
+
+```powershell
+Remove-Item -Path 'output\agentic' -Recurse -Force -ErrorAction 'Ignore'
+```
 
 ### Diagnosing test failures from XML output
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,6 +105,12 @@ When running long commands through the `powershell` tool, prefer `mode="async"` 
 - **Always look at the *latest* result file**: every test invocation rewrites these XML files, so sort by `LastWriteTime` descending instead of relying on a hard-coded path.
 - The failing-test summary written to the log file (e.g. `Build FAILED. N tasks, 1 errors, ...`) tells you *that* something failed; only the XML tells you *what* failed. Quote the XML message in any report back to the user — do not paraphrase the build-log tail.
 
+## Git workflow
+
+- Never run `git commit`, `git push`, or `git tag`. Leave all commits to the user so they can review with `git diff` first.
+- Stage changes with `git add` only when explicitly asked to prepare a commit.
+- After completing work, summarize what changed so the user can review before committing.
+
 ## High-level architecture
 
 - `Sampler/` is the module source. `Sampler.psm1` dot-sources everything under `Public/` and `Private/` and exports public function basenames but is rarely used as it's overridden during build by the built artifact under `output/module/`. The module is designed to be imported and used directly from the source tree for development when necessary, but the built artifact is the intended consumption method for users and CI.
@@ -124,7 +130,7 @@ When running long commands through the `powershell` tool, prefer `mode="async"` 
 - Use `Set-SamplerTaskVariable -AsNewBuild` for tasks that are establishing fresh artifact state, and pass `-ArtifactContext 'Chocolatey'` (or another explicit context) for non-default artifact pipelines. Do not infer alternate artifact types by probing output folder existence.
 - For non-module sources, the default version fallback chain is `ModuleVersion`/`SemVer` -> `GitVersion` -> static version `0.0.1`.
 - Treat template changes as product changes. If you modify anything under `Sampler/Templates/`, update the matching integration tests under `tests/Integration/PlasterTemplates/` and preserve expected scaffolded file trees.
-- The repo enforces changelog discipline through QA tests. For any repository change that affects behavior, tests, templates, tasks, or documentation consumed by users/contributors, update `CHANGELOG.md` under `Unreleased` in the same change set or QA tests will fail.
+- The repo enforces changelog discipline through QA tests. Update `CHANGELOG.md` under `Unreleased` only for changes that affect the module behavior, public API, templates, tasks, or module-facing documentation consumed by users or contributors. Build, pipeline, CI, and Copilot-instruction-only changes do not require changelog entries.
 - Public and private functions are expected to have comment-based help and corresponding unit tests; QA tests inspect `.SYNOPSIS`, `.DESCRIPTION`, examples, and parameter help for every exported function.
 - Prefer `-ErrorAction 'Ignore'` over `-ErrorAction 'SilentlyContinue'` for cmdlet calls whose failure is *expected* (probes such as `Get-Command`, `Get-Module`, `Get-Item`, `Test-Path`-style lookups). `Ignore` does not append to `$Error`, keeping the error history clean for real diagnostics. Reserve `SilentlyContinue` for cases where you intentionally want the error recorded but not surfaced.
 - Code must run on **both Windows PowerShell 5.1 (Desktop) and PowerShell 7+ (Core)**, and must work cross-platform on Windows, Linux, and macOS, unless the module manifest of the module under development declares otherwise (i.e. `PowerShellVersion` is `'7.0'` or higher and/or `CompatiblePSEditions` is restricted to `@('Core')`). Sampler itself targets `PowerShellVersion = '5.0'` with no `CompatiblePSEditions` restriction (see `Sampler/Sampler.psd1`), so any change to Sampler source, templates, build tasks, or scripts must:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -110,6 +110,7 @@ Remove-Item -Path 'output\agentic' -Recurse -Force -ErrorAction 'Ignore'
 
 - **Always look at the *latest* result file**: every test invocation rewrites these XML files, so sort by `LastWriteTime` descending instead of relying on a hard-coded path.
 - The failing-test summary written to the log file (e.g. `Build FAILED. N tasks, 1 errors, ...`) tells you *that* something failed; only the XML tells you *what* failed. Quote the XML message in any report back to the user — do not paraphrase the build-log tail.
+- **The built module output path uses only the main version number**, not the full prerelease tag. `output/module/Sampler/0.119.2/Sampler.psm1` is the path even when `ModuleVersion` is `0.119.2-gaelcolas`. Do not infer a stale CI build from a version mismatch in the path alone — compare the commit SHA instead.
 
 ## Git workflow
 

--- a/.github/instructions/build-tasks.instructions.md
+++ b/.github/instructions/build-tasks.instructions.md
@@ -10,6 +10,7 @@ applyTo: '.build/tasks/*.build.ps1'
 - All build task files live under `.build/tasks/` and follow the pattern `<Purpose>.<Subsystem>.build.ps1` (e.g., `Invoke-Pester.pester.build.ps1`, `Build-Module.ModuleBuilder.build.ps1`).
 - The file naming determines the alias that `suffix.ps1` auto-registers for InvokeBuild: `<BaseName>.Sampler.ib.tasks`. Do not register aliases manually inside task files.
 - Task files in `.build/tasks/` are copied into the built module (`output/module/Sampler/<version>/tasks/`) via the `CopyPaths` entry in `build.yaml`. If you add a new task file, add any required module imports or workflow entries to `build.yaml` — not to `build.ps1`.
+- Put helper functions used by a task in a sibling `.psm1` file next to the task file (e.g., `MyTasks.build.psm1` alongside `MyTasks.build.ps1`). Keep the `.build.ps1` focused on task parameters, task definitions, and task-scoped logging; keep helper modules free of task-scoped UI concerns such as `Write-Build`.
 
 ## Parameter block
 

--- a/.github/instructions/classes-and-type-accelerators.instructions.md
+++ b/.github/instructions/classes-and-type-accelerators.instructions.md
@@ -1,0 +1,38 @@
+---
+description: 'Module class export and type accelerator instructions'
+applyTo: '{source/suffix.ps1,source/Classes/*.ps1,source/Enum/*.ps1,source/synio.process.psm1}'
+---
+
+# Classes and Type Accelerators Guidelines
+
+## Purpose
+
+- This repository uses the `source\suffix.ps1` type-accelerator pattern to expose selected PowerShell classes after module import.
+- This is a deliberate workaround for PowerShell modules not being able to export classes directly.
+
+## Registration rules
+
+- Keep type-accelerator registration in `source\suffix.ps1`, after classes are available.
+- Use module-qualified accelerators when possible to reduce name collisions.
+- Resolve the module name dynamically rather than hard-coding it.
+- Validate that each type exists before registering its accelerator.
+- Warn when overriding an existing accelerator and fail when the target type cannot be found.
+
+## Cleanup rules
+
+- Remove namespaced accelerators in the module `OnRemove` handler.
+- Keep cleanup logic aligned with the accelerators registered during import.
+
+## Usage implications
+
+- Module consumers must import the module before invoking code paths that depend on exported type accelerators.
+- Dependent modules should rely on manifest `RequiredModules` when they need these accelerators available before command invocation.
+- Keep this pattern compatible with Windows PowerShell 5.1 and PowerShell 7.
+
+## Change safety
+
+- When adding, removing, or renaming exported classes, update:
+  - `source\suffix.ps1`
+  - the relevant class files under `source\Classes\`
+  - any tests that instantiate or reference those classes
+- Preserve the current collision-avoidance behavior unless intentionally redesigning the class consumption model.

--- a/.github/instructions/private-functions.instructions.md
+++ b/.github/instructions/private-functions.instructions.md
@@ -17,6 +17,25 @@ Private functions follow the same baseline engineering rules as public functions
 - Use `[CmdletBinding()]` and include `[OutputType(...)]`.
 - Use explicit .NET parameter types (`[System.String]`, `[System.Boolean]`, etc.).
 - Keep parameter names and defaults stable when consumed by public functions/tasks.
+- Follow DSC Community parameter style: `[Parameter()]` attribute, type, and variable name each on their own line, with a blank line between comma-separated parameter declarations:
+
+```powershell
+param
+(
+    [Parameter(Mandatory = $true)]
+    [System.String]
+    $ProjectName,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $Force
+)
+```
+
+## PowerShell style
+
+- Prefer `$null = <expression>` over `<expression> | Out-Null` to suppress output.
+- Prefer splatting over backtick-based line continuation for multi-line command calls.
 
 ## Validation model
 

--- a/.github/instructions/private-functions.instructions.md
+++ b/.github/instructions/private-functions.instructions.md
@@ -36,6 +36,7 @@ param
 
 - Prefer `$null = <expression>` over `<expression> | Out-Null` to suppress output.
 - Prefer splatting over backtick-based line continuation for multi-line command calls.
+- Never use hardcoded backslash separators inside `Join-Path -ChildPath` strings. Build multi-level paths with chained `Join-Path` calls (one component at a time). Backslashes in a `ChildPath` are not path separators on Linux/macOS.
 
 ## Validation model
 

--- a/.github/instructions/public-functions.instructions.md
+++ b/.github/instructions/public-functions.instructions.md
@@ -50,6 +50,31 @@ Get-ChildItem -Path $OutputDirectory `
     -Recurse
 ```
 
+## Cross-platform path construction
+
+- Never use hardcoded backslash separators inside `Join-Path -ChildPath` strings. On Linux/macOS, backslashes are not path separators; a `ChildPath` containing backslashes is treated as a single filename component, not a multi-level path.
+- Build multi-level paths with chained `Join-Path` calls:
+
+```powershell
+# Wrong — backslash is not a separator on Linux
+Join-Path -Path $root -ChildPath 'output\module\MyModule\*\MyModule.psd1'
+
+# Correct
+$p = Join-Path -Path $root -ChildPath 'output'
+$p = Join-Path -Path $p    -ChildPath 'module'
+$p = Join-Path -Path $p    -ChildPath $ModuleName
+$p = Join-Path -Path $p    -ChildPath '*'
+$p = Join-Path -Path $p    -ChildPath "$ModuleName.psd1"
+```
+
+- Never hard-code `\` in user-facing messages that include paths; use `Join-Path` to build the example path.
+
+## State-changing functions (`SupportsShouldProcess`)
+
+- Functions whose verb implies state change (`New-`, `Remove-`, `Set-`, `Start-`, etc.) must declare `[CmdletBinding(SupportsShouldProcess = $true)]` to satisfy PSScriptAnalyzer rule `PSUseShouldProcessForStateChangingFunctions`.
+- Wrap the actual mutation with `if ($PSCmdlet.ShouldProcess($target, $action))`.
+- In tests, pass `-Confirm:$false` to bypass the `ShouldProcess` prompt.
+
 ## Validation model
 
 - Prefer enums over `ValidateSet` for option lists that are reused or expected to evolve.

--- a/.github/instructions/public-functions.instructions.md
+++ b/.github/instructions/public-functions.instructions.md
@@ -17,6 +17,38 @@ Public functions are user-facing and are the most critical API surface of Sample
 - Use `[CmdletBinding()]` and include `[OutputType(...)]`.
 - Use explicit .NET parameter types (`[System.String]`, `[System.Boolean]`, etc.).
 - Keep parameter names and defaults stable unless intentionally introducing a breaking change.
+- Follow DSC Community parameter style: `[Parameter()]` attribute, type, and variable name each on their own line, with a blank line between comma-separated parameter declarations:
+
+```powershell
+param
+(
+    [Parameter(Mandatory = $true)]
+    [System.String]
+    $ProjectName,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $Force
+)
+```
+
+## PowerShell style
+
+- Prefer `$null = <expression>` over `<expression> | Out-Null` to suppress output.
+- Prefer splatting over backtick-based line continuation for multi-line command calls:
+
+```powershell
+# Preferred
+$params = @{
+    Path    = $OutputDirectory
+    Recurse = $true
+}
+Get-ChildItem @params
+
+# Avoid
+Get-ChildItem -Path $OutputDirectory `
+    -Recurse
+```
 
 ## Validation model
 

--- a/.github/instructions/test-writing.instructions.md
+++ b/.github/instructions/test-writing.instructions.md
@@ -79,6 +79,18 @@ Use the most specific assertion available — avoid `Should -Be $true` when a de
 - Always scope mock-call assertions with `-Scope It` so counts reset between tests.
 - Call the function under test with its module-qualified name (`Sampler\Get-Foo`) to avoid accidentally calling a mock or a stale imported version.
 
+## Windows PowerShell 5.1 compatibility
+
+- Always wrap pipeline expressions in `@()` before calling `.Count`, `.Length`, or indexing into the result (`[0]`). On Windows PowerShell 5.1, a pipeline that produces exactly one object returns a scalar, not an array, and scalars without a `Count` property return `$null` instead of `1`. PowerShell 7 adds a synthetic `Count` member to all objects, masking the bug.
+
+```powershell
+# Wrong — returns $null on WinPS 5.1 when exactly one item matches
+($collection | Where-Object { $_.Name -eq 'X' }).Count | Should -Be 1
+
+# Correct
+@($collection | Where-Object { $_.Name -eq 'X' }).Count | Should -Be 1
+```
+
 ## Build and pipeline intent in tests
 
 - Be explicit about whether the scenario expects a built module artifact.

--- a/.github/instructions/test-writing.instructions.md
+++ b/.github/instructions/test-writing.instructions.md
@@ -79,6 +79,51 @@ Use the most specific assertion available — avoid `Should -Be $true` when a de
 - Always scope mock-call assertions with `-Scope It` so counts reset between tests.
 - Call the function under test with its module-qualified name (`Sampler\Get-Foo`) to avoid accidentally calling a mock or a stale imported version.
 
+## Cross-platform test paths
+
+- Never use hardcoded Windows paths (`'C:\src\...'`, `'C:\output\...'`) as test inputs when the code under test passes those values to `Join-Path`, `[System.IO.Path]::IsPathRooted`, `Test-Path`, or `New-Item`. On Linux, `C:\` is not rooted, and `Join-Path` may produce wrong results or throw a drive-not-found error.
+- Use `$TestDrive` as the base for any absolute path in test fixtures. `$TestDrive` is always a valid, OS-appropriate absolute path on every platform:
+
+```powershell
+# Wrong — C:\ is not rooted on Linux
+$repoRoot = 'C:\src\MyModule'
+
+# Correct
+$repoRoot = Join-Path -Path $TestDrive -ChildPath 'MyModule'
+```
+
+- When constructing expected paths, use chained `Join-Path` calls rather than hardcoded separators:
+
+```powershell
+# Correct — cross-platform
+$expected = Join-Path -Path $TestDrive -ChildPath (Join-Path -Path 'output' -ChildPath 'module')
+```
+
+## `InModuleScope` usage
+
+- Use `InModuleScope` only when the test needs to call a **private** function directly, or when the assertion relies on module-internal state.
+- Do NOT wrap calls to **public** functions in `InModuleScope`. Call them directly with the module-qualified name (`Sampler\Get-Foo`). The mocks registered via `$PSDefaultParameterValues['Mock:ModuleName'] = 'Sampler'` still intercept any private function calls made internally by the public function.
+- Do NOT reference `$script:` variables inside an `InModuleScope` block. Inside `InModuleScope`, `$script:` refers to the **module's** script scope, not the test file's. Variables set in `BeforeAll` with `$script:` are not visible there:
+
+```powershell
+# Wrong — $script:myVar is $null inside InModuleScope
+BeforeAll { $script:myVar = 'value' }
+It 'example' {
+    InModuleScope -ScriptBlock { $script:myVar | Should -Be 'value' }  # fails
+}
+
+# Correct — compute the value outside InModuleScope, or pass via mock that uses $TestDrive
+It 'example' {
+    $expected = 'value'
+    $result = Sampler\Get-Foo
+    $result | Should -Be $expected
+}
+```
+
+## `SupportsShouldProcess` in tests
+
+- For commands that use `SupportsShouldProcess`, pass `-Confirm:$false` in unit tests that are meant to exercise the execution path. Do not rely on `$ConfirmPreference` being low enough to skip the prompt.
+
 ## Windows PowerShell 5.1 compatibility
 
 - Always wrap pipeline expressions in `@()` before calling `.Count`, `.Length`, or indexing into the result (`[0]`). On Windows PowerShell 5.1, a pipeline that produces exactly one object returns a scalar, not an array, and scalars without a `Count` property return `$null` instead of `1`. PowerShell 7 adds a synthetic `Count` member to all objects, masking the bug.

--- a/.github/skills/validate-changes/SKILL.md
+++ b/.github/skills/validate-changes/SKILL.md
@@ -65,17 +65,23 @@ Run the right Sampler test scope for a change, fast first and broad only when ne
 
 ## Running these commands without hanging
 
-Always tee `./build.ps1` output to a log file rather than wrapping the call in `| Select-Object -Last <N>` (or any other buffering filter). Inline `Select-Object` against a long-running pipeline forces full-stream buffering and the agent shell appears to hang — even after the build finishes — and would also swallow any unexpected prompt. Instead, stream freely and read the log:
+Always tee `./build.ps1` output to `output\agentic\` — this subfolder is excluded from the `Clean` task so logs survive between builds. Create it first, then stream:
 
 ```powershell
-if (Test-Path output\validate-test.log) { Remove-Item output\validate-test.log -Force }
+$null = New-Item -Path 'output\agentic' -ItemType Directory -Force
 
 ./build.ps1 -Tasks test -PesterPath '<paths>' -CodeCoverageThreshold 0 2>&1 |
-    Tee-Object -FilePath output\validate-test.log
+    Tee-Object -FilePath 'output\agentic\test.log'
 
 # Then poll/inspect the log without re-running:
-Get-Content output\validate-test.log -Tail 20
-Select-String -Path output\validate-test.log -Pattern 'Build (FAILED|succeeded)'
+Get-Content output\agentic\test.log -Tail 20
+Select-String -Path output\agentic\test.log -Pattern 'Build (FAILED|succeeded)'
+```
+
+**Clean up when done:** Remove `output\agentic` once investigation is complete:
+
+```powershell
+Remove-Item -Path 'output\agentic' -Recurse -Force -ErrorAction 'Ignore'
 ```
 
 When invoked through the `powershell` tool, prefer `mode="async"` with `Tee-Object` and poll periodically — never tail with `| Select -Last N` against a still-running build.

--- a/.github/skills/validate-changes/SKILL.md
+++ b/.github/skills/validate-changes/SKILL.md
@@ -126,6 +126,7 @@ Test failures are recorded in machine-readable XML under `output/testResults/`. 
 - For template changes: corresponding integration tests pass.
 - For public/private function changes: relevant unit tests pass.
 - If behavior is user-visible: ensure `CHANGELOG.md` has an `Unreleased` entry.
+- **Before declaring work complete on any PR-bound change, run the full `./build.ps1 -Tasks test` suite** (not just focused tests). Focused tests validate the changed scope; the full suite catches HQRM, ScriptAnalyzer, help quality, and test-coverage regressions that focused runs skip. A focused run passing is a necessary but not sufficient condition for readiness.
 
 ## Report format
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `Link_Local_Workspace_Dependencies` build task and supporting public functions (`Get-SamplerWorkspaceBuiltModulePath`, `New-SamplerWorkspaceModuleLink`) for linking sibling workspace module build outputs into the local module output path when working across related repos in a multi-repo workspace. Configure via `WorkspaceModules` in `build.yaml`.
+- `Clean` task now preserves `output\agentic\` across builds (in addition to `RequiredModules`), providing a stable location for build and test log files that survive clean cycles. The subfolder name is configurable via the `AgentOutputSubdirectory` parameter (default `'agentic'`; set to empty string to disable the exclusion).
 - `package_psresource_nupkg` tasks that recursively packs dependencies, ignoring `ExternalDependencies` using `PSResourceGet` module.
 - `New-SampleModule` `Features` parameter now accepts `github`, `vscode`, `codecov`, `azurepipelines`, and `gitversion` to mirror the Plaster template's feature choices.
 - `New-SampleModule` documents the `CustomModule` `ModuleType` and the new `MainGitBranch` parameter.

--- a/Sampler/Private/Get-SamplerWorkspaceLinkedModuleRoot.ps1
+++ b/Sampler/Private/Get-SamplerWorkspaceLinkedModuleRoot.ps1
@@ -1,0 +1,72 @@
+
+<#
+    .SYNOPSIS
+        Resolves the directory where workspace module symlinks will be created.
+
+    .DESCRIPTION
+        Determines the linked module root path based on the output directory and
+        the built module subdirectory. The logic is:
+
+        - If `OutputDirectory` is absolute, use it directly; otherwise join it
+          with `BuildRoot`.
+        - If `BuiltModuleSubdirectory` is null or whitespace, return the output
+          root as-is.
+        - If `BuiltModuleSubdirectory` is absolute, return it directly.
+        - Otherwise join the output root with `BuiltModuleSubdirectory`.
+
+    .PARAMETER BuildRoot
+        The root directory of the current build (typically `$BuildRoot` in
+        InvokeBuild context).
+
+    .PARAMETER OutputDirectory
+        The output directory path. May be absolute or relative to `BuildRoot`.
+
+    .PARAMETER BuiltModuleSubdirectory
+        The subdirectory under the output root where modules are placed.
+        Defaults to `module`. May be empty, absolute, or relative.
+
+    .EXAMPLE
+        Get-SamplerWorkspaceLinkedModuleRoot -BuildRoot 'C:\src\MyRepo' -OutputDirectory 'output' -BuiltModuleSubdirectory 'module'
+        # C:\src\MyRepo\output\module
+#>
+function Get-SamplerWorkspaceLinkedModuleRoot
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $BuildRoot,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $OutputDirectory,
+
+        [Parameter()]
+        [AllowEmptyString()]
+        [System.String]
+        $BuiltModuleSubdirectory = 'module'
+    )
+
+    $outputRoot = if ([System.IO.Path]::IsPathRooted($OutputDirectory))
+    {
+        $OutputDirectory
+    }
+    else
+    {
+        Join-Path -Path $BuildRoot -ChildPath $OutputDirectory
+    }
+
+    if ([System.String]::IsNullOrWhiteSpace($BuiltModuleSubdirectory))
+    {
+        return $outputRoot
+    }
+
+    if ([System.IO.Path]::IsPathRooted($BuiltModuleSubdirectory))
+    {
+        return $BuiltModuleSubdirectory
+    }
+
+    return (Join-Path -Path $outputRoot -ChildPath $BuiltModuleSubdirectory)
+}

--- a/Sampler/Private/Get-SamplerWorkspaceRepositoryRoot.ps1
+++ b/Sampler/Private/Get-SamplerWorkspaceRepositoryRoot.ps1
@@ -1,0 +1,45 @@
+
+<#
+    .SYNOPSIS
+        Gets the absolute path of a sibling repository root in the workspace.
+
+    .DESCRIPTION
+        Validates that a sibling repository directory exists at
+        `<WorkspaceRoot>\<ModuleName>`. Throws with a clear message if the
+        directory is not found. Returns the absolute path string when successful.
+
+    .PARAMETER ModuleName
+        The name of the sibling module whose repository root to locate.
+
+    .PARAMETER WorkspaceRoot
+        The root directory of the multi-repo workspace, typically the parent
+        directory of the current build root.
+
+    .EXAMPLE
+        Get-SamplerWorkspaceRepositoryRoot -ModuleName 'MyModule' -WorkspaceRoot 'C:\src'
+        # C:\src\MyModule
+#>
+function Get-SamplerWorkspaceRepositoryRoot
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $ModuleName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $WorkspaceRoot
+    )
+
+    $moduleRepositoryRoot = Join-Path -Path $WorkspaceRoot -ChildPath $ModuleName
+
+    if (-not (Test-Path -Path $moduleRepositoryRoot))
+    {
+        throw ("Unable to find the sibling repository root '{0}'." -f $moduleRepositoryRoot)
+    }
+
+    return $moduleRepositoryRoot
+}

--- a/Sampler/Public/Get-SamplerWorkspaceBuiltModulePath.ps1
+++ b/Sampler/Public/Get-SamplerWorkspaceBuiltModulePath.ps1
@@ -1,0 +1,73 @@
+
+<#
+    .SYNOPSIS
+        Finds the built module root for a sibling workspace module.
+
+    .DESCRIPTION
+        Searches the sibling repository's output directories for a built module
+        manifest matching the given module name. The function checks these glob
+        patterns in order:
+
+        1. `<repoRoot>\output\module\<ModuleName>\*\<ModuleName>.psd1`
+        2. `<repoRoot>\output\<ModuleName>\*\<ModuleName>.psd1`
+
+        Returns the parent of the version subfolder
+        (`$manifestPath.Directory.Parent.FullName`), which is the path suitable
+        for symlinking into the local module output.
+
+        Throws with a helpful message including the sibling build command if no
+        manifest is found.
+
+    .PARAMETER ModuleName
+        The name of the sibling module to locate the built output for.
+
+    .PARAMETER WorkspaceRoot
+        The root directory of the multi-repo workspace, typically the parent
+        directory of the current build root.
+
+    .EXAMPLE
+        Get-SamplerWorkspaceBuiltModulePath -ModuleName 'MyModule' -WorkspaceRoot 'C:\src'
+        # C:\src\MyModule\output\module\MyModule
+#>
+function Get-SamplerWorkspaceBuiltModulePath
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $ModuleName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $WorkspaceRoot
+    )
+
+    $moduleRepositoryRoot = Get-SamplerWorkspaceRepositoryRoot -ModuleName $ModuleName -WorkspaceRoot $WorkspaceRoot
+
+    $manifestSearchPatterns = @(
+        (Join-Path -Path $moduleRepositoryRoot -ChildPath ('output\module\{0}\*\{0}.psd1' -f $ModuleName))
+        (Join-Path -Path $moduleRepositoryRoot -ChildPath ('output\{0}\*\{0}.psd1' -f $ModuleName))
+    )
+
+    foreach ($manifestSearchPattern in $manifestSearchPatterns)
+    {
+        $getChildItemParams = @{
+            Path        = $manifestSearchPattern
+            File        = $true
+            ErrorAction = 'Ignore'
+        }
+
+        $manifestPath = Get-ChildItem @getChildItemParams |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1
+
+        if ($manifestPath)
+        {
+            return $manifestPath.Directory.Parent.FullName
+        }
+    }
+
+    throw ("Unable to find a built module output for '{0}'. Build the sibling repository first, for example: {1}\build.ps1 -Tasks build" -f $ModuleName, $moduleRepositoryRoot)
+}

--- a/Sampler/Public/Get-SamplerWorkspaceBuiltModulePath.ps1
+++ b/Sampler/Public/Get-SamplerWorkspaceBuiltModulePath.ps1
@@ -46,9 +46,13 @@ function Get-SamplerWorkspaceBuiltModulePath
 
     $moduleRepositoryRoot = Get-SamplerWorkspaceRepositoryRoot -ModuleName $ModuleName -WorkspaceRoot $WorkspaceRoot
 
+    $outputPath = Join-Path -Path $moduleRepositoryRoot -ChildPath 'output'
+    $manifestFileName = '{0}.psd1' -f $ModuleName
+    $versionGlob = Join-Path -Path '*' -ChildPath $manifestFileName
+
     $manifestSearchPatterns = @(
-        (Join-Path -Path $moduleRepositoryRoot -ChildPath ('output\module\{0}\*\{0}.psd1' -f $ModuleName))
-        (Join-Path -Path $moduleRepositoryRoot -ChildPath ('output\{0}\*\{0}.psd1' -f $ModuleName))
+        (Join-Path -Path (Join-Path -Path (Join-Path -Path $outputPath -ChildPath 'module') -ChildPath $ModuleName) -ChildPath $versionGlob)
+        (Join-Path -Path (Join-Path -Path $outputPath -ChildPath $ModuleName) -ChildPath $versionGlob)
     )
 
     foreach ($manifestSearchPattern in $manifestSearchPatterns)
@@ -69,5 +73,5 @@ function Get-SamplerWorkspaceBuiltModulePath
         }
     }
 
-    throw ("Unable to find a built module output for '{0}'. Build the sibling repository first, for example: {1}\build.ps1 -Tasks build" -f $ModuleName, $moduleRepositoryRoot)
+    throw ("Unable to find a built module output for '{0}'. Build the sibling repository first: '{1}' -Tasks build" -f $ModuleName, (Join-Path -Path $moduleRepositoryRoot -ChildPath 'build.ps1'))
 }

--- a/Sampler/Public/New-SamplerWorkspaceModuleLink.ps1
+++ b/Sampler/Public/New-SamplerWorkspaceModuleLink.ps1
@@ -32,7 +32,7 @@
 #>
 function New-SamplerWorkspaceModuleLink
 {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     [OutputType([System.String])]
     param
     (
@@ -54,42 +54,45 @@ function New-SamplerWorkspaceModuleLink
         Remove-Item -Path $LinkPath -Recurse -Force
     }
 
-    try
+    if ($PSCmdlet.ShouldProcess($LinkPath, ('Create workspace module link to {0}' -f $TargetPath)))
     {
-        $newItemParams = @{
-            Path        = $LinkPath
-            ItemType    = 'SymbolicLink'
-            Target      = $TargetPath
-            Force       = $true
-            ErrorAction = 'Stop'
-        }
-
-        $null = New-Item @newItemParams
-        return 'SymbolicLink'
-    }
-    catch
-    {
-        if (-not $IsWindowsPlatform)
+        try
         {
-            throw ("Failed to create the symbolic link '{0}' -> '{1}'. Ensure symbolic links are allowed in this session. {2}" -f $LinkPath, $TargetPath, $_.Exception.Message)
-        }
-    }
+            $newItemParams = @{
+                Path        = $LinkPath
+                ItemType    = 'SymbolicLink'
+                Target      = $TargetPath
+                Force       = $true
+                ErrorAction = 'Stop'
+            }
 
-    try
-    {
-        $newItemParams = @{
-            Path        = $LinkPath
-            ItemType    = 'Junction'
-            Target      = $TargetPath
-            Force       = $true
-            ErrorAction = 'Stop'
+            $null = New-Item @newItemParams
+            return 'SymbolicLink'
+        }
+        catch
+        {
+            if (-not $IsWindowsPlatform)
+            {
+                throw ("Failed to create the symbolic link '{0}' -> '{1}'. Ensure symbolic links are allowed in this session. {2}" -f $LinkPath, $TargetPath, $_.Exception.Message)
+            }
         }
 
-        $null = New-Item @newItemParams
-        return 'Junction'
-    }
-    catch
-    {
-        throw ("Failed to create a local workspace link '{0}' -> '{1}'. Symbolic link and junction creation both failed. {2}" -f $LinkPath, $TargetPath, $_.Exception.Message)
+        try
+        {
+            $newItemParams = @{
+                Path        = $LinkPath
+                ItemType    = 'Junction'
+                Target      = $TargetPath
+                Force       = $true
+                ErrorAction = 'Stop'
+            }
+
+            $null = New-Item @newItemParams
+            return 'Junction'
+        }
+        catch
+        {
+            throw ("Failed to create a local workspace link '{0}' -> '{1}'. Symbolic link and junction creation both failed. {2}" -f $LinkPath, $TargetPath, $_.Exception.Message)
+        }
     }
 }

--- a/Sampler/Public/New-SamplerWorkspaceModuleLink.ps1
+++ b/Sampler/Public/New-SamplerWorkspaceModuleLink.ps1
@@ -1,0 +1,95 @@
+
+<#
+    .SYNOPSIS
+        Creates a filesystem link (symbolic link or junction) at a given path.
+
+    .DESCRIPTION
+        Creates a filesystem link at `LinkPath` pointing to `TargetPath`. The
+        algorithm is:
+
+        1. If `LinkPath` already exists, it is removed with `-Recurse -Force`.
+        2. A symbolic link creation is attempted via `New-Item -ItemType SymbolicLink`.
+           On success, `'SymbolicLink'` is returned.
+        3. On failure: if the platform is not Windows, the error is re-thrown.
+           On Windows, execution falls through to the junction fallback.
+        4. A junction creation is attempted via `New-Item -ItemType Junction`.
+           On success, `'Junction'` is returned.
+        5. If junction creation also fails, a combined error message is thrown.
+
+    .PARAMETER LinkPath
+        The filesystem path where the link should be created.
+
+    .PARAMETER TargetPath
+        The target path the link should point to.
+
+    .PARAMETER IsWindowsPlatform
+        Whether the current platform is Windows. Defaults to
+        `($env:OS -eq 'Windows_NT')`. Override for testing purposes.
+
+    .EXAMPLE
+        New-SamplerWorkspaceModuleLink -LinkPath 'C:\src\MyRepo\output\module\OtherModule' -TargetPath 'C:\src\OtherModule\output\module\OtherModule'
+        # SymbolicLink
+#>
+function New-SamplerWorkspaceModuleLink
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $LinkPath,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $TargetPath,
+
+        [Parameter()]
+        [System.Boolean]
+        $IsWindowsPlatform = ($env:OS -eq 'Windows_NT')
+    )
+
+    if (Test-Path -Path $LinkPath)
+    {
+        Remove-Item -Path $LinkPath -Recurse -Force
+    }
+
+    try
+    {
+        $newItemParams = @{
+            Path        = $LinkPath
+            ItemType    = 'SymbolicLink'
+            Target      = $TargetPath
+            Force       = $true
+            ErrorAction = 'Stop'
+        }
+
+        $null = New-Item @newItemParams
+        return 'SymbolicLink'
+    }
+    catch
+    {
+        if (-not $IsWindowsPlatform)
+        {
+            throw ("Failed to create the symbolic link '{0}' -> '{1}'. Ensure symbolic links are allowed in this session. {2}" -f $LinkPath, $TargetPath, $_.Exception.Message)
+        }
+    }
+
+    try
+    {
+        $newItemParams = @{
+            Path        = $LinkPath
+            ItemType    = 'Junction'
+            Target      = $TargetPath
+            Force       = $true
+            ErrorAction = 'Stop'
+        }
+
+        $null = New-Item @newItemParams
+        return 'Junction'
+    }
+    catch
+    {
+        throw ("Failed to create a local workspace link '{0}' -> '{1}'. Symbolic link and junction creation both failed. {2}" -f $LinkPath, $TargetPath, $_.Exception.Message)
+    }
+}

--- a/Sampler/WikiSource/Getting-started.md
+++ b/Sampler/WikiSource/Getting-started.md
@@ -2026,3 +2026,74 @@ Sets the module path to what is defined for the machine. The machines `PSModuleP
 ```powershell
 [System.Environment]::GetEnvironmentVariable('PSModulePath', 'Machine')
 ```
+
+### `Link_Local_Workspace_Dependencies`
+
+This task links sibling workspace module build outputs into the local output
+module path so that they are discoverable on `PSModulePath` during builds and
+tests, without requiring them to be published to a feed.
+
+This is useful when working in a multi-repo workspace (for example a VSCode
+workspace spanning several related modules) and you want changes in sibling
+repos to be immediately visible in the current repo's build and test pipeline.
+
+The task assumes that all related repositories are siblings under the same
+workspace root (one level above each repository's `BuildRoot`). Each sibling
+must have been built at least once before this task runs.
+
+For each configured module the task:
+
+1. Resolves the sibling repository root at `<workspaceRoot>\<ModuleName>`.
+2. Finds the sibling's built module root (the folder containing its versioned
+   sub-folder, typically `output\module\<ModuleName>`).
+3. Creates a symbolic link (or a directory junction on Windows as a fallback)
+   inside the local `output\module\` directory pointing at the sibling's built
+   module root.
+
+After the task runs, `Import-Module <SiblingName>` resolves the locally built
+version without any extra `PSModulePath` manipulation.
+
+```yaml
+  build:
+    - Clean
+    - Build_Module_ModuleBuilder
+    - Link_Local_Workspace_Dependencies
+
+  test:
+    - Link_Local_Workspace_Dependencies
+    - Pester_Tests_Stop_On_Fail
+    - Pester_If_Code_Coverage_Under_Threshold
+```
+
+#### Task parameters
+
+Some task parameters are vital for the task to work. See comment-based help in
+the task file for the full parameter list. The most important are described
+below.
+
+#### Task configuration
+
+The build configuration (_build.yaml_) controls which sibling modules are
+linked. See [[Workspace-Dependencies]] for the full reference.
+
+```yaml
+####################################################
+#       Workspace Dependencies Configuration       #
+####################################################
+WorkspaceModules:
+  - MyHelperModule
+  - MySharedModule
+```
+
+#### Section `WorkspaceModules`
+
+A list of sibling module names to link. Each entry must match the directory
+name of the sibling repository under the shared workspace root. If the list
+is empty or the key is absent, the task logs a message and exits without
+error.
+
+```yaml
+WorkspaceModules:
+  - MyHelperModule
+  - MySharedModule
+```

--- a/Sampler/WikiSource/Home.md
+++ b/Sampler/WikiSource/Home.md
@@ -12,6 +12,12 @@ for this repository.
 
 See the section [[Getting started]]
 
+## Working across related repositories
+
+See [[Workspace-Dependencies]] for how to link sibling workspace module builds
+into the local output path so they are discoverable during builds and tests
+without publishing them to a feed.
+
 ## Prerequisites
 
 - PowerShell 5.or higher

--- a/Sampler/WikiSource/Workspace-Dependencies.md
+++ b/Sampler/WikiSource/Workspace-Dependencies.md
@@ -1,0 +1,152 @@
+# Workspace Dependencies
+
+The `Link_Local_Workspace_Dependencies` build task and its supporting public
+functions let you wire together related Sampler-based repositories in a local
+multi-repo workspace without publishing any of them to a PowerShell feed.
+
+## When to use this
+
+Use this when you are working across several related module repositories at
+once (for example in a VSCode workspace) and you want one repo's build and
+test pipeline to consume the locally built output of its siblings rather than
+a version fetched from a gallery.
+
+Typical scenarios:
+
+- You are iterating on a shared helper module and a consuming module
+  simultaneously.
+- You want to validate an unpublished breaking change across several repos
+  before committing.
+- You are running the full test suite of a composition-root module that imports
+  several sibling modules.
+
+## Prerequisites
+
+- All repositories involved must be siblings under the same parent directory
+  (the _workspace root_).
+- Each sibling module must have been built at least once
+  (`./build.ps1 -Tasks build` in that repo) so its output exists.
+- To create symbolic links on Windows, the process must either run elevated or
+  Developer Mode must be enabled. If neither is available, the task falls back
+  to a directory junction automatically.
+
+## Workspace layout
+
+```
+WorkspaceRoot\
+├── MyModule\          ← the repo you are working in
+│   ├── build.ps1
+│   ├── build.yaml
+│   └── output\
+│       └── module\
+│           ├── MyModule\        ← built by ModuleBuilder
+│           ├── SiblingA\        ← symlink created by this task
+│           └── SiblingB\        ← symlink created by this task
+├── SiblingA\
+│   └── output\
+│       └── module\
+│           └── SiblingA\
+│               └── 1.2.3\
+└── SiblingB\
+    └── output\
+        └── module\
+            └── SiblingB\
+                └── 0.9.0\
+```
+
+Because `output\module` is prepended to `PSModulePath` by `build.ps1`, all
+three modules (`MyModule`, `SiblingA`, `SiblingB`) are discoverable after the
+task runs.
+
+## Configuration
+
+Add `WorkspaceModules` to your `build.yaml` and include the task in the
+workflows where the sibling modules need to be available.
+
+```yaml
+####################################################
+#       Workspace Dependencies Configuration       #
+####################################################
+WorkspaceModules:
+  - SiblingA
+  - SiblingB
+
+BuildWorkflow:
+  build:
+    - Clean
+    - Build_Module_ModuleBuilder
+    - Build_NestedModules_ModuleBuilder
+    - Link_Local_Workspace_Dependencies   # runs after the local build
+
+  test:
+    - Link_Local_Workspace_Dependencies   # re-link before tests in case siblings were rebuilt
+    - Pester_Tests_Stop_On_Fail
+    - Pester_If_Code_Coverage_Under_Threshold
+```
+
+### `WorkspaceModules` property
+
+| Type | Default | Required |
+|------|---------|----------|
+| `String[]` | `@()` (empty) | No |
+
+A list of sibling module names to link. Each entry must match the folder name
+of the sibling repository under the shared workspace root. If the list is
+empty or absent the task exits silently without error.
+
+## How it works
+
+For each module name in `WorkspaceModules` the task:
+
+1. Resolves `<workspaceRoot>\<ModuleName>` and fails fast if the directory does
+   not exist.
+2. Searches `output\module\<ModuleName>\*\<ModuleName>.psd1` (and a fallback
+   `output\<ModuleName>\*\<ModuleName>.psd1`) inside the sibling repo.
+3. Returns `$manifestPath.Directory.Parent.FullName` — the folder that contains
+   the versioned sub-folder. This is the link target.
+4. Creates a symbolic link (Windows: falls back to a junction) at
+   `<localOutputModule>\<ModuleName>` pointing at that target.
+
+If the link already exists it is removed and recreated so it always points at
+the current build output.
+
+## Supporting public functions
+
+These functions are exposed by Sampler and can be called directly in custom
+build tasks or scripts.
+
+### `Get-SamplerWorkspaceBuiltModulePath`
+
+Finds the built module root directory (`output\module\<name>`) for a named
+module inside a sibling workspace repository.
+
+```powershell
+$path = Get-SamplerWorkspaceBuiltModulePath -ModuleName 'SiblingA' -WorkspaceRoot 'C:\src'
+# Returns e.g. C:\src\SiblingA\output\module\SiblingA
+```
+
+Throws if the sibling repo directory does not exist or if no built manifest
+is found. The error message includes the `build.ps1` command to run.
+
+### `New-SamplerWorkspaceModuleLink`
+
+Creates a filesystem link from `LinkPath` to `TargetPath`. Returns the string
+`'SymbolicLink'` or `'Junction'` depending on which type was created.
+
+```powershell
+$linkType = New-SamplerWorkspaceModuleLink `
+    -LinkPath 'C:\src\MyModule\output\module\SiblingA' `
+    -TargetPath 'C:\src\SiblingA\output\module\SiblingA'
+```
+
+On non-Windows platforms, symbolic link failure is fatal. On Windows, the task
+falls back to a directory junction and the task logs a yellow warning.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `Unable to find the sibling repository root` | The sibling folder name in `WorkspaceModules` does not match the actual directory name | Check spelling and that the repo is checked out under the same workspace root |
+| `Unable to find a built module output` | The sibling repo has not been built yet | Run `./build.ps1 -Tasks build` in the sibling repo |
+| Symbolic link creation fails with access denied | Windows requires elevation or Developer Mode for symlinks | Enable Developer Mode, or run the terminal elevated; the task will fall back to a junction automatically |
+| Stale module version loaded during tests | The symlink exists but points at an old build | Re-run the sibling's build, then re-run `Link_Local_Workspace_Dependencies` |

--- a/Sampler/suffix.ps1
+++ b/Sampler/suffix.ps1
@@ -8,5 +8,5 @@ Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'tasks\*') -Includ
     }
 
 $SetSamplerTaskVariableAliasName = 'Set-SamplerTaskVariable'
-$SetSamplerTaskVariableAliasValue = "$PSScriptRoot/scripts/Set-SamplerTaskVariable.ps1"
+$SetSamplerTaskVariableAliasValue = Join-Path -Path $PSScriptRoot -ChildPath 'scripts/Set-SamplerTaskVariable.ps1'
 Set-Alias -Name $SetSamplerTaskVariableAliasName -Value $SetSamplerTaskVariableAliasValue

--- a/tests/Unit/Private/Get-SamplerWorkspaceLinkedModuleRoot.tests.ps1
+++ b/tests/Unit/Private/Get-SamplerWorkspaceLinkedModuleRoot.tests.ps1
@@ -1,0 +1,80 @@
+BeforeAll {
+    $script:moduleName = 'Sampler'
+
+    # If the module is not found, run the build task 'noop'.
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        # Redirect all streams to $null, except the error stream (stream 2)
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    # Re-import the module using force to get any code changes between runs.
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Remove-Module -Name $script:moduleName
+}
+
+Describe 'Get-SamplerWorkspaceLinkedModuleRoot' {
+    Context 'When OutputDirectory is absolute and BuiltModuleSubdirectory is provided' {
+        It 'Should return the joined absolute output and subdirectory path' {
+            InModuleScope -ScriptBlock {
+                $result = Get-SamplerWorkspaceLinkedModuleRoot `
+                    -BuildRoot 'C:\src\MyRepo' `
+                    -OutputDirectory 'C:\src\MyRepo\output' `
+                    -BuiltModuleSubdirectory 'module'
+
+                $result | Should -Be (Join-Path -Path 'C:\src\MyRepo\output' -ChildPath 'module')
+            }
+        }
+    }
+
+    Context 'When OutputDirectory is relative' {
+        It 'Should join OutputDirectory with BuildRoot before appending BuiltModuleSubdirectory' {
+            InModuleScope -ScriptBlock {
+                $result = Get-SamplerWorkspaceLinkedModuleRoot `
+                    -BuildRoot 'C:\src\MyRepo' `
+                    -OutputDirectory 'output' `
+                    -BuiltModuleSubdirectory 'module'
+
+                $expectedOutputRoot = Join-Path -Path 'C:\src\MyRepo' -ChildPath 'output'
+                $result | Should -Be (Join-Path -Path $expectedOutputRoot -ChildPath 'module')
+            }
+        }
+    }
+
+    Context 'When BuiltModuleSubdirectory is empty' {
+        It 'Should return the output root without any subdirectory appended' {
+            InModuleScope -ScriptBlock {
+                $result = Get-SamplerWorkspaceLinkedModuleRoot `
+                    -BuildRoot 'C:\src\MyRepo' `
+                    -OutputDirectory 'C:\src\MyRepo\output' `
+                    -BuiltModuleSubdirectory ''
+
+                $result | Should -Be 'C:\src\MyRepo\output'
+            }
+        }
+    }
+
+    Context 'When BuiltModuleSubdirectory is absolute' {
+        It 'Should return the absolute BuiltModuleSubdirectory path directly' {
+            InModuleScope -ScriptBlock {
+                $result = Get-SamplerWorkspaceLinkedModuleRoot `
+                    -BuildRoot 'C:\src\MyRepo' `
+                    -OutputDirectory 'C:\src\MyRepo\output' `
+                    -BuiltModuleSubdirectory 'C:\custom\moduleroot'
+
+                $result | Should -Be 'C:\custom\moduleroot'
+            }
+        }
+    }
+}

--- a/tests/Unit/Private/Get-SamplerWorkspaceLinkedModuleRoot.tests.ps1
+++ b/tests/Unit/Private/Get-SamplerWorkspaceLinkedModuleRoot.tests.ps1
@@ -28,12 +28,15 @@ Describe 'Get-SamplerWorkspaceLinkedModuleRoot' {
     Context 'When OutputDirectory is absolute and BuiltModuleSubdirectory is provided' {
         It 'Should return the joined absolute output and subdirectory path' {
             InModuleScope -ScriptBlock {
+                $buildRoot  = $TestDrive
+                $absOutput  = Join-Path -Path $TestDrive -ChildPath 'output'
+
                 $result = Get-SamplerWorkspaceLinkedModuleRoot `
-                    -BuildRoot 'C:\src\MyRepo' `
-                    -OutputDirectory 'C:\src\MyRepo\output' `
+                    -BuildRoot $buildRoot `
+                    -OutputDirectory $absOutput `
                     -BuiltModuleSubdirectory 'module'
 
-                $result | Should -Be (Join-Path -Path 'C:\src\MyRepo\output' -ChildPath 'module')
+                $result | Should -Be (Join-Path -Path $absOutput -ChildPath 'module')
             }
         }
     }
@@ -41,12 +44,14 @@ Describe 'Get-SamplerWorkspaceLinkedModuleRoot' {
     Context 'When OutputDirectory is relative' {
         It 'Should join OutputDirectory with BuildRoot before appending BuiltModuleSubdirectory' {
             InModuleScope -ScriptBlock {
+                $buildRoot = $TestDrive
+
                 $result = Get-SamplerWorkspaceLinkedModuleRoot `
-                    -BuildRoot 'C:\src\MyRepo' `
+                    -BuildRoot $buildRoot `
                     -OutputDirectory 'output' `
                     -BuiltModuleSubdirectory 'module'
 
-                $expectedOutputRoot = Join-Path -Path 'C:\src\MyRepo' -ChildPath 'output'
+                $expectedOutputRoot = Join-Path -Path $buildRoot -ChildPath 'output'
                 $result | Should -Be (Join-Path -Path $expectedOutputRoot -ChildPath 'module')
             }
         }
@@ -55,12 +60,14 @@ Describe 'Get-SamplerWorkspaceLinkedModuleRoot' {
     Context 'When BuiltModuleSubdirectory is empty' {
         It 'Should return the output root without any subdirectory appended' {
             InModuleScope -ScriptBlock {
+                $absOutput = Join-Path -Path $TestDrive -ChildPath 'output'
+
                 $result = Get-SamplerWorkspaceLinkedModuleRoot `
-                    -BuildRoot 'C:\src\MyRepo' `
-                    -OutputDirectory 'C:\src\MyRepo\output' `
+                    -BuildRoot $TestDrive `
+                    -OutputDirectory $absOutput `
                     -BuiltModuleSubdirectory ''
 
-                $result | Should -Be 'C:\src\MyRepo\output'
+                $result | Should -Be $absOutput
             }
         }
     }
@@ -68,12 +75,14 @@ Describe 'Get-SamplerWorkspaceLinkedModuleRoot' {
     Context 'When BuiltModuleSubdirectory is absolute' {
         It 'Should return the absolute BuiltModuleSubdirectory path directly' {
             InModuleScope -ScriptBlock {
-                $result = Get-SamplerWorkspaceLinkedModuleRoot `
-                    -BuildRoot 'C:\src\MyRepo' `
-                    -OutputDirectory 'C:\src\MyRepo\output' `
-                    -BuiltModuleSubdirectory 'C:\custom\moduleroot'
+                $absSubDir = Join-Path -Path $TestDrive -ChildPath 'custom-moduleroot'
 
-                $result | Should -Be 'C:\custom\moduleroot'
+                $result = Get-SamplerWorkspaceLinkedModuleRoot `
+                    -BuildRoot $TestDrive `
+                    -OutputDirectory (Join-Path -Path $TestDrive -ChildPath 'output') `
+                    -BuiltModuleSubdirectory $absSubDir
+
+                $result | Should -Be $absSubDir
             }
         }
     }

--- a/tests/Unit/Private/Get-SamplerWorkspaceRepositoryRoot.tests.ps1
+++ b/tests/Unit/Private/Get-SamplerWorkspaceRepositoryRoot.tests.ps1
@@ -1,0 +1,60 @@
+BeforeAll {
+    $script:moduleName = 'Sampler'
+
+    # If the module is not found, run the build task 'noop'.
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        # Redirect all streams to $null, except the error stream (stream 2)
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    # Re-import the module using force to get any code changes between runs.
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Remove-Module -Name $script:moduleName
+}
+
+Describe 'Get-SamplerWorkspaceRepositoryRoot' {
+    Context 'When the sibling repository root exists' {
+        BeforeAll {
+            Mock -CommandName Test-Path -MockWith {
+                return $true
+            }
+        }
+
+        It 'Should return the joined sibling repository path' {
+            InModuleScope -ScriptBlock {
+                $result = Get-SamplerWorkspaceRepositoryRoot -ModuleName 'MyModule' -WorkspaceRoot 'C:\src'
+
+                $result | Should -Be (Join-Path -Path 'C:\src' -ChildPath 'MyModule')
+            }
+        }
+    }
+
+    Context 'When the sibling repository root does not exist' {
+        BeforeAll {
+            Mock -CommandName Test-Path -MockWith {
+                return $false
+            }
+        }
+
+        It 'Should throw with a message containing the expected path' {
+            InModuleScope -ScriptBlock {
+                $expectedPath = Join-Path -Path 'C:\src' -ChildPath 'MissingModule'
+
+                { Get-SamplerWorkspaceRepositoryRoot -ModuleName 'MissingModule' -WorkspaceRoot 'C:\src' } |
+                    Should -Throw -ExpectedMessage ("*'{0}'*" -f $expectedPath)
+            }
+        }
+    }
+}

--- a/tests/Unit/Private/Get-SamplerWorkspaceRepositoryRoot.tests.ps1
+++ b/tests/Unit/Private/Get-SamplerWorkspaceRepositoryRoot.tests.ps1
@@ -33,10 +33,13 @@ Describe 'Get-SamplerWorkspaceRepositoryRoot' {
         }
 
         It 'Should return the joined sibling repository path' {
-            InModuleScope -ScriptBlock {
-                $result = Get-SamplerWorkspaceRepositoryRoot -ModuleName 'MyModule' -WorkspaceRoot 'C:\src'
+            $workspaceRoot = $TestDrive
+            $expected = Join-Path -Path $workspaceRoot -ChildPath 'MyModule'
 
-                $result | Should -Be (Join-Path -Path 'C:\src' -ChildPath 'MyModule')
+            InModuleScope -Parameters @{ WorkspaceRoot = $workspaceRoot; Expected = $expected } -ScriptBlock {
+                $result = Get-SamplerWorkspaceRepositoryRoot -ModuleName 'MyModule' -WorkspaceRoot $WorkspaceRoot
+
+                $result | Should -Be $Expected
             }
         }
     }
@@ -49,11 +52,12 @@ Describe 'Get-SamplerWorkspaceRepositoryRoot' {
         }
 
         It 'Should throw with a message containing the expected path' {
-            InModuleScope -ScriptBlock {
-                $expectedPath = Join-Path -Path 'C:\src' -ChildPath 'MissingModule'
+            $workspaceRoot = $TestDrive
+            $expectedPath = Join-Path -Path $workspaceRoot -ChildPath 'MissingModule'
 
-                { Get-SamplerWorkspaceRepositoryRoot -ModuleName 'MissingModule' -WorkspaceRoot 'C:\src' } |
-                    Should -Throw -ExpectedMessage ("*'{0}'*" -f $expectedPath)
+            InModuleScope -Parameters @{ WorkspaceRoot = $workspaceRoot; ExpectedPath = $expectedPath } -ScriptBlock {
+                { Get-SamplerWorkspaceRepositoryRoot -ModuleName 'MissingModule' -WorkspaceRoot $WorkspaceRoot } |
+                    Should -Throw -ExpectedMessage ("*'{0}'*" -f $ExpectedPath)
             }
         }
     }

--- a/tests/Unit/Public/Get-SamplerWorkspaceBuiltModulePath.tests.ps1
+++ b/tests/Unit/Public/Get-SamplerWorkspaceBuiltModulePath.tests.ps1
@@ -25,43 +25,42 @@ AfterAll {
 }
 
 Describe 'Get-SamplerWorkspaceBuiltModulePath' {
-    Context 'When the built module manifest is found in output\module\<name>' {
+    Context 'When the built module manifest is found in output/module/<name>' {
         BeforeAll {
             Mock -CommandName Get-SamplerWorkspaceRepositoryRoot -MockWith {
-                return 'C:\src\MyModule'
+                return (Join-Path -Path $TestDrive -ChildPath 'MyModule')
             }
 
             Mock -CommandName Get-ChildItem -MockWith {
-                $fakeParentParent = [System.IO.DirectoryInfo]::new('C:\src\MyModule\output\module\MyModule')
-                $fakeParent = [System.IO.DirectoryInfo]::new('C:\src\MyModule\output\module\MyModule\1.0.0')
+                $moduleRoot   = Join-Path -Path $TestDrive -ChildPath (Join-Path -Path 'MyModule' -ChildPath (Join-Path -Path 'output' -ChildPath (Join-Path -Path 'module' -ChildPath 'MyModule')))
+                $versionDir   = Join-Path -Path $moduleRoot -ChildPath '1.0.0'
+                $manifestFile = Join-Path -Path $versionDir -ChildPath 'MyModule.psd1'
 
-                $fakeItem = [PSCustomObject] @{
-                    FullName  = 'C:\src\MyModule\output\module\MyModule\1.0.0\MyModule.psd1'
+                return [PSCustomObject] @{
+                    FullName  = $manifestFile
                     Directory = [PSCustomObject] @{
-                        Parent   = $fakeParentParent
-                        FullName = $fakeParent.FullName
+                        Parent   = [PSCustomObject] @{ FullName = $moduleRoot }
+                        FullName = $versionDir
                     }
                 }
-
-                return $fakeItem
             } -ParameterFilter {
-                $Path -like '*output\module\MyModule\*'
+                $Path -like '*module*MyModule*'
             }
         }
 
         It 'Should return the versioned module parent directory' {
-            InModuleScope -ScriptBlock {
-                $result = Sampler\Get-SamplerWorkspaceBuiltModulePath -ModuleName 'MyModule' -WorkspaceRoot 'C:\src'
+            $expectedPath = Join-Path -Path $TestDrive -ChildPath (Join-Path -Path 'MyModule' -ChildPath (Join-Path -Path 'output' -ChildPath (Join-Path -Path 'module' -ChildPath 'MyModule')))
 
-                $result | Should -Be 'C:\src\MyModule\output\module\MyModule'
-            }
+            $result = Sampler\Get-SamplerWorkspaceBuiltModulePath -ModuleName 'MyModule' -WorkspaceRoot $TestDrive
+
+            $result | Should -Be $expectedPath
         }
     }
 
     Context 'When no built manifest is found' {
         BeforeAll {
             Mock -CommandName Get-SamplerWorkspaceRepositoryRoot -MockWith {
-                return 'C:\src\MyModule'
+                return (Join-Path -Path $TestDrive -ChildPath 'MyModule')
             }
 
             Mock -CommandName Get-ChildItem -MockWith {
@@ -70,10 +69,8 @@ Describe 'Get-SamplerWorkspaceBuiltModulePath' {
         }
 
         It 'Should throw with a message containing the module name' {
-            InModuleScope -ScriptBlock {
-                { Sampler\Get-SamplerWorkspaceBuiltModulePath -ModuleName 'MyModule' -WorkspaceRoot 'C:\src' } |
-                    Should -Throw -ExpectedMessage '*MyModule*'
-            }
+            { Sampler\Get-SamplerWorkspaceBuiltModulePath -ModuleName 'MyModule' -WorkspaceRoot $TestDrive } |
+                Should -Throw -ExpectedMessage '*MyModule*'
         }
     }
 }

--- a/tests/Unit/Public/Get-SamplerWorkspaceBuiltModulePath.tests.ps1
+++ b/tests/Unit/Public/Get-SamplerWorkspaceBuiltModulePath.tests.ps1
@@ -1,0 +1,79 @@
+BeforeAll {
+    $script:moduleName = 'Sampler'
+
+    # If the module is not found, run the build task 'noop'.
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        # Redirect all streams to $null, except the error stream (stream 2)
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    # Re-import the module using force to get any code changes between runs.
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Remove-Module -Name $script:moduleName
+}
+
+Describe 'Get-SamplerWorkspaceBuiltModulePath' {
+    Context 'When the built module manifest is found in output\module\<name>' {
+        BeforeAll {
+            Mock -CommandName Get-SamplerWorkspaceRepositoryRoot -MockWith {
+                return 'C:\src\MyModule'
+            }
+
+            Mock -CommandName Get-ChildItem -MockWith {
+                $fakeParentParent = [System.IO.DirectoryInfo]::new('C:\src\MyModule\output\module\MyModule')
+                $fakeParent = [System.IO.DirectoryInfo]::new('C:\src\MyModule\output\module\MyModule\1.0.0')
+
+                $fakeItem = [PSCustomObject] @{
+                    FullName  = 'C:\src\MyModule\output\module\MyModule\1.0.0\MyModule.psd1'
+                    Directory = [PSCustomObject] @{
+                        Parent   = $fakeParentParent
+                        FullName = $fakeParent.FullName
+                    }
+                }
+
+                return $fakeItem
+            } -ParameterFilter {
+                $Path -like '*output\module\MyModule\*'
+            }
+        }
+
+        It 'Should return the versioned module parent directory' {
+            InModuleScope -ScriptBlock {
+                $result = Sampler\Get-SamplerWorkspaceBuiltModulePath -ModuleName 'MyModule' -WorkspaceRoot 'C:\src'
+
+                $result | Should -Be 'C:\src\MyModule\output\module\MyModule'
+            }
+        }
+    }
+
+    Context 'When no built manifest is found' {
+        BeforeAll {
+            Mock -CommandName Get-SamplerWorkspaceRepositoryRoot -MockWith {
+                return 'C:\src\MyModule'
+            }
+
+            Mock -CommandName Get-ChildItem -MockWith {
+                return $null
+            }
+        }
+
+        It 'Should throw with a message containing the module name' {
+            InModuleScope -ScriptBlock {
+                { Sampler\Get-SamplerWorkspaceBuiltModulePath -ModuleName 'MyModule' -WorkspaceRoot 'C:\src' } |
+                    Should -Throw -ExpectedMessage '*MyModule*'
+            }
+        }
+    }
+}

--- a/tests/Unit/Public/New-SamplerWorkspaceModuleLink.tests.ps1
+++ b/tests/Unit/Public/New-SamplerWorkspaceModuleLink.tests.ps1
@@ -1,0 +1,146 @@
+BeforeAll {
+    $script:moduleName = 'Sampler'
+
+    # If the module is not found, run the build task 'noop'.
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        # Redirect all streams to $null, except the error stream (stream 2)
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    # Re-import the module using force to get any code changes between runs.
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Remove-Module -Name $script:moduleName
+}
+
+Describe 'New-SamplerWorkspaceModuleLink' {
+    Context 'When the link path does not exist and symbolic link creation succeeds' {
+        BeforeAll {
+            Mock -CommandName Test-Path -MockWith {
+                return $false
+            }
+
+            Mock -CommandName New-Item -MockWith {
+                return [PSCustomObject] @{ FullName = 'C:\output\module\MyModule' }
+            } -ParameterFilter {
+                $ItemType -eq 'SymbolicLink'
+            }
+        }
+
+        It 'Should return SymbolicLink' {
+            InModuleScope -ScriptBlock {
+                $result = Sampler\New-SamplerWorkspaceModuleLink `
+                    -LinkPath 'C:\output\module\MyModule' `
+                    -TargetPath 'C:\src\MyModule\output\module\MyModule'
+
+                $result | Should -Be 'SymbolicLink'
+            }
+        }
+
+        It 'Should invoke New-Item with ItemType SymbolicLink' {
+            InModuleScope -ScriptBlock {
+                $null = Sampler\New-SamplerWorkspaceModuleLink `
+                    -LinkPath 'C:\output\module\MyModule' `
+                    -TargetPath 'C:\src\MyModule\output\module\MyModule'
+
+                Should -Invoke -CommandName New-Item -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $ItemType -eq 'SymbolicLink'
+                }
+            }
+        }
+    }
+
+    Context 'When the link path already exists' {
+        BeforeAll {
+            Mock -CommandName Test-Path -MockWith {
+                return $true
+            }
+
+            Mock -CommandName Remove-Item
+
+            Mock -CommandName New-Item -MockWith {
+                return [PSCustomObject] @{ FullName = 'C:\output\module\MyModule' }
+            } -ParameterFilter {
+                $ItemType -eq 'SymbolicLink'
+            }
+        }
+
+        It 'Should invoke Remove-Item to remove the existing link path' {
+            InModuleScope -ScriptBlock {
+                $null = Sampler\New-SamplerWorkspaceModuleLink `
+                    -LinkPath 'C:\output\module\MyModule' `
+                    -TargetPath 'C:\src\MyModule\output\module\MyModule'
+
+                Should -Invoke -CommandName Remove-Item -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Path -eq 'C:\output\module\MyModule'
+                }
+            }
+        }
+    }
+
+    Context 'When symbolic link creation fails on Windows and junction succeeds' {
+        BeforeAll {
+            Mock -CommandName Test-Path -MockWith {
+                return $false
+            }
+
+            Mock -CommandName New-Item -MockWith {
+                throw 'Symbolic link creation failed'
+            } -ParameterFilter {
+                $ItemType -eq 'SymbolicLink'
+            }
+
+            Mock -CommandName New-Item -MockWith {
+                return [PSCustomObject] @{ FullName = 'C:\output\module\MyModule' }
+            } -ParameterFilter {
+                $ItemType -eq 'Junction'
+            }
+        }
+
+        It 'Should return Junction when falling back on Windows' {
+            InModuleScope -ScriptBlock {
+                $result = Sampler\New-SamplerWorkspaceModuleLink `
+                    -LinkPath 'C:\output\module\MyModule' `
+                    -TargetPath 'C:\src\MyModule\output\module\MyModule' `
+                    -IsWindowsPlatform $true
+
+                $result | Should -Be 'Junction'
+            }
+        }
+    }
+
+    Context 'When symbolic link creation fails on a non-Windows platform' {
+        BeforeAll {
+            Mock -CommandName Test-Path -MockWith {
+                return $false
+            }
+
+            Mock -CommandName New-Item -MockWith {
+                throw 'Symbolic link creation failed'
+            } -ParameterFilter {
+                $ItemType -eq 'SymbolicLink'
+            }
+        }
+
+        It 'Should throw when the platform is not Windows' {
+            InModuleScope -ScriptBlock {
+                { Sampler\New-SamplerWorkspaceModuleLink `
+                        -LinkPath '/output/module/MyModule' `
+                        -TargetPath '/src/MyModule/output/module/MyModule' `
+                        -IsWindowsPlatform $false } |
+                    Should -Throw
+            }
+        }
+    }
+}

--- a/tests/Unit/Public/New-SamplerWorkspaceModuleLink.tests.ps1
+++ b/tests/Unit/Public/New-SamplerWorkspaceModuleLink.tests.ps1
@@ -42,7 +42,8 @@ Describe 'New-SamplerWorkspaceModuleLink' {
             InModuleScope -ScriptBlock {
                 $result = Sampler\New-SamplerWorkspaceModuleLink `
                     -LinkPath 'C:\output\module\MyModule' `
-                    -TargetPath 'C:\src\MyModule\output\module\MyModule'
+                    -TargetPath 'C:\src\MyModule\output\module\MyModule' `
+                    -Confirm:$false
 
                 $result | Should -Be 'SymbolicLink'
             }
@@ -52,7 +53,8 @@ Describe 'New-SamplerWorkspaceModuleLink' {
             InModuleScope -ScriptBlock {
                 $null = Sampler\New-SamplerWorkspaceModuleLink `
                     -LinkPath 'C:\output\module\MyModule' `
-                    -TargetPath 'C:\src\MyModule\output\module\MyModule'
+                    -TargetPath 'C:\src\MyModule\output\module\MyModule' `
+                    -Confirm:$false
 
                 Should -Invoke -CommandName New-Item -Exactly -Times 1 -Scope It -ParameterFilter {
                     $ItemType -eq 'SymbolicLink'
@@ -80,7 +82,8 @@ Describe 'New-SamplerWorkspaceModuleLink' {
             InModuleScope -ScriptBlock {
                 $null = Sampler\New-SamplerWorkspaceModuleLink `
                     -LinkPath 'C:\output\module\MyModule' `
-                    -TargetPath 'C:\src\MyModule\output\module\MyModule'
+                    -TargetPath 'C:\src\MyModule\output\module\MyModule' `
+                    -Confirm:$false
 
                 Should -Invoke -CommandName Remove-Item -Exactly -Times 1 -Scope It -ParameterFilter {
                     $Path -eq 'C:\output\module\MyModule'
@@ -113,7 +116,8 @@ Describe 'New-SamplerWorkspaceModuleLink' {
                 $result = Sampler\New-SamplerWorkspaceModuleLink `
                     -LinkPath 'C:\output\module\MyModule' `
                     -TargetPath 'C:\src\MyModule\output\module\MyModule' `
-                    -IsWindowsPlatform $true
+                    -IsWindowsPlatform $true `
+                    -Confirm:$false
 
                 $result | Should -Be 'Junction'
             }
@@ -138,7 +142,8 @@ Describe 'New-SamplerWorkspaceModuleLink' {
                 { Sampler\New-SamplerWorkspaceModuleLink `
                         -LinkPath '/output/module/MyModule' `
                         -TargetPath '/src/MyModule/output/module/MyModule' `
-                        -IsWindowsPlatform $false } |
+                        -IsWindowsPlatform $false `
+                        -Confirm:$false } |
                     Should -Throw
             }
         }

--- a/tests/Unit/tasks/Build-Module.ModuleBuilder.build.Tests.ps1
+++ b/tests/Unit/tasks/Build-Module.ModuleBuilder.build.Tests.ps1
@@ -89,12 +89,6 @@ Describe 'Build_ModuleOutput_ModuleBuilder' {
             $Path -match 'ReleaseNotes.md'
         }
 
-        Mock -CommandName Get-SamplerModuleInfo -RemoveParameterValidation 'ModuleManifestPath' -MockWith {
-            return @{
-                AliasesToExport = '*'
-            }
-        }
-
         Mock -CommandName Update-ModuleManifest
 
         Mock -CommandName Get-Content -ParameterFilter {
@@ -114,13 +108,79 @@ Describe 'Build_ModuleOutput_ModuleBuilder' {
         }
     }
 
-    It 'Should run the build task without throwing' {
-        {
-            Invoke-Build -Task 'Build_ModuleOutput_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
-        } | Should -Not -Throw
+    Context 'When source manifest has AliasesToExport set to wildcard and ModuleBuilder resolved no aliases' {
+        BeforeAll {
+            Mock -CommandName Get-SamplerModuleInfo -RemoveParameterValidation 'ModuleManifestPath' -MockWith {
+                return @{
+                    AliasesToExport = '*'
+                }
+            }
 
-        Should -Invoke -CommandName Update-ModuleManifest -Exactly -Times 1 -Scope It -ParameterFilter {
-            $AliasesToExport -eq '*'
+            Mock -CommandName Import-PowerShellDataFile -RemoveParameterValidation 'Path' -MockWith {
+                return @{
+                    AliasesToExport = @()
+                }
+            }
+        }
+
+        It 'Should run the build task without throwing and restore the wildcard so dynamically registered aliases remain visible' {
+            {
+                Invoke-Build -Task 'Build_ModuleOutput_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Invoke -CommandName Update-ModuleManifest -Exactly -Times 1 -Scope It -ParameterFilter {
+                $AliasesToExport -eq '*'
+            }
+        }
+    }
+
+    Context 'When source manifest has AliasesToExport set to wildcard and ModuleBuilder resolved a concrete alias list' {
+        BeforeAll {
+            Mock -CommandName Get-SamplerModuleInfo -RemoveParameterValidation 'ModuleManifestPath' -MockWith {
+                return @{
+                    AliasesToExport = '*'
+                }
+            }
+
+            Mock -CommandName Import-PowerShellDataFile -RemoveParameterValidation 'Path' -MockWith {
+                return @{
+                    AliasesToExport = @('Get-Foo', 'Set-Foo')
+                }
+            }
+        }
+
+        It 'Should run the build task without throwing and not override the concrete alias list resolved by ModuleBuilder' {
+            {
+                Invoke-Build -Task 'Build_ModuleOutput_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Not -Invoke -CommandName Update-ModuleManifest -Scope It
+        }
+    }
+
+    Context 'When source manifest has a concrete AliasesToExport list' {
+        BeforeAll {
+            Mock -CommandName Get-SamplerModuleInfo -RemoveParameterValidation 'ModuleManifestPath' -MockWith {
+                return @{
+                    AliasesToExport = @('Get-Foo', 'Set-Foo')
+                }
+            }
+
+            Mock -CommandName Import-PowerShellDataFile -RemoveParameterValidation 'Path' -MockWith {
+                return @{
+                    AliasesToExport = @()
+                }
+            }
+        }
+
+        It 'Should run the build task without throwing and propagate the concrete alias list' {
+            {
+                Invoke-Build -Task 'Build_ModuleOutput_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Invoke -CommandName Update-ModuleManifest -Exactly -Times 1 -Scope It -ParameterFilter {
+                $AliasesToExport -contains 'Get-Foo' -and $AliasesToExport -contains 'Set-Foo'
+            }
         }
     }
 }

--- a/tests/Unit/tasks/Clean.ModuleBuilder.build.Tests.ps1
+++ b/tests/Unit/tasks/Clean.ModuleBuilder.build.Tests.ps1
@@ -35,16 +35,58 @@ Describe 'Clean' {
         }
     }
 
-    Context 'When creating a preview release tag' {
+    Context 'When running the task with default parameters' {
         BeforeAll {
             Mock -CommandName Get-ChildItem
             Mock -CommandName Remove-Item
         }
 
-        It 'Should run the build task without throwing' {
+        It 'Should run the build task without throwing and exclude both RequiredModules and the agentic subfolder' {
             {
                 Invoke-Build -Task 'Clean' -File $taskAlias.Definition @mockTaskParameters
             } | Should -Not -Throw
+
+            Should -Invoke -CommandName Get-ChildItem -Exactly -Times 1 -Scope It -ParameterFilter {
+                $Exclude -contains 'RequiredModules' -and $Exclude -contains 'agentic'
+            }
+        }
+    }
+
+    Context 'When AgentOutputSubdirectory is set to a custom value' {
+        BeforeAll {
+            Mock -CommandName Get-ChildItem
+            Mock -CommandName Remove-Item
+        }
+
+        It 'Should run the build task without throwing and exclude the custom agent subfolder' {
+            $taskParametersWithCustomAgent = $mockTaskParameters + @{ AgentOutputSubdirectory = 'ci-logs' }
+
+            {
+                Invoke-Build -Task 'Clean' -File $taskAlias.Definition @taskParametersWithCustomAgent
+            } | Should -Not -Throw
+
+            Should -Invoke -CommandName Get-ChildItem -Exactly -Times 1 -Scope It -ParameterFilter {
+                $Exclude -contains 'ci-logs'
+            }
+        }
+    }
+
+    Context 'When AgentOutputSubdirectory is empty' {
+        BeforeAll {
+            Mock -CommandName Get-ChildItem
+            Mock -CommandName Remove-Item
+        }
+
+        It 'Should run the build task without throwing and only exclude RequiredModules' {
+            $taskParametersNoAgent = $mockTaskParameters + @{ AgentOutputSubdirectory = '' }
+
+            {
+                Invoke-Build -Task 'Clean' -File $taskAlias.Definition @taskParametersNoAgent
+            } | Should -Not -Throw
+
+            Should -Invoke -CommandName Get-ChildItem -Exactly -Times 1 -Scope It -ParameterFilter {
+                $Exclude -contains 'RequiredModules' -and $Exclude -notcontains 'agentic'
+            }
         }
     }
 }

--- a/tests/Unit/tasks/WorkspaceDependencies.build.Tests.ps1
+++ b/tests/Unit/tasks/WorkspaceDependencies.build.Tests.ps1
@@ -37,10 +37,9 @@ Describe 'Link_Local_Workspace_Dependencies' {
     Context 'When WorkspaceModules is configured in BuildInfo' {
         BeforeAll {
             $mockTaskParameters = @{
-                OutputDirectory = Join-Path -Path $TestDrive -ChildPath 'output'
-                BuildInfo       = @{
-                    WorkspaceModules = @('ModuleA', 'ModuleB')
-                }
+                OutputDirectory  = Join-Path -Path $TestDrive -ChildPath 'output'
+                WorkspaceModules = @('ModuleA', 'ModuleB')
+                BuildInfo        = @{}
             }
 
             Mock -CommandName Get-SamplerWorkspaceLinkedModuleRoot -MockWith {
@@ -72,8 +71,9 @@ Describe 'Link_Local_Workspace_Dependencies' {
     Context 'When WorkspaceModules is empty and not in BuildInfo' {
         BeforeAll {
             $mockTaskParameters = @{
-                OutputDirectory = Join-Path -Path $TestDrive -ChildPath 'output'
-                BuildInfo       = @{ }
+                OutputDirectory  = Join-Path -Path $TestDrive -ChildPath 'output'
+                WorkspaceModules = @()
+                BuildInfo        = @{}
             }
 
             Mock -CommandName New-SamplerWorkspaceModuleLink
@@ -91,10 +91,9 @@ Describe 'Link_Local_Workspace_Dependencies' {
     Context 'When New-SamplerWorkspaceModuleLink returns Junction' {
         BeforeAll {
             $mockTaskParameters = @{
-                OutputDirectory = Join-Path -Path $TestDrive -ChildPath 'output'
-                BuildInfo       = @{
-                    WorkspaceModules = @('ModuleA')
-                }
+                OutputDirectory  = Join-Path -Path $TestDrive -ChildPath 'output'
+                WorkspaceModules = @('ModuleA')
+                BuildInfo        = @{}
             }
 
             Mock -CommandName Get-SamplerWorkspaceLinkedModuleRoot -MockWith {

--- a/tests/Unit/tasks/WorkspaceDependencies.build.Tests.ps1
+++ b/tests/Unit/tasks/WorkspaceDependencies.build.Tests.ps1
@@ -1,0 +1,129 @@
+BeforeAll {
+    $script:moduleName = 'Sampler'
+
+    # If the module is not found, run the build task 'noop'.
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        # Redirect all streams to $null, except the error stream (stream 2)
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    # Re-import the module using force to get any code changes between runs.
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
+AfterAll {
+    Remove-Module -Name $script:moduleName
+}
+
+Describe 'WorkspaceDependencies.build' {
+    It 'Should have exported the alias correctly' {
+        $taskAlias = Get-Alias -Name 'WorkspaceDependencies.build.Sampler.ib.tasks'
+
+        $taskAlias.Name | Should -Be 'WorkspaceDependencies.build.Sampler.ib.tasks'
+        $taskAlias.ReferencedCommand | Should -Be 'WorkspaceDependencies.build.ps1'
+        $taskAlias.Definition | Should -Match 'Sampler[\/|\\]\d+\.\d+\.\d+[\/|\\]tasks[\/|\\]WorkspaceDependencies\.build\.ps1'
+    }
+}
+
+Describe 'Link_Local_Workspace_Dependencies' {
+    BeforeAll {
+        # Dot-source mocks
+        . $PSScriptRoot/../TestHelpers/MockSetSamplerTaskVariable
+
+        $taskAlias = Get-Alias -Name 'WorkspaceDependencies.build.Sampler.ib.tasks'
+    }
+
+    Context 'When WorkspaceModules is configured in BuildInfo' {
+        BeforeAll {
+            $mockTaskParameters = @{
+                OutputDirectory = Join-Path -Path $TestDrive -ChildPath 'output'
+                BuildInfo       = @{
+                    WorkspaceModules = @('ModuleA', 'ModuleB')
+                }
+            }
+
+            Mock -CommandName Get-SamplerWorkspaceLinkedModuleRoot -MockWith {
+                return (Join-Path -Path $TestDrive -ChildPath 'output\module')
+            }
+
+            Mock -CommandName Test-Path -MockWith {
+                return $true
+            }
+
+            Mock -CommandName Get-SamplerWorkspaceBuiltModulePath -MockWith {
+                return ('C:\src\{0}\output\module\{0}' -f $ModuleName)
+            }
+
+            Mock -CommandName New-SamplerWorkspaceModuleLink -MockWith {
+                return 'SymbolicLink'
+            }
+        }
+
+        It 'Should invoke New-SamplerWorkspaceModuleLink once per configured module' {
+            {
+                Invoke-Build -Task 'Link_Local_Workspace_Dependencies' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Invoke -CommandName New-SamplerWorkspaceModuleLink -Exactly -Times 2 -Scope It
+        }
+    }
+
+    Context 'When WorkspaceModules is empty and not in BuildInfo' {
+        BeforeAll {
+            $mockTaskParameters = @{
+                OutputDirectory = Join-Path -Path $TestDrive -ChildPath 'output'
+                BuildInfo       = @{ }
+            }
+
+            Mock -CommandName New-SamplerWorkspaceModuleLink
+        }
+
+        It 'Should run without throwing and never call New-SamplerWorkspaceModuleLink' {
+            {
+                Invoke-Build -Task 'Link_Local_Workspace_Dependencies' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Invoke -CommandName New-SamplerWorkspaceModuleLink -Exactly -Times 0 -Scope It
+        }
+    }
+
+    Context 'When New-SamplerWorkspaceModuleLink returns Junction' {
+        BeforeAll {
+            $mockTaskParameters = @{
+                OutputDirectory = Join-Path -Path $TestDrive -ChildPath 'output'
+                BuildInfo       = @{
+                    WorkspaceModules = @('ModuleA')
+                }
+            }
+
+            Mock -CommandName Get-SamplerWorkspaceLinkedModuleRoot -MockWith {
+                return (Join-Path -Path $TestDrive -ChildPath 'output\module')
+            }
+
+            Mock -CommandName Test-Path -MockWith {
+                return $true
+            }
+
+            Mock -CommandName Get-SamplerWorkspaceBuiltModulePath -MockWith {
+                return 'C:\src\ModuleA\output\module\ModuleA'
+            }
+
+            Mock -CommandName New-SamplerWorkspaceModuleLink -MockWith {
+                return 'Junction'
+            }
+
+            Mock -CommandName Write-Build
+        }
+
+        It 'Should invoke Write-Build with Yellow color for the Junction fallback' {
+            {
+                Invoke-Build -Task 'Link_Local_Workspace_Dependencies' -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Invoke -CommandName Write-Build -Exactly -Times 1 -Scope It -ParameterFilter {
+                $Color -eq 'Yellow'
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces several improvements to the build system, coding guidelines, and documentation for the repository. The most significant changes include enhancements to build output management (especially around agent log handling), stricter and clearer PowerShell style guidelines, improved module dependency handling for multi-repo workspaces, and new documentation for class/type accelerator usage. These updates aim to make builds more reliable, logs more persistent and accessible, and coding standards more consistent across the project.

**Build Output and Log Management:**

- The `Clean` task now excludes the `output\agentic` subdirectory, ensuring that agent log files persist between builds and are not accidentally deleted. Parameters and logic were updated to support this, and documentation was changed to instruct users to tee logs to this folder and clean it up manually when done. (.build/tasks/Clean.ModuleBuilder.build.ps1, .github/copilot-instructions.md, .github/skills/validate-changes/SKILL.md) [[1]](diffhunk://#diff-fef1eb65a18d5d294658b0c7d846bddc3d9de9a858f58edfcde11f225f5a9c20L4-R13) [[2]](diffhunk://#diff-fef1eb65a18d5d294658b0c7d846bddc3d9de9a858f58edfcde11f225f5a9c20L18-R32) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L45-R72) [[4]](diffhunk://#diff-2b810aa946a58e4ad8b6792be6a656fe8ee3cc1b9d1bbad5ea2ed90035d48fe3L68-R84)

**PowerShell Coding Style and Guidelines:**

- Updated both public and private function guidelines to enforce the DSC Community parameter style, require explicit .NET types, and recommend PowerShell best practices such as preferring `$null = ...` over `... | Out-Null` and using splatting for multi-line commands. (.github/instructions/public-functions.instructions.md, .github/instructions/private-functions.instructions.md) [[1]](diffhunk://#diff-496df50ecbc4c67e85b8f06f770d4ec25be2d65ad469f25e8954c8c150185a8dR20-R51) [[2]](diffhunk://#diff-48854c2cae4c8cc8a888b069a635528c8014edfd60f460831fc56b90d412e254R20-R38)
- Added a guideline to always wrap pipeline expressions in `@()` before using `.Count` or indexing, to ensure compatibility with Windows PowerShell 5.1. (.github/instructions/test-writing.instructions.md)

**Module Dependency Handling:**

- Added a new build task (`WorkspaceDependencies.build.ps1`) to automatically link sibling workspace module outputs into the local output path, making multi-repo development and testing smoother by ensuring dependencies resolve correctly. (.build/tasks/WorkspaceDependencies.build.ps1)

**Class and Type Accelerator Documentation:**

- Introduced a new documentation file detailing how to export classes and register type accelerators in a PowerShell module, including registration and cleanup rules, usage implications, and guidance for safe changes. (.github/instructions/classes-and-type-accelerators.instructions.md)

**Other Improvements:**

- Improved handling of `AliasesToExport` propagation in the module build process to better handle wildcard and concrete alias lists, avoiding accidental loss or overwriting of alias exports. (.build/tasks/Build-Module.ModuleBuilder.build.ps1) [[1]](diffhunk://#diff-eeb287298aa251e90d538da9a71c8028bba0adf083c588b3653d0673222cbe60L105-R107) [[2]](diffhunk://#diff-eeb287298aa251e90d538da9a71c8028bba0adf083c588b3653d0673222cbe60L116-R139)
- Clarified changelog requirements: only user-facing changes require changelog entries; infrastructure and Copilot-instruction changes do not. (.github/copilot-instructions.md)
- Added a note to build task instructions recommending helper functions be placed in sibling `.psm1` files rather than in the task file itself. (.github/instructions/build-tasks.instructions.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/579)
<!-- Reviewable:end -->
