### PR TITLE
Fix MainGitBranch resolution from Yaml if not set

### DIFF
--- a/.build/tasks/Build-Module.ModuleBuilder.build.ps1
+++ b/.build/tasks/Build-Module.ModuleBuilder.build.ps1
@@ -135,7 +135,7 @@ Task Build_ModuleOutput_ModuleBuilder {
 
         if ($shouldUpdate)
         {
-            Update-ModuleManifest -Path $builtModuleManifestPath -AliasesToExport $sourceAliasesToExport
+            Update-Metadata -Path $builtModuleManifestPath -PropertyName 'AliasesToExport' -Value $sourceAliasesToExport
         }
     }
 

--- a/.build/tasks/Build-Module.ModuleBuilder.build.ps1
+++ b/.build/tasks/Build-Module.ModuleBuilder.build.ps1
@@ -159,6 +159,15 @@ Task Build_ModuleOutput_ModuleBuilder {
     {
         $releaseNotes = Get-Content -Path $ReleaseNotesPath -Raw
 
+        <#
+            Strip non-ASCII characters before embedding the release notes into the
+            built module manifest. Import-PowerShellDataFile on Windows PowerShell 5.1
+            cannot parse a PSD1 file that contains non-ASCII characters in string values
+            when the file is encoded as UTF-8 without BOM (which is the default on Linux/macOS).
+            Replace any non-ASCII character with '?' so the manifest remains parseable.
+        #>
+        $releaseNotes = [System.Text.RegularExpressions.Regex]::Replace($releaseNotes, '[^\x00-\x7F]', '?')
+
         $outputManifest = $BuiltModule.Path
 
         Update-Metadata -Path $outputManifest -PropertyName 'PrivateData.PSData.ReleaseNotes' -Value $releaseNotes

--- a/.build/tasks/Create_Changelog_Branch.build.ps1
+++ b/.build/tasks/Create_Changelog_Branch.build.ps1
@@ -42,7 +42,9 @@
 
     .PARAMETER MainGitBranch
         The name of the default branch. Defaults to 'main'. It is used to compare
-        and target the branch against.
+        and target the branch against. If not set as a task parameter or InvokeBuild
+        property, the value is read from `BuildInfo.GitConfig.MainGitBranch` in
+        `build.yaml`.
 
     .PARAMETER BasicAuthPAT
         The personal access token to use to access the Azure DevOps Git repository.
@@ -100,7 +102,7 @@ param
     $ChangelogUpdateChangelogOnPrerelease = (property ChangelogUpdateChangelogOnPrerelease $false),
 
     [Parameter()]
-    $MainGitBranch = (property MainGitBranch 'main'),
+    $MainGitBranch = (property MainGitBranch ''),
 
     [Parameter()]
     $BasicAuthPAT = (property BasicAuthPAT ''),
@@ -146,7 +148,21 @@ task Create_Changelog_Branch {
         }
     }
 
-    Write-Build DarkGray "`tSetting git configuration."
+    if ([System.String]::IsNullOrEmpty($MainGitBranch))
+    {
+        if ($BuildInfo.GitConfig.MainGitBranch)
+        {
+            $MainGitBranch = $BuildInfo.GitConfig.MainGitBranch
+
+            Write-Build DarkGray "`t...Set property MainGitBranch to the value $MainGitBranch from build configuration."
+        }
+        else
+        {
+            $MainGitBranch = 'main'
+        }
+    }
+
+    "`tMainGitBranch              = '$MainGitBranch'"
 
     Sampler\Invoke-SamplerGit -Argument @('config', 'user.name', $GitConfigUserName)
     Sampler\Invoke-SamplerGit -Argument @('config', 'user.email', $GitConfigUserEmail)

--- a/.build/tasks/Create_Release_Git_Tag.build.ps1
+++ b/.build/tasks/Create_Release_Git_Tag.build.ps1
@@ -77,7 +77,7 @@ param
     $SkipPublish = (property SkipPublish ''),
 
     [Parameter()]
-    $MainGitBranch = (property MainGitBranch 'main'),
+    $MainGitBranch = (property MainGitBranch ''),
 
     [Parameter()]
     $BasicAuthPAT = (property BasicAuthPAT ''),
@@ -145,6 +145,22 @@ task Create_Release_Git_Tag {
                 Write-Build DarkGray "`t...Set property $gitConfigVariableName to the value $configurationValue"
             }
         }
