### PR TITLE
Refactor Git configuration handling and Params

### DIFF
--- a/.build/tasks/Create_Changelog_Branch.build.ps1
+++ b/.build/tasks/Create_Changelog_Branch.build.ps1
@@ -164,8 +164,16 @@ task Create_Changelog_Branch {
 
     "`tMainGitBranch              = '$MainGitBranch'"
 
-    Sampler\Invoke-SamplerGit -Argument @('config', 'user.name', $GitConfigUserName)
-    Sampler\Invoke-SamplerGit -Argument @('config', 'user.email', $GitConfigUserEmail)
+    if (-not [System.String]::IsNullOrEmpty($GitConfigUserName))
+    {
+        Sampler\Invoke-SamplerGit -Argument @('config', 'user.name', $GitConfigUserName)
+    }
+
+    if (-not [System.String]::IsNullOrEmpty($GitConfigUserEmail))
+    {
+        Sampler\Invoke-SamplerGit -Argument @('config', 'user.email', $GitConfigUserEmail)
+    }
+
     Sampler\Invoke-SamplerGit -Argument @('config', 'pull.rebase', 'true')
 
     Write-Build DarkGray ("`tPulling latest commits and tags from branch '{0}'." -f $MainGitBranch)

--- a/.build/tasks/Create_Release_Git_Tag.build.ps1
+++ b/.build/tasks/Create_Release_Git_Tag.build.ps1
@@ -164,8 +164,15 @@ task Create_Release_Git_Tag {
 
         Write-Build DarkGray "`tSetting git configuration."
 
-        Sampler\Invoke-SamplerGit -Argument @('config', 'user.name', $GitConfigUserName)
-        Sampler\Invoke-SamplerGit -Argument @('config', 'user.email', $GitConfigUserEmail)
+        if (-not [System.String]::IsNullOrEmpty($GitConfigUserName))
+        {
+            Sampler\Invoke-SamplerGit -Argument @('config', 'user.name', $GitConfigUserName)
+        }
+
+        if (-not [System.String]::IsNullOrEmpty($GitConfigUserEmail))
+        {
+            Sampler\Invoke-SamplerGit -Argument @('config', 'user.email', $GitConfigUserEmail)
+        }
 
         # Make empty line in output
         ''

--- a/.github/instructions/ai-instruction-authoring.instructions.md
+++ b/.github/instructions/ai-instruction-authoring.instructions.md
@@ -20,3 +20,4 @@ concise guidance.
   frontmatter `applyTo`
 - Use `##`/`###` headings, `-` bullets, backticks for code tokens, fenced blocks for multi-line examples.
 - No bold/italic emphasis, conversational tone, or verbose examples.
+- Prefer using ASCII characters in most authored files (instructions, prompts, skills, AGENTS.md, copilot-instructions.md). Non-ASCII characters (em-dashes, smart quotes, Unicode arrows, etc.) in PowerShell source files trigger PSScriptAnalyzer rule `PSUseBOMForUnicodeEncodedFile` and in CHANGELOG.md they break `Import-PowerShellDataFile` on Windows PowerShell 5.1. Use plain ASCII: `->` not `->`, `-` not `--`, straight quotes, hyphens instead of dashes.

--- a/.github/instructions/private-functions.instructions.md
+++ b/.github/instructions/private-functions.instructions.md
@@ -37,6 +37,7 @@ param
 - Prefer `$null = <expression>` over `<expression> | Out-Null` to suppress output.
 - Prefer splatting over backtick-based line continuation for multi-line command calls.
 - Never use hardcoded backslash separators inside `Join-Path -ChildPath` strings. Build multi-level paths with chained `Join-Path` calls (one component at a time). Backslashes in a `ChildPath` are not path separators on Linux/macOS.
+- Use only ASCII characters in `.ps1` source files. Non-ASCII characters (em-dashes, smart quotes, Unicode arrows, etc.) trigger PSScriptAnalyzer rule `PSUseBOMForUnicodeEncodedFile`. Use `->` not Unicode arrows, `-` not dashes, straight quotes.
 
 ## Validation model
 

--- a/.github/instructions/public-functions.instructions.md
+++ b/.github/instructions/public-functions.instructions.md
@@ -44,11 +44,9 @@ $params = @{
     Recurse = $true
 }
 Get-ChildItem @params
-
-# Avoid
-Get-ChildItem -Path $OutputDirectory `
-    -Recurse
 ```
+
+- Use only ASCII characters in `.ps1` source files. Non-ASCII characters (em-dashes, smart quotes, Unicode arrows, etc.) trigger PSScriptAnalyzer rule `PSUseBOMForUnicodeEncodedFile`. Use `->` not Unicode arrows, `-` not dashes, straight quotes.
 
 ## Cross-platform path construction
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Create_Release_Git_Tag` and `Create_Changelog_Branch` tasks now read `MainGitBranch` from `BuildInfo.GitConfig.MainGitBranch` in `build.yaml` when not set as a task parameter or InvokeBuild property. The resolution order is: task parameter -> `build.yaml` `GitConfig.MainGitBranch` -> default `'main'`.
-- `New-SampleModule` `Features` parameter now accepts `github`, `vscode`, `codecov`, `azurepipelines`, and `gitversion` to mirror the Plaster template's feature choices.
+- `Create_Release_Git_Tag` and `Create_Changelog_Branch` tasks no longer call `git config user.name` or `git config user.email` when `GitConfigUserName` or `GitConfigUserEmail` are not set (empty/null), allowing the existing global or system git identity to be used without being overwritten with an empty value.
+- The `Build` Plaster template (`build.yaml.template`) now scaffolds a `GitConfig:` section with `MainGitBranch` pre-populated from the Plaster parameter entered during scaffolding, and `UserName`/`UserEmail` as commented-out examples.
+- `New-SampleModule` now accepts `-GitHubOwner` and `-GitHubOwnerDscCommunity` parameters so the GitHub owner can be specified non-interactively when scaffolding GitHub-enabled or `dsccommunity` modules.
+- `New-SampleModule` now forwards empty-string parameter values (such as `ModuleDescription = ''`) to Plaster instead of silently dropping them, eliminating unexpected interactive prompts when all parameters are splatted.
 - `New-SampleModule` documents the `CustomModule` `ModuleType` and the new `MainGitBranch` parameter.
 - `New-SampleModule` `ModuleType` `ValidateSet` now includes `CustomModule`.
 - `New-SampleModule` exposes a `MainGitBranch` parameter (defaults to `main`) for templates that configure a default Git branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,20 @@ on GitHub then start with the guide [Getting Started as a Contributor](https://d
 ## Running the Tests
 
 If want to know how to run this module's tests you can look at the [Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines/#running-tests).
+
+## Changelog
+
+All user-visible changes must have an entry in `CHANGELOG.md` under the
+`## [Unreleased]` section. Build, pipeline, CI, and Copilot-instruction-only
+changes do not need entries.
+
+> **Important:** `CHANGELOG.md` must contain only ASCII characters. Non-ASCII
+> characters (Unicode arrows, em-dashes, smart quotes, etc.) are
+> embedded verbatim into the built module manifest's `ReleaseNotes` field.
+> Windows PowerShell 5.1 cannot parse a module manifest that contains non-ASCII
+> characters when the file is UTF-8 encoded without a BOM (which is the default
+> on Linux and macOS). Use plain ASCII equivalents: `->` instead of `->`,
+> `-` instead of `--`, straight quotes instead of curly quotes.
+>
+> The QA test suite enforces this rule - a PR with non-ASCII characters in
+> `CHANGELOG.md` will fail the `Changelog contains only ASCII characters` test.

--- a/Sampler/Public/New-SampleModule.ps1
+++ b/Sampler/Public/New-SampleModule.ps1
@@ -49,6 +49,12 @@
         How you would like to call your Source repository to differentiate from the output and the tests folder. We recommend to call it 'source',
         and the default value is 'source'.
 
+    .PARAMETER GitHubOwner
+        The GitHub owner (personal account or organization) that will host and publish the module.
+        For non-dsccommunity module types this maps to the `GitHubOwner` Plaster parameter.
+        For `dsccommunity` module types it maps to the `GitHubOwnerDscCommunity` Plaster parameter.
+        Supplying this parameter suppresses the interactive GitHub-owner prompt regardless of module type.
+
     .PARAMETER Features
         If you'd rather select specific features from this template to build your module, use this parameter instead.
         Valid values mirror the Plaster template feature choices:
@@ -123,6 +129,10 @@ function New-SampleModule
         $SourceDirectory = 'source',
 
         [Parameter()]
+        [System.String]
+        $GitHubOwner,
+
+        [Parameter()]
         [ValidateSet(
             'All',
             'Enum',
@@ -175,10 +185,41 @@ function New-SampleModule
     {
         $paramValue = Get-Variable -Name $paramName -ValueOnly -ErrorAction SilentlyContinue
 
-        # if $paramName is $null, leave it to Plaster to ask the user.
-        if ($paramvalue -and -not $invokePlasterParam.ContainsKey($paramName))
+        <#
+            Skip parameters that are $null (not set) and not explicitly bound.
+            Use $null -ne check so that empty strings and $false are still forwarded —
+            they are valid values that suppress Plaster prompts (e.g. ModuleDescription='').
+            Do not forward parameters already in the hashtable (e.g. ModuleName added above).
+            GitHubOwner is handled separately below after the loop; skip it here.
+        #>
+        if ($paramName -eq 'GitHubOwner')
+        {
+            continue
+        }
+
+        if ($null -ne $paramValue -and -not $invokePlasterParam.ContainsKey($paramName))
         {
             $invokePlasterParam.Add($paramName, $paramValue)
+        }
+    }
+
+    <#
+        Route GitHubOwner to the correct Plaster parameter depending on ModuleType.
+        dsccommunity uses GitHubOwnerDscCommunity; all other types use GitHubOwner.
+        Remove the generic key if it was added by the loop above, then add the
+        correct Plaster key so the caller only needs to think about one parameter.
+    #>
+    if ($PSBoundParameters.ContainsKey('GitHubOwner'))
+    {
+        $invokePlasterParam.Remove('GitHubOwner')
+
+        if ($ModuleType -eq 'dsccommunity')
+        {
+            $invokePlasterParam['GitHubOwnerDscCommunity'] = $GitHubOwner
+        }
+        else
+        {
+            $invokePlasterParam['GitHubOwner'] = $GitHubOwner
         }
     }
 

--- a/Sampler/Public/New-SampleModule.ps1
+++ b/Sampler/Public/New-SampleModule.ps1
@@ -187,8 +187,8 @@ function New-SampleModule
 
         <#
             Skip parameters that are $null (not set) and not explicitly bound.
-            Use $null -ne check so that empty strings and $false are still forwarded —
-            they are valid values that suppress Plaster prompts (e.g. ModuleDescription='').
+            Use $null -ne check so that empty strings and $false are still forwarded -
+            they are valid values that suppress Plaster prompts (e.g. ModuleDescription = '').
             Do not forward parameters already in the hashtable (e.g. ModuleName added above).
             GitHubOwner is handled separately below after the loop; skip it here.
         #>

--- a/Sampler/Templates/Build/build.yaml.template
+++ b/Sampler/Templates/Build/build.yaml.template
@@ -351,6 +351,23 @@ GitHubConfig:
     }
 %>
 
+####################################################
+#             Git Configuration                    #
+####################################################
+GitConfig:
+  # UserName: dscbot
+  # UserEmail: dsccommunity@outlook.com
+  MainGitBranch: <%= ${PLASTER_PARAM_MainGitBranch} %>
+
+####################################################
+#          Changelog Configuration                 #
+####################################################
+# Used by Create_Changelog_Branch task. Defaults are shown below.
+# ChangelogConfig:
+#   FilesToAdd:
+#     - 'CHANGELOG.md'
+#   UpdateChangelogOnPrerelease: false  # Set to true to update changelog on pre-releases too
+
 <%
     if ($PLASTER_PARAM_ModuleType -eq 'dsccommunity' -or $PLASTER_PARAM_Features -Contains ("All")) {
 @"

--- a/Sampler/WikiSource/Getting-started.md
+++ b/Sampler/WikiSource/Getting-started.md
@@ -1880,11 +1880,10 @@ ChangelogConfig:
 GitConfig:
   UserName: bot
   UserEmail: bot@company.local
+  MainGitBranch: main
 ```
 
 #### Section ChangelogConfig
-
-##### Property FilesToAdd
 
 This specifies one or more files to add to the commit when creating the
 PR branch. If left out it will default to the one file _CHANGELOG.md_.
@@ -1906,6 +1905,12 @@ User name of the user that should push the tag.
 ##### Property UserEmail
 
 E-mail address of the user that should push the tag.
+
+##### Property MainGitBranch
+
+The name of the default branch. If not set here or as a task parameter, defaults
+to `'main'`. Set this when your repository uses a different default branch name
+(e.g. `master` or `develop`).
 
 ### `Create_Release_Git_Tag`
 
@@ -1940,6 +1945,7 @@ of the build task.
 GitConfig:
   UserName: bot
   UserEmail: bot@company.local
+  MainGitBranch: main
 ```
 
 #### Section GitConfig
@@ -1954,6 +1960,12 @@ User name of the user that should push the tag.
 ##### Property UserEmail
 
 E-mail address of the user that should push the tag.
+
+##### Property MainGitBranch
+
+The name of the default branch. If not set here or as a task parameter, defaults
+to `'main'`. Set this when your repository uses a different default branch name
+(e.g. `master` or `develop`).
 
 ### `Set_PSModulePath`
 
@@ -2025,6 +2037,30 @@ Sets the module path to what is defined for the machine. The machines `PSModuleP
 
 ```powershell
 [System.Environment]::GetEnvironmentVariable('PSModulePath', 'Machine')
+```
+
+### `Clean`
+
+This task deletes the content of the build output folder to ensure a clean
+build. By default it preserves the `RequiredModules` subfolder (to avoid
+re-downloading all dependencies on every build).
+
+It also preserves a dedicated subfolder for agent/Copilot log files so that
+build logs survive clean cycles.
+
+#### Task parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `OutputDirectory` | `output` | The root output directory to clean. |
+| `RequiredModulesDirectory` | `output/RequiredModules` | Always excluded from deletion. |
+| `AgentOutputSubdirectory` | `agentic` | Subfolder excluded from deletion for use as a stable log destination. Set to empty string to disable. |
+
+#### Task configuration
+
+```yaml
+# Override the agent log subfolder name (or disable with empty string)
+AgentOutputSubdirectory: agentic
 ```
 
 ### `Link_Local_Workspace_Dependencies`

--- a/tests/Unit/Public/New-SampleModule.tests.ps1
+++ b/tests/Unit/Public/New-SampleModule.tests.ps1
@@ -194,4 +194,87 @@ Describe New-SampleModule {
             }
         }
     }
+
+    Context 'When ModuleDescription is an empty string' {
+        It 'Should forward ModuleDescription to Plaster so no interactive prompt is shown' {
+            InModuleScope -Parameters @{ DestinationPath = $TestDrive } -ScriptBlock {
+                $script:capturedPlasterParameters = $null
+
+                $newSampleModuleParameters = @{
+                    DestinationPath   = $DestinationPath
+                    ModuleName        = 'testMod'
+                    ModuleDescription = ''
+                    ModuleType        = 'SimpleModule'
+                }
+
+                { New-SampleModule @newSampleModuleParameters } | Should -Not -Throw
+
+                $script:capturedPlasterParameters.ContainsKey('ModuleDescription') | Should -BeTrue
+                $script:capturedPlasterParameters['ModuleDescription'] | Should -Be ''
+            }
+        }
+    }
+
+    Context 'When GitHubOwner is explicitly supplied for a non-dsccommunity module' {
+        It 'Should forward GitHubOwner as the GitHubOwner Plaster parameter' {
+            InModuleScope -Parameters @{ DestinationPath = $TestDrive } -ScriptBlock {
+                $script:capturedPlasterParameters = $null
+
+                $newSampleModuleParameters = @{
+                    DestinationPath   = $DestinationPath
+                    ModuleName        = 'testMod'
+                    ModuleDescription = 'my module'
+                    ModuleType        = 'CustomModule'
+                    Features          = @('github')
+                    GitHubOwner       = 'MyOrg'
+                }
+
+                { New-SampleModule @newSampleModuleParameters } | Should -Not -Throw
+
+                $script:capturedPlasterParameters['GitHubOwner'] | Should -Be 'MyOrg'
+                $script:capturedPlasterParameters.ContainsKey('GitHubOwnerDscCommunity') | Should -BeFalse
+            }
+        }
+    }
+
+    Context 'When GitHubOwner is explicitly supplied for a dsccommunity module' {
+        It 'Should forward GitHubOwner as the GitHubOwnerDscCommunity Plaster parameter' {
+            InModuleScope -Parameters @{ DestinationPath = $TestDrive } -ScriptBlock {
+                $script:capturedPlasterParameters = $null
+
+                $newSampleModuleParameters = @{
+                    DestinationPath   = $DestinationPath
+                    ModuleName        = 'testMod'
+                    ModuleDescription = 'my module'
+                    ModuleType        = 'dsccommunity'
+                    GitHubOwner       = 'myorg'
+                }
+
+                { New-SampleModule @newSampleModuleParameters } | Should -Not -Throw
+
+                $script:capturedPlasterParameters['GitHubOwnerDscCommunity'] | Should -Be 'myorg'
+                $script:capturedPlasterParameters.ContainsKey('GitHubOwner') | Should -BeFalse
+            }
+        }
+    }
+
+    Context 'When GitHubOwner is not supplied' {
+        It 'Should not forward GitHubOwner or GitHubOwnerDscCommunity to Plaster' {
+            InModuleScope -Parameters @{ DestinationPath = $TestDrive } -ScriptBlock {
+                $script:capturedPlasterParameters = $null
+
+                $newSampleModuleParameters = @{
+                    DestinationPath   = $DestinationPath
+                    ModuleName        = 'testMod'
+                    ModuleDescription = 'my module'
+                    ModuleType        = 'SimpleModule'
+                }
+
+                { New-SampleModule @newSampleModuleParameters } | Should -Not -Throw
+
+                $script:capturedPlasterParameters.ContainsKey('GitHubOwner') | Should -BeFalse
+                $script:capturedPlasterParameters.ContainsKey('GitHubOwnerDscCommunity') | Should -BeFalse
+            }
+        }
+    }
 }

--- a/tests/Unit/tasks/Create_Changelog_Branch.build.Tests.ps1
+++ b/tests/Unit/tasks/Create_Changelog_Branch.build.Tests.ps1
@@ -146,4 +146,42 @@ Describe 'Create_Changelog_Branch' {
             }
         }
     }
+
+    Context 'When GitConfigUserName and GitConfigUserEmail are not set' {
+        BeforeAll {
+            # Dot-source mocks
+            . $PSScriptRoot/../TestHelpers/MockSetSamplerTaskVariable
+
+            Mock -CommandName Sampler\Invoke-SamplerGit
+
+            Mock -CommandName Sampler\Invoke-SamplerGit -ParameterFilter {
+                $Argument -contains 'rev-parse'
+            } -MockWith {
+                return '0c23efc'
+            }
+
+            $mockTaskParameters = @{
+                ProjectPath        = Join-Path -Path $TestDrive -ChildPath 'MyModule'
+                OutputDirectory    = Join-Path -Path $TestDrive -ChildPath 'MyModule/output'
+                SourcePath         = Join-Path -Path $TestDrive -ChildPath 'MyModule/source'
+                ProjectName        = 'MyModule'
+                BasicAuthPAT       = '22222'
+                GitConfigUserName  = ''
+                GitConfigUserEmail = ''
+                MainGitBranch      = 'main'
+                ChangelogPath      = 'CHANGELOG.md'
+                BuildInfo          = @{}
+            }
+        }
+
+        It 'Should run the build task without throwing and not call git config user.name or user.email' {
+            {
+                Invoke-Build -Task $buildTaskName -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Not -Invoke -CommandName Sampler\Invoke-SamplerGit -Scope It -ParameterFilter {
+                $Argument -contains 'user.name' -or $Argument -contains 'user.email'
+            }
+        }
+    }
 }

--- a/tests/Unit/tasks/Create_Release_Git_Tag.build.Tests.ps1
+++ b/tests/Unit/tasks/Create_Release_Git_Tag.build.Tests.ps1
@@ -191,4 +191,54 @@ Describe 'Create_Release_Git_Tag' {
             }
         }
     }
+
+    Context 'When GitConfigUserName and GitConfigUserEmail are not set' {
+        BeforeAll {
+            # Dot-source mocks
+            . $PSScriptRoot/../TestHelpers/MockSetSamplerTaskVariable
+
+            function script:git
+            {
+                throw '{0}: StubNotImplemented' -f $MyInvocation.MyCommand
+            }
+
+            Mock -CommandName git
+
+            Mock -CommandName Sampler\Invoke-SamplerGit
+
+            Mock -CommandName Sampler\Invoke-SamplerGit -ParameterFilter {
+                $Argument -contains 'rev-parse'
+            } -MockWith {
+                return '0c23efc'
+            }
+
+            Mock -CommandName Start-Sleep
+
+            $mockTaskParameters = @{
+                ProjectPath        = Join-Path -Path $TestDrive -ChildPath 'MyModule'
+                OutputDirectory    = Join-Path -Path $TestDrive -ChildPath 'MyModule/output'
+                SourcePath         = Join-Path -Path $TestDrive -ChildPath 'MyModule/source'
+                ProjectName        = 'MyModule'
+                BasicAuthPAT       = '22222'
+                GitConfigUserName  = ''
+                GitConfigUserEmail = ''
+                MainGitBranch      = 'main'
+                BuildInfo          = @{}
+            }
+        }
+
+        AfterAll {
+            Remove-Item 'function:git'
+        }
+
+        It 'Should run the build task without throwing and not call git config user.name or user.email' {
+            {
+                Invoke-Build -Task $buildTaskName -File $taskAlias.Definition @mockTaskParameters
+            } | Should -Not -Throw
+
+            Should -Not -Invoke -CommandName Sampler\Invoke-SamplerGit -Scope It -ParameterFilter {
+                $Argument -contains 'user.name' -or $Argument -contains 'user.email'
+            }
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the build pipeline, module scaffolding, and documentation. The most important changes include making git identity configuration conditional, enhancing the `New-SampleModule` scaffolding command to better handle parameters and GitHub ownership, updating templates and documentation for better clarity and automation, and adding comprehensive tests to cover the new behaviors.

**Build Pipeline Improvements:**
- The `Create_Release_Git_Tag` and `Create_Changelog_Branch` tasks now only set `git config user.name` and `git config user.email` if the corresponding values are provided, preventing accidental overwrites of global git configuration with empty values. [[1]](diffhunk://#diff-211b4c9d07ddf8d1efe0ea09ae86b2ccecbd6e026a7c99fdcaea2e09bf3a670dR167-R176) [[2]](diffhunk://#diff-97ccaacce031f2fba06fe2352c3389a09ee61fff3f4c634d595732e5436552f1R167-R175) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL19-R22) [[4]](diffhunk://#diff-3f1fc09f8337549d8182fedc7501b7ea56b1db66597df98aaad77f6599e0a617R149-R186) [[5]](diffhunk://#diff-692f53ab37c371f5269b21b6cc34a52bd7d9c22ec3bbbd3bbfcea36ad5165384R194-R243)

**Module Scaffolding Enhancements:**
- `New-SampleModule` now accepts a `-GitHubOwner` parameter, which is routed to the appropriate Plaster template parameter (`GitHubOwner` or `GitHubOwnerDscCommunity`) based on the module type, allowing non-interactive scaffolding for all module types. [[1]](diffhunk://#diff-31f5e344c51b6fcfa92ceeacacac641ae20c2a5d8d1c3e4e931cfa6d680d0d08R52-R57) [[2]](diffhunk://#diff-31f5e344c51b6fcfa92ceeacacac641ae20c2a5d8d1c3e4e931cfa6d680d0d08R131-R134) [[3]](diffhunk://#diff-31f5e344c51b6fcfa92ceeacacac641ae20c2a5d8d1c3e4e931cfa6d680d0d08L178-R225) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL19-R22) [[5]](diffhunk://#diff-bee723d5a5f7fc03d9fd9571f72770f13a0c4b8b412375f391ad0b5b7536194dR197-R279)
- Empty-string parameter values (such as `ModuleDescription = ''`) are now forwarded to Plaster, avoiding unexpected interactive prompts and ensuring all user input is respected. [[1]](diffhunk://#diff-31f5e344c51b6fcfa92ceeacacac641ae20c2a5d8d1c3e4e931cfa6d680d0d08L178-R225) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL19-R22) [[3]](diffhunk://#diff-bee723d5a5f7fc03d9fd9571f72770f13a0c4b8b412375f391ad0b5b7536194dR197-R279)

**Templates and Documentation:**
- The `build.yaml.template` now scaffolds a `GitConfig` section with `MainGitBranch` pre-populated and commented-out examples for `UserName` and `UserEmail`, improving the default configuration for new modules. [[1]](diffhunk://#diff-6fe78bfed74fb07fc7ac4bec1bf8dc28fe9fcf0920f17e10d2b4d4a6fbb43cdaR354-R370) [[2]](diffhunk://#diff-aecd9bb3b3e8566c501f3a8a8a648c9900899227926ca8d6550cd1ccc48ccf7eR1883-L1888) [[3]](diffhunk://#diff-aecd9bb3b3e8566c501f3a8a8a648c9900899227926ca8d6550cd1ccc48ccf7eR1909-R1914) [[4]](diffhunk://#diff-aecd9bb3b3e8566c501f3a8a8a648c9900899227926ca8d6550cd1ccc48ccf7eR1948) [[5]](diffhunk://#diff-aecd9bb3b3e8566c501f3a8a8a648c9900899227926ca8d6550cd1ccc48ccf7eR1964-R1969)
- The `CONTRIBUTING.md` file now documents the requirement for ASCII-only `CHANGELOG.md` entries to avoid module manifest parsing issues on Windows PowerShell 5.1.
- The documentation for the `Clean` build task and changelog configuration has been expanded for clarity.

**Testing:**
- New unit tests verify that git identity configuration is only set when values are provided and that `New-SampleModule` correctly handles empty strings and the `GitHubOwner` parameter for all module types. [[1]](diffhunk://#diff-bee723d5a5f7fc03d9fd9571f72770f13a0c4b8b412375f391ad0b5b7536194dR197-R279) [[2]](diffhunk://#diff-3f1fc09f8337549d8182fedc7501b7ea56b1db66597df98aaad77f6599e0a617R149-R186) [[3]](diffhunk://#diff-692f53ab37c371f5269b21b6cc34a52bd7d9c22ec3bbbd3bbfcea36ad5165384R194-R243)

**Changelog Updates:**
- The changelog has been updated to reflect all the above user-visible changes, including improvements to parameter handling, scaffolding, and documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/581)
<!-- Reviewable:end -->