+
+        if ([System.String]::IsNullOrEmpty($MainGitBranch))
+        {
+            if ($BuildInfo.GitConfig.MainGitBranch)
+            {
+                $MainGitBranch = $BuildInfo.GitConfig.MainGitBranch
+
+                Write-Build DarkGray "`t...Set property MainGitBranch to the value $MainGitBranch from build configuration."
+            }
+            else
+            {
+                $MainGitBranch = 'main'
+            }
+        }
+
+        "`tMainGitBranch              = '$MainGitBranch'"
 
         Write-Build DarkGray "`tSetting git configuration."
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Create_Release_Git_Tag` and `Create_Changelog_Branch` tasks now read `MainGitBranch` from `BuildInfo.GitConfig.MainGitBranch` in `build.yaml` when not set as a task parameter or InvokeBuild property. The resolution order is: task parameter → `build.yaml` `GitConfig.MainGitBranch` → default `'main'`.
+- `Create_Release_Git_Tag` and `Create_Changelog_Branch` tasks now read `MainGitBranch` from `BuildInfo.GitConfig.MainGitBranch` in `build.yaml` when not set as a task parameter or InvokeBuild property. The resolution order is: task parameter -> `build.yaml` `GitConfig.MainGitBranch` -> default `'main'`.
 - `New-SampleModule` `Features` parameter now accepts `github`, `vscode`, `codecov`, `azurepipelines`, and `gitversion` to mirror the Plaster template's feature choices.
 - `New-SampleModule` documents the `CustomModule` `ModuleType` and the new `MainGitBranch` parameter.
 - `New-SampleModule` `ModuleType` `ValidateSet` now includes `CustomModule`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `Link_Local_Workspace_Dependencies` build task and supporting public functions (`Get-SamplerWorkspaceBuiltModulePath`, `New-SamplerWorkspaceModuleLink`) for linking sibling workspace module build outputs into the local module output path when working across related repos in a multi-repo workspace. Configure via `WorkspaceModules` in `build.yaml`.
 - `Clean` task now preserves `output\agentic\` across builds (in addition to `RequiredModules`), providing a stable location for build and test log files that survive clean cycles. The subfolder name is configurable via the `AgentOutputSubdirectory` parameter (default `'agentic'`; set to empty string to disable the exclusion).
 - `package_psresource_nupkg` tasks that recursively packs dependencies, ignoring `ExternalDependencies` using `PSResourceGet` module.
+
+### Fixed
+
+- `Create_Release_Git_Tag` and `Create_Changelog_Branch` tasks now read `MainGitBranch` from `BuildInfo.GitConfig.MainGitBranch` in `build.yaml` when not set as a task parameter or InvokeBuild property. The resolution order is: task parameter → `build.yaml` `GitConfig.MainGitBranch` → default `'main'`.
 - `New-SampleModule` `Features` parameter now accepts `github`, `vscode`, `codecov`, `azurepipelines`, and `gitversion` to mirror the Plaster template's feature choices.
 - `New-SampleModule` documents the `CustomModule` `ModuleType` and the new `MainGitBranch` parameter.
 - `New-SampleModule` `ModuleType` `ValidateSet` now includes `CustomModule`.

--- a/tests/QA/module.tests.ps1
+++ b/tests/QA/module.tests.ps1
@@ -82,6 +82,18 @@ Describe 'Changelog Management' -Tag 'Changelog' {
     It 'Changelog should have an Unreleased header' -Skip:$skipTest {
             (Get-ChangelogData -Path (Join-Path -Path $ProjectPath -ChildPath 'CHANGELOG.md') -ErrorAction Stop).Unreleased | Should -Not -BeNullOrEmpty
     }
+
+    It 'Changelog contains only ASCII characters' {
+        $changelogPath = Join-Path -Path $ProjectPath -ChildPath 'CHANGELOG.md'
+        $content = Get-Content -Path $changelogPath -Raw -ErrorAction Stop
+        $nonAsciiMatches = [System.Text.RegularExpressions.Regex]::Matches($content, '[^\x00-\x7F]')
+
+        $nonAsciiMatches | Should -BeNullOrEmpty -Because (
+            'non-ASCII characters in CHANGELOG.md are embedded in the built module manifest ReleaseNotes ' +
+            'and cause Import-PowerShellDataFile to fail on Windows PowerShell 5.1. ' +
+            'Replace characters like smart quotes, em-dashes, or Unicode arrows (e.g. -> instead of ->).'
+        )
+    }
 }
 
 Describe 'General module control' -Tags 'FunctionalQuality' {

--- a/tests/Unit/tasks/Build-Module.ModuleBuilder.build.Tests.ps1
+++ b/tests/Unit/tasks/Build-Module.ModuleBuilder.build.Tests.ps1
@@ -128,8 +128,8 @@ Describe 'Build_ModuleOutput_ModuleBuilder' {
                 Invoke-Build -Task 'Build_ModuleOutput_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
             } | Should -Not -Throw
 
-            Should -Invoke -CommandName Update-ModuleManifest -Exactly -Times 1 -Scope It -ParameterFilter {
-                $AliasesToExport -eq '*'
+            Should -Invoke -CommandName Update-Metadata -Exactly -Times 1 -Scope It -ParameterFilter {
+                $PropertyName -eq 'AliasesToExport' -and $Value -eq '*'
             }
         }
     }
@@ -154,7 +154,9 @@ Describe 'Build_ModuleOutput_ModuleBuilder' {
                 Invoke-Build -Task 'Build_ModuleOutput_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
             } | Should -Not -Throw
 
-            Should -Not -Invoke -CommandName Update-ModuleManifest -Scope It
+            Should -Not -Invoke -CommandName Update-Metadata -Scope It -ParameterFilter {
+                $PropertyName -eq 'AliasesToExport'
+            }
         }
     }
 
@@ -178,8 +180,9 @@ Describe 'Build_ModuleOutput_ModuleBuilder' {
                 Invoke-Build -Task 'Build_ModuleOutput_ModuleBuilder' -File $taskAlias.Definition @mockTaskParameters
             } | Should -Not -Throw
 
-            Should -Invoke -CommandName Update-ModuleManifest -Exactly -Times 1 -Scope It -ParameterFilter {
-                $AliasesToExport -contains 'Get-Foo' -and $AliasesToExport -contains 'Set-Foo'
+            Should -Invoke -CommandName Update-Metadata -Exactly -Times 1 -Scope It -ParameterFilter {
+                $PropertyName -eq 'AliasesToExport' -and
+                $Value -contains 'Get-Foo' -and $Value -contains 'Set-Foo'
             }
         }
     }

--- a/tests/Unit/tasks/Create_Changelog_Branch.build.Tests.ps1
+++ b/tests/Unit/tasks/Create_Changelog_Branch.build.Tests.ps1
@@ -43,15 +43,16 @@ Describe 'Create_Changelog_Branch' {
             }
 
             $mockTaskParameters = @{
-                ProjectPath = Join-Path -Path $TestDrive -ChildPath 'MyModule'
-                OutputDirectory = Join-Path -Path $TestDrive -ChildPath 'MyModule/output'
-                SourcePath = Join-Path -Path $TestDrive -ChildPath 'MyModule/source'
-                ProjectName = 'MyModule'
-                BasicAuthPAT = '22222'
-                GitConfigUserName = 'bot'
+                ProjectPath        = Join-Path -Path $TestDrive -ChildPath 'MyModule'
+                OutputDirectory    = Join-Path -Path $TestDrive -ChildPath 'MyModule/output'
+                SourcePath         = Join-Path -Path $TestDrive -ChildPath 'MyModule/source'
+                ProjectName        = 'MyModule'
+                BasicAuthPAT       = '22222'
+                GitConfigUserName  = 'bot'
                 GitConfigUserEmail = 'bot@company.local'
-                MainGitBranch = 'main'
-                ChangelogPath = 'CHANGELOG.md'
+                MainGitBranch      = 'main'
+                ChangelogPath      = 'CHANGELOG.md'
+                BuildInfo          = @{}
             }
         }
 
@@ -84,15 +85,16 @@ Describe 'Create_Changelog_Branch' {
             Mock -CommandName Update-Changelog -RemoveParameterValidation 'Path'
 
             $mockTaskParameters = @{
-                ProjectPath = Join-Path -Path $TestDrive -ChildPath 'MyModule'
-                OutputDirectory = Join-Path -Path $TestDrive -ChildPath 'MyModule/output'
-                SourcePath = Join-Path -Path $TestDrive -ChildPath 'MyModule/source'
-                ProjectName = 'MyModule'
-                BasicAuthPAT = '22222'
-                GitConfigUserName = 'bot'
+                ProjectPath        = Join-Path -Path $TestDrive -ChildPath 'MyModule'
+                OutputDirectory    = Join-Path -Path $TestDrive -ChildPath 'MyModule/output'
+                SourcePath         = Join-Path -Path $TestDrive -ChildPath 'MyModule/source'
+                ProjectName        = 'MyModule'
+                BasicAuthPAT       = '22222'
+                GitConfigUserName  = 'bot'
                 GitConfigUserEmail = 'bot@company.local'
-                MainGitBranch = 'main'
-                ChangelogPath = 'CHANGELOG.md'
+                MainGitBranch      = 'main'
+                ChangelogPath      = 'CHANGELOG.md'
+                BuildInfo          = @{}
             }
         }
 
@@ -100,6 +102,48 @@ Describe 'Create_Changelog_Branch' {
             {
                 Invoke-Build -Task $buildTaskName -File $taskAlias.Definition @mockTaskParameters
             } | Should -Not -Throw
+        }
+    }
+
+    Context 'When MainGitBranch is not set and BuildInfo.GitConfig.MainGitBranch is configured' {
+        BeforeAll {
+            # Dot-source mocks
+            . $PSScriptRoot/../TestHelpers/MockSetSamplerTaskVariable
+
+            Mock -CommandName Sampler\Invoke-SamplerGit
+
+            Mock -CommandName Sampler\Invoke-SamplerGit -ParameterFilter {
+                $Argument -contains 'rev-parse'
+            } -MockWith {
+                return '0c23efc'
+            }
+
+            $mockTaskParameters = @{
+                ProjectPath        = Join-Path -Path $TestDrive -ChildPath 'MyModule'
+                OutputDirectory    = Join-Path -Path $TestDrive -ChildPath 'MyModule/output'
+                SourcePath         = Join-Path -Path $TestDrive -ChildPath 'MyModule/source'
+                ProjectName        = 'MyModule'
+                BasicAuthPAT       = '22222'
+                GitConfigUserName  = 'bot'
+                GitConfigUserEmail = 'bot@company.local'
+                MainGitBranch      = ''
+                ChangelogPath      = 'CHANGELOG.md'
+                BuildInfo          = @{
+                    GitConfig = @{
+                        MainGitBranch = 'develop'
+                    }
+                }
+            }
+        }
+
+        It 'Should run the build task without throwing and use the branch from BuildInfo' {
+            {
+                Invoke-Build -Task $buildTaskName -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Invoke -CommandName Sampler\Invoke-SamplerGit -Scope It -ParameterFilter {
+                $Argument -contains 'rev-parse' -and $Argument -contains 'origin/develop'
+            }
         }
     }
 }

--- a/tests/Unit/tasks/Create_Release_Git_Tag.build.Tests.ps1
+++ b/tests/Unit/tasks/Create_Release_Git_Tag.build.Tests.ps1
@@ -60,6 +60,7 @@ Describe 'Create_Release_Git_Tag' {
                 GitConfigUserName = 'bot'
                 GitConfigUserEmail = 'bot@company.local'
                 MainGitBranch = 'main'
+                BuildInfo = @{}
             }
         }
 
@@ -122,6 +123,7 @@ Describe 'Create_Release_Git_Tag' {
                 GitConfigUserName = 'bot'
                 GitConfigUserEmail = 'bot@company.local'
                 MainGitBranch = 'main'
+                BuildInfo = @{}
             }
         }
 
@@ -133,6 +135,60 @@ Describe 'Create_Release_Git_Tag' {
             {
                 Invoke-Build -Task $buildTaskName -File $taskAlias.Definition @mockTaskParameters
             } | Should -Not -Throw
+        }
+    }
+
+    Context 'When MainGitBranch is not set and BuildInfo.GitConfig.MainGitBranch is configured' {
+        BeforeAll {
+            # Dot-source mocks
+            . $PSScriptRoot/../TestHelpers/MockSetSamplerTaskVariable
+
+            function script:git
+            {
+                throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+            }
+
+            Mock -CommandName git
+
+            Mock -CommandName Sampler\Invoke-SamplerGit
+
+            Mock -CommandName Sampler\Invoke-SamplerGit -ParameterFilter {
+                $Argument -contains 'rev-parse'
+            } -MockWith {
+                return '0c23efc'
+            }
+
+            Mock -CommandName Start-Sleep
+
+            $mockTaskParameters = @{
+                ProjectPath       = Join-Path -Path $TestDrive -ChildPath 'MyModule'
+                OutputDirectory   = Join-Path -Path $TestDrive -ChildPath 'MyModule/output'
+                SourcePath        = Join-Path -Path $TestDrive -ChildPath 'MyModule/source'
+                ProjectName       = 'MyModule'
+                BasicAuthPAT      = '22222'
+                GitConfigUserName = 'bot'
+                GitConfigUserEmail = 'bot@company.local'
+                MainGitBranch     = ''
+                BuildInfo         = @{
+                    GitConfig = @{
+                        MainGitBranch = 'develop'
+                    }
+                }
+            }
+        }
+
+        AfterAll {
+            Remove-Item 'function:git'
+        }
+
+        It 'Should run the build task without throwing and use the branch from BuildInfo' {
+            {
+                Invoke-Build -Task $buildTaskName -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Invoke -CommandName Sampler\Invoke-SamplerGit -Scope It -ParameterFilter {
+                $Argument -contains 'rev-parse' -and $Argument -contains 'origin/develop'
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request improves how the `MainGitBranch` parameter is resolved in the `Create_Changelog_Branch` and `Create_Release_Git_Tag` build tasks. If `MainGitBranch` is not set explicitly, the tasks will now look for the value in `BuildInfo.GitConfig.MainGitBranch` from `build.yaml`, and only default to `'main'` if neither is set. The update also adds corresponding unit tests to ensure this resolution order works as expected and updates the documentation.

**Parameter Resolution Improvements:**

* The `MainGitBranch` parameter in both `Create_Changelog_Branch` and `Create_Release_Git_Tag` tasks is now empty by default, and if not set, will be loaded from `BuildInfo.GitConfig.MainGitBranch` in `build.yaml`, falling back to `'main'` if not found. This makes branch configuration more flexible and centralized. [[1]](diffhunk://#diff-211b4c9d07ddf8d1efe0ea09ae86b2ccecbd6e026a7c99fdcaea2e09bf3a670dL45-R47) [[2]](diffhunk://#diff-211b4c9d07ddf8d1efe0ea09ae86b2ccecbd6e026a7c99fdcaea2e09bf3a670dL103-R105) [[3]](diffhunk://#diff-211b4c9d07ddf8d1efe0ea09ae86b2ccecbd6e026a7c99fdcaea2e09bf3a670dL149-R165) [[4]](diffhunk://#diff-97ccaacce031f2fba06fe2352c3389a09ee61fff3f4c634d595732e5436552f1L80-R80) [[5]](diffhunk://#diff-97ccaacce031f2fba06fe2352c3389a09ee61fff3f4c634d595732e5436552f1R149-R164)

**Testing Enhancements:**

* Added unit tests for both tasks to verify that when `MainGitBranch` is not set, the value from `BuildInfo.GitConfig.MainGitBranch` is used. [[1]](diffhunk://#diff-3f1fc09f8337549d8182fedc7501b7ea56b1db66597df98aaad77f6599e0a617R55) [[2]](diffhunk://#diff-3f1fc09f8337549d8182fedc7501b7ea56b1db66597df98aaad77f6599e0a617R97) [[3]](diffhunk://#diff-3f1fc09f8337549d8182fedc7501b7ea56b1db66597df98aaad77f6599e0a617R107-R148) [[4]](diffhunk://#diff-692f53ab37c371f5269b21b6cc34a52bd7d9c22ec3bbbd3bbfcea36ad5165384R63) [[5]](diffhunk://#diff-692f53ab37c371f5269b21b6cc34a52bd7d9c22ec3bbbd3bbfcea36ad5165384R126) [[6]](diffhunk://#diff-692f53ab37c371f5269b21b6cc34a52bd7d9c22ec3bbbd3bbfcea36ad5165384R140-R193)

**Documentation Updates:**

* Updated the documentation in `.build/tasks/Create_Changelog_Branch.build.ps1` and the changelog to describe the new resolution order for `MainGitBranch`. [[1]](diffhunk://#diff-211b4c9d07ddf8d1efe0ea09ae86b2ccecbd6e026a7c99fdcaea2e09bf3a670dL45-R47) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR15-R18)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/580)
<!-- Reviewable:end -->
