### PR TITLE
Add GitHub Copilot instructions and validation skill templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `Copilot` Plaster template under `Sampler/Templates/Copilot/` that scaffolds GitHub Copilot instruction files and a `validate-changes` skill into any Sampler-based module. Available via `Add-Sample -Sample Copilot` and as a `copilot` feature option in `New-SampleModule` (CustomModule and CompleteSample).
 - New `Link_Local_Workspace_Dependencies` build task and supporting public functions (`Get-SamplerWorkspaceLinkedModuleRoot`, `Get-SamplerWorkspaceBuiltModulePath`, `New-SamplerWorkspaceModuleLink`) for linking sibling workspace module build outputs into the local module output path when working across related repos in a multi-repo workspace. Configure via `WorkspaceModules` in `build.yaml`.
 - `Clean` task now preserves `output\agentic\` across builds (in addition to `RequiredModules`), providing a stable location for build and test log files that survive clean cycles. The subfolder name is configurable via the `AgentOutputSubdirectory` parameter (default `'agentic'`; set to empty string to disable the exclusion).
 - `package_psresource_nupkg` tasks that recursively packs dependencies, ignoring `ExternalDependencies` using `PSResourceGet` module.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ maintaining infrastructure.
 - **Build, test, pack & publish**: A curated set of InvokeBuild tasks
   covers the full lifecycle from source to the PowerShell Gallery.
 - **Rich templates**: Add classes, MOF-based DSC resources, class-based
-  DSC resources, helper modules, composite resources, and more with a
-  single command.
+  DSC resources, helper modules, composite resources, GitHub Copilot
+  instruction files, and more with a single command.
 - **Reproducible everywhere**: The same build runs on a developer
   workstation, behind a corporate firewall, or in a CI agent — no
   local-admin rights or pre-installed tooling required.

--- a/Sampler/Public/Add-Sample.ps1
+++ b/Sampler/Public/Add-Sample.ps1
@@ -14,6 +14,7 @@
             - Classes: A sample of 4 classes with inheritence and how to manage the orders to avoid parsing errors.
             - ClassResource: A Class-Based DSC Resources showing some best practices including tests, Reasons, localized strings.
             - Composite: A DSC Composite Resource (a configuration block) packaged the right way to make sure it's visible by Get-DscResource.
+            - Copilot: Scaffolds GitHub Copilot instruction files under .github/ for the current module project.
             - Enum: An example of a simple Enum.
             - MofResource: A sample of a MOF-Based DSC Resource following the DSC Community practices.
             - PrivateFunction: A sample of a Private function (not exported from the module) and its test.
@@ -49,6 +50,7 @@ function Add-Sample
             'ClassFolderResource',
             'ClassResource',
             'Composite',
+            'Copilot',
             'Enum',
             'Examples',
             'GithubConfig',

--- a/Sampler/Public/New-SampleModule.ps1
+++ b/Sampler/Public/New-SampleModule.ps1
@@ -59,7 +59,7 @@
         If you'd rather select specific features from this template to build your module, use this parameter instead.
         Valid values mirror the Plaster template feature choices:
             All, Enum, Classes, DSCResources, ClassDSCResource, SampleScripts,
-            git, gitversion, github, vscode, codecov, azurepipelines,
+            git, gitversion, github, vscode, codecov, azurepipelines, copilot,
             Gherkin, UnitTests, ModuleQuality, Build, AppVeyor, TestKitchen.
 
     .EXAMPLE
@@ -146,6 +146,7 @@ function New-SampleModule
             'vscode',
             'codecov',
             'azurepipelines',
+            'copilot',
             'Gherkin',
             'UnitTests',
             'ModuleQuality',

--- a/Sampler/Templates/Copilot/copilot-instructions.md.template
+++ b/Sampler/Templates/Copilot/copilot-instructions.md.template
@@ -1,0 +1,65 @@
+# GitHub Copilot Instructions for <%= $PLASTER_PARAM_ModuleName %>
+
+## Build and test
+
+- Use `./build.ps1` as the only entry point for all build, test, and environment setup operations.
+- Never invoke `Build-Module`, `Invoke-Pester`, or `Invoke-Build` directly.
+- Never manually prepend anything to `PSModulePath`.
+- Standard commands:
+  - Bootstrap dependencies: `./build.ps1 -ResolveDependency -Tasks noop`
+  - Build: `./build.ps1 -Tasks build`
+  - Focused test: `./build.ps1 -Tasks test -PesterPath 'tests/Unit/Public/MyFunction.Tests.ps1' -CodeCoverageThreshold 0`
+  - Full test suite: `./build.ps1 -Tasks test`
+  - Quality gate: `./build.ps1 -Tasks hqrmtest`
+
+## Git workflow
+
+- Never commit, push, tag, or publish on behalf of the user.
+- Leave all Git operations to the user.
+
+## Repository structure
+
+- Module name: `<%= $PLASTER_PARAM_ModuleName %>`
+- Source folder: `<%= $PLASTER_PARAM_SourceDirectory %>/`
+- Do not edit the root module `.psm1` directly; it is generated from source files during build.
+- Public functions live under `<%= $PLASTER_PARAM_SourceDirectory %>/Public/`.
+- Private functions live under `<%= $PLASTER_PARAM_SourceDirectory %>/Private/`.
+
+## Instruction files
+
+Read the per-area instruction files before making changes in the relevant area:
+
+- `.github/instructions/public-functions.instructions.md` - public function authoring rules
+- `.github/instructions/private-functions.instructions.md` - private function authoring rules
+- `.github/instructions/test-writing.instructions.md` - Pester test conventions
+- `.github/instructions/build-tasks.instructions.md` - InvokeBuild task authoring rules
+
+## Changelog policy
+
+- Update `CHANGELOG.md` only for module behavior changes that are visible to users.
+- Do not add changelog entries for CI, pipeline, or tooling-only changes.
+- Use the `## [Unreleased]` section for new entries.
+- Use ASCII-only characters in `CHANGELOG.md` (no em-dashes, smart quotes, or Unicode arrows).
+
+## PowerShell style
+
+- Use `$null = <expression>` not `<expression> | Out-Null` to suppress output.
+- Prefer splatting over backtick-based line continuation for multi-line calls.
+- Use ASCII-only characters in `.ps1` source files.
+- Follow DSC Community parameter style: `[Parameter()]` attribute, type, and variable name each on their own line with a blank line between parameter declarations.
+- Use explicit .NET types (`[System.String]`, `[System.Boolean]`, etc.).
+- Use `[CmdletBinding()]` and `[OutputType(...)]` on all functions.
+- Build multi-level paths with chained `Join-Path` calls; never use hardcoded backslash separators inside `Join-Path -ChildPath` strings.
+
+## Long-running commands
+
+- Always tee `./build.ps1` output to `output\agentic\` so logs survive between builds:
+
+```powershell
+$null = New-Item -Path 'output\agentic' -ItemType Directory -Force
+
+./build.ps1 -Tasks test -PesterPath '<paths>' -CodeCoverageThreshold 0 2>&1 |
+    Tee-Object -FilePath 'output\agentic\test.log'
+```
+
+- Poll the log with `Get-Content output\agentic\test.log -Tail 20` rather than re-running the build.

--- a/Sampler/Templates/Copilot/instructions/ai-instruction-authoring.instructions.md
+++ b/Sampler/Templates/Copilot/instructions/ai-instruction-authoring.instructions.md
@@ -1,0 +1,23 @@
+---
+applyTo: "{.github/instructions/*.md,.github/prompts/*.md,.github/skills/*.md,**/AGENTS.md,.github/copilot-instructions.md}"
+---
+
+# AI Instruction Authoring
+
+These files are AI-only. No human-facing prose, tutorials, or rationale. Meant to
+reduce token usage, eliminate conflicting information and ensure precise, clear,
+concise guidance.
+
+## Rules
+
+- Write short imperative directives. Bullet lists over prose.
+- Remove filler words, redundant qualifiers, repeated context.
+- Omit *why* unless the reason changes behaviour.
+- Check existing instructions before adding rules. Update existing rules on conflict; never duplicate.
+- Use narrowest `applyTo` glob possible. Never `**/*` when a specific
+  path suffices. `ApplyTo` attribute must be a string, never an array.
+- Start each file, except copilot-instructions.md and **/AGENTS.md, with YAML
+  frontmatter `applyTo`
+- Use `##`/`###` headings, `-` bullets, backticks for code tokens, fenced blocks for multi-line examples.
+- No bold/italic emphasis, conversational tone, or verbose examples.
+- Prefer using ASCII characters in most authored files (instructions, prompts, skills, AGENTS.md, copilot-instructions.md). Non-ASCII characters (em-dashes, smart quotes, Unicode arrows, etc.) in PowerShell source files trigger PSScriptAnalyzer rule `PSUseBOMForUnicodeEncodedFile` and in CHANGELOG.md they break `Import-PowerShellDataFile` on Windows PowerShell 5.1. Use plain ASCII: `->` not `->`, `-` not `--`, straight quotes, hyphens instead of dashes.

--- a/Sampler/Templates/Copilot/instructions/build-task-files.instructions.md
+++ b/Sampler/Templates/Copilot/instructions/build-task-files.instructions.md
@@ -1,0 +1,80 @@
+---
+description: 'Custom build task authoring instructions'
+applyTo: '{.build/tasks/*.build.ps1,.build/tasks/*.build.psm1}'
+---
+
+# Build Task Development Guidelines
+
+## File layout
+
+- Keep custom build task files under `.build/tasks/`.
+- Name task files `<Purpose>.<Subsystem>.build.ps1`.
+- Put helper functions used by a custom task in a sibling `.build.psm1` file next to the task file.
+- Keep the `.build.ps1` file focused on task parameters, task definitions, and task-scoped logging.
+- Keep helper modules free of task-scoped UI concerns such as `Write-Build`.
+
+## Parameter block
+
+- Start every `.build.ps1` task file with a `param` block.
+- Use InvokeBuild `property` defaults for task parameters.
+- Always include `$BuildInfo = (property BuildInfo @{ })`.
+- Use fully qualified .NET types such as `[System.String]` and `[System.Management.Automation.SwitchParameter]`.
+- Do not hard-code output, source, or manifest paths in task parameters.
+
+```powershell
+param
+(
+    [Parameter()]
+    [System.String]
+    $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot 'output')),
+
+    [Parameter()]
+    [System.Collections.Hashtable]
+    $BuildInfo = (property BuildInfo @{ })
+)
+```
+
+## Shared task variables
+
+- At the start of each task body, dot-source `Set-SamplerTaskVariable`.
+- Add the standard Sampler comment before dot-sourcing task variables.
+- Use `-AsNewBuild` only for tasks that start a new build context.
+- Use `-ArtifactContext` only when the task is building or packaging a non-default artifact from the same source tree.
+- Do not re-derive `$ProjectName`, `$SourcePath`, `$ModuleVersion`, `$BuiltModuleManifest`, or related build context inside custom tasks.
+
+```powershell
+task My_Task {
+    # Get the values for task variables, see https://github.com/gaelcolas/Sampler?tab=readme-ov-file#build-task-variables.
+    . Set-SamplerTaskVariable
+}
+```
+
+## Task definitions
+
+- Prefix each task body with a `# Synopsis:` comment.
+- Use compound tasks without a body when a task only sequences other tasks.
+- Treat compound tasks as the stable public surface for local workflows.
+- Use `Write-Build -Color <Color> -Text <message>` for task output.
+- Use `Green` for success, `Yellow` for warnings, and `DarkGray` for verbose detail.
+- Keep `Write-Build` calls in the task file, not in helper modules.
+
+```powershell
+# Synopsis: Run local workspace dependency linking.
+task Link_Local_Workspace_Dependencies {
+    # Get the values for task variables, see https://github.com/gaelcolas/Sampler?tab=readme-ov-file#build-task-variables.
+    . Set-SamplerTaskVariable
+}
+```
+
+## Paths and build context
+
+- Resolve task-facing paths with `Get-SamplerAbsolutePath` when the path can come from `build.yaml` or task parameters.
+- Use Sampler task variables and built-manifest discovery instead of hard-coded `output\...` assumptions.
+- Fail fast when a task requires built module output and that output is missing.
+- Keep source kind and artifact kind separate; do not infer artifact context by probing folders.
+
+## Helper modules
+
+- Export helper functions explicitly from the sibling `.build.psm1`.
+- Keep helper functions reusable and free of task orchestration logic.
+- Return state to the task file when the task needs to decide how to log or sequence work.

--- a/Sampler/Templates/Copilot/instructions/build-tasks.instructions.md
+++ b/Sampler/Templates/Copilot/instructions/build-tasks.instructions.md
@@ -1,85 +1,30 @@
 ---
-description: 'Build task authoring instructions'
-applyTo: '.build/tasks/*.build.ps1'
+description: "Build and workflow authoring instructions"
+applyTo: "{build.ps1,build.yaml,.build/*.ps1,.github/workflows/*.yml,.github/workflows/*.yaml}"
 ---
 
-# Build Task Development Guidelines
+# Build and Workflow Development Guidelines
 
-## File naming and location
+## Entry points
 
-- All build task files live under `.build/tasks/` and follow the pattern `<Purpose>.<Subsystem>.build.ps1` (e.g., `Invoke-Pester.pester.build.ps1`, `Build-Module.ModuleBuilder.build.ps1`).
-- The file naming determines the alias that `suffix.ps1` auto-registers for InvokeBuild: `<BaseName>.Sampler.ib.tasks`. Do not register aliases manually inside task files.
-- Task files in `.build/tasks/` are copied into the built module (`output/module/Sampler/<version>/tasks/`) via the `CopyPaths` entry in `build.yaml`. If you add a new task file, add any required module imports or workflow entries to `build.yaml` -- not to `build.ps1`.
-- Put helper functions used by a task in a sibling `.psm1` file next to the task file (e.g., `MyTasks.build.psm1` alongside `MyTasks.build.ps1`). Keep the `.build.ps1` focused on task parameters, task definitions, and task-scoped logging; keep helper modules free of task-scoped UI concerns such as `Write-Build`.
+- Use `build.ps1` as the only bootstrap, build, and test entrypoint.
+- Keep `build.ps1` focused on bootstrap and runtime parameters.
+- Prefer changing `build.yaml` when altering workflow composition, copied assets, default test paths, code coverage behavior, or publish workflow ordering.
 
-## Parameter block
+## Dependency and artifact rules
 
-Every task file must open with a `param` block that declares all variables the tasks consume. Use InvokeBuild's `property` helper to set defaults -- never hard-code paths:
+- Restore dependencies with `./build.ps1 -ResolveDependency -Tasks noop`.
+- Do not manually edit `PSModulePath`; let `build.ps1` manage it.
+- Keep required modules resolving into `output\RequiredModules`.
+- Treat `output\module` as the validation target and disposable build output.
+- Keep `CopyPaths` in `build.yaml` aligned with the shipped runtime assets under `source\`.
 
-```powershell
-param
-(
-    [Parameter()]
-    [System.String]
-    $ProjectName = (property ProjectName ''),
+## Custom task rules
 
-    [Parameter()]
-    [System.String]
-    $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot 'output')),
+- See `build-task-files.instructions.md` for `.build/tasks/*.build.ps1` authoring rules (parameters, `Set-SamplerTaskVariable`, task definitions).
+- Keep PowerShell Universal publish logic aligned with the built package path and `BuildInfo.UniversalServer` settings rather than re-deriving that state elsewhere.
 
-    [Parameter()]
-    [System.Collections.Hashtable]
-    $BuildInfo = (property BuildInfo @{ })
-)
-```
+## Validation
 
-- Always include `$BuildInfo` as a `[System.Collections.Hashtable]` parameter -- tasks read per-workflow configuration from it.
-- Use fully-qualified .NET types (e.g., `[System.String]`, `[System.Management.Automation.SwitchParameter]`) for all parameters.
-
-## Shared task variables
-
-At the start of every task body, dot-source `Set-SamplerTaskVariable` to populate the standard shared variables (`$ProjectName`, `$SourcePath`, `$BuildModuleOutput`, `$ModuleVersion`, etc.):
-
-```powershell
-task My_Task {
-    # Get the values for task variables, see https://github.com/gaelcolas/Sampler?tab=readme-ov-file#build-task-variables.
-    . Set-SamplerTaskVariable
-
-    # ... task body
-}
-```
-
-Use `-AsNewBuild` only for tasks that represent the start of a new build (e.g., tasks that derive the version fresh):
-
-```powershell
-    . Set-SamplerTaskVariable -AsNewBuild
-```
-
-- Use `-ArtifactContext` when the task is producing or packaging a non-default artifact from the same source tree:
-
-```powershell
-    . Set-SamplerTaskVariable -AsNewBuild -ArtifactContext 'Chocolatey'
-```
-
-- Treat source kind and artifact kind as separate concepts. A repository can be a PowerShell module source and still package a Chocolatey artifact; do not infer Chocolatey packaging by probing output folders.
-- For module-source tasks that do not use `-AsNewBuild`, `Set-SamplerTaskVariable` is expected to read version and paths from the built module output and fail fast if that output is missing.
-- For non-module sources, version resolution falls back in this order: `ModuleVersion`/`SemVer` -> `GitVersion` -> static version `0.0.1`.
-**Never re-derive** `$ProjectName`, `$SourcePath`, or version information independently inside a task. Always rely on `Set-SamplerTaskVariable`.
-
-## Task definitions
-
-- Prefix every task definition with a `# Synopsis:` comment -- InvokeBuild surfaces this as the task description:
-  ```powershell
-  # Synopsis: Build the module output using ModuleBuilder.
-  task Build_ModuleOutput_ModuleBuilder {
-      . Set-SamplerTaskVariable -AsNewBuild
-      # ...
-  }
-  ```
-- Compound tasks (tasks that only sequence other tasks) do not need a body -- list dependencies inline:
-  ```powershell
-  task Build_Module_ModuleBuilder Build_ModuleOutput_ModuleBuilder, Build_DscResourcesToExport_ModuleBuilder
-  ```
-- Prefer exposing workflows through compound tasks instead of having downstream projects call low-level implementation tasks directly. Treat compound tasks as the stable public surface so internal task composition can change in Sampler without requiring updates in projects that consume it.
-- Use `Write-Build -Color <Color> -Text <message>` for task output, not `Write-Host`. Prefer `Green` for success, `Yellow` for warnings, `DarkGray` for verbose detail.
-- Resolve all paths through `Get-SamplerAbsolutePath -Path <path> -RelativeTo $BuildRoot` (or `$OutputDirectory`) rather than with `Join-Path` alone, so relative paths in `build.yaml` resolve correctly.
+- Treat changes to `build.ps1`, `build.yaml`, `.build\`, or workflow files as validation-impacting changes.
+- Run at least `./build.ps1 -Tasks test` after workflow wiring changes.

--- a/Sampler/Templates/Copilot/instructions/build-tasks.instructions.md
+++ b/Sampler/Templates/Copilot/instructions/build-tasks.instructions.md
@@ -1,0 +1,85 @@
+---
+description: 'Build task authoring instructions'
+applyTo: '.build/tasks/*.build.ps1'
+---
+
+# Build Task Development Guidelines
+
+## File naming and location
+
+- All build task files live under `.build/tasks/` and follow the pattern `<Purpose>.<Subsystem>.build.ps1` (e.g., `Invoke-Pester.pester.build.ps1`, `Build-Module.ModuleBuilder.build.ps1`).
+- The file naming determines the alias that `suffix.ps1` auto-registers for InvokeBuild: `<BaseName>.Sampler.ib.tasks`. Do not register aliases manually inside task files.
+- Task files in `.build/tasks/` are copied into the built module (`output/module/Sampler/<version>/tasks/`) via the `CopyPaths` entry in `build.yaml`. If you add a new task file, add any required module imports or workflow entries to `build.yaml` -- not to `build.ps1`.
+- Put helper functions used by a task in a sibling `.psm1` file next to the task file (e.g., `MyTasks.build.psm1` alongside `MyTasks.build.ps1`). Keep the `.build.ps1` focused on task parameters, task definitions, and task-scoped logging; keep helper modules free of task-scoped UI concerns such as `Write-Build`.
+
+## Parameter block
+
+Every task file must open with a `param` block that declares all variables the tasks consume. Use InvokeBuild's `property` helper to set defaults -- never hard-code paths:
+
+```powershell
+param
+(
+    [Parameter()]
+    [System.String]
+    $ProjectName = (property ProjectName ''),
+
+    [Parameter()]
+    [System.String]
+    $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot 'output')),
+
+    [Parameter()]
+    [System.Collections.Hashtable]
+    $BuildInfo = (property BuildInfo @{ })
+)
+```
+
+- Always include `$BuildInfo` as a `[System.Collections.Hashtable]` parameter -- tasks read per-workflow configuration from it.
+- Use fully-qualified .NET types (e.g., `[System.String]`, `[System.Management.Automation.SwitchParameter]`) for all parameters.
+
+## Shared task variables
+
+At the start of every task body, dot-source `Set-SamplerTaskVariable` to populate the standard shared variables (`$ProjectName`, `$SourcePath`, `$BuildModuleOutput`, `$ModuleVersion`, etc.):
+
+```powershell
+task My_Task {
+    # Get the values for task variables, see https://github.com/gaelcolas/Sampler?tab=readme-ov-file#build-task-variables.
+    . Set-SamplerTaskVariable
+
+    # ... task body
+}
+```
+
+Use `-AsNewBuild` only for tasks that represent the start of a new build (e.g., tasks that derive the version fresh):
+
+```powershell
+    . Set-SamplerTaskVariable -AsNewBuild
+```
+
+- Use `-ArtifactContext` when the task is producing or packaging a non-default artifact from the same source tree:
+
+```powershell
+    . Set-SamplerTaskVariable -AsNewBuild -ArtifactContext 'Chocolatey'
+```
+
+- Treat source kind and artifact kind as separate concepts. A repository can be a PowerShell module source and still package a Chocolatey artifact; do not infer Chocolatey packaging by probing output folders.
+- For module-source tasks that do not use `-AsNewBuild`, `Set-SamplerTaskVariable` is expected to read version and paths from the built module output and fail fast if that output is missing.
+- For non-module sources, version resolution falls back in this order: `ModuleVersion`/`SemVer` -> `GitVersion` -> static version `0.0.1`.
+**Never re-derive** `$ProjectName`, `$SourcePath`, or version information independently inside a task. Always rely on `Set-SamplerTaskVariable`.
+
+## Task definitions
+
+- Prefix every task definition with a `# Synopsis:` comment -- InvokeBuild surfaces this as the task description:
+  ```powershell
+  # Synopsis: Build the module output using ModuleBuilder.
+  task Build_ModuleOutput_ModuleBuilder {
+      . Set-SamplerTaskVariable -AsNewBuild
+      # ...
+  }
+  ```
+- Compound tasks (tasks that only sequence other tasks) do not need a body -- list dependencies inline:
+  ```powershell
+  task Build_Module_ModuleBuilder Build_ModuleOutput_ModuleBuilder, Build_DscResourcesToExport_ModuleBuilder
+  ```
+- Prefer exposing workflows through compound tasks instead of having downstream projects call low-level implementation tasks directly. Treat compound tasks as the stable public surface so internal task composition can change in Sampler without requiring updates in projects that consume it.
+- Use `Write-Build -Color <Color> -Text <message>` for task output, not `Write-Host`. Prefer `Green` for success, `Yellow` for warnings, `DarkGray` for verbose detail.
+- Resolve all paths through `Get-SamplerAbsolutePath -Path <path> -RelativeTo $BuildRoot` (or `$OutputDirectory`) rather than with `Join-Path` alone, so relative paths in `build.yaml` resolve correctly.

--- a/Sampler/Templates/Copilot/instructions/classes-and-type-accelerators.instructions.md.template
+++ b/Sampler/Templates/Copilot/instructions/classes-and-type-accelerators.instructions.md.template
@@ -1,0 +1,39 @@
+---
+description: 'Module class export and type accelerator instructions'
+applyTo: '{<%= $PLASTER_PARAM_SourceDirectory %>/suffix.ps1,<%= $PLASTER_PARAM_SourceDirectory %>/Classes/*.ps1,<%= $PLASTER_PARAM_SourceDirectory %>/Enum/*.ps1}'
+---
+
+# Classes and Type Accelerators Guidelines
+
+## Purpose
+
+- This repository uses the `<%= $PLASTER_PARAM_SourceDirectory %>\suffix.ps1` type-accelerator pattern to expose selected PowerShell classes after module import.
+- This is a deliberate workaround for PowerShell modules not being able to export classes directly.
+
+## Registration rules
+
+- Keep type-accelerator registration in `<%= $PLASTER_PARAM_SourceDirectory %>\suffix.ps1`, after classes are available.
+- Use `$typesToExportAsIs` only for classes that should be referenced without a module prefix.
+- Prefer module-qualified accelerators via `$typesToExportWithNamespace` to reduce name collisions.
+- Resolve the module name dynamically rather than hard-coding it.
+- Validate that each type exists before registering its accelerator.
+- Warn when overriding an existing accelerator and fail when the target type cannot be found.
+
+## Cleanup rules
+
+- Remove namespaced accelerators in the module `OnRemove` handler.
+- Keep the cleanup logic aligned with the accelerators registered during import.
+
+## Usage implications
+
+- Module consumers must import the module before invoking code paths that depend on exported type accelerators.
+- Dependent modules should rely on manifest `RequiredModules` when they need these accelerators available before command invocation.
+- Keep this pattern compatible with Windows PowerShell 5.1 and PowerShell 7.
+
+## Change safety
+
+- When adding, removing, or renaming exported classes, update:
+  - `<%= $PLASTER_PARAM_SourceDirectory %>\suffix.ps1`
+  - the relevant class files under `<%= $PLASTER_PARAM_SourceDirectory %>\Classes\`
+  - any tests that instantiate or reference those classes
+- Preserve the current collision-avoidance behavior unless intentionally redesigning the class consumption model.

--- a/Sampler/Templates/Copilot/instructions/private-functions.instructions.md.template
+++ b/Sampler/Templates/Copilot/instructions/private-functions.instructions.md.template
@@ -1,0 +1,62 @@
+---
+description: 'Private function authoring instructions'
+applyTo: '<%= $PLASTER_PARAM_SourceDirectory %>/Private/**/*.ps1'
+---
+
+# Private Function Development Guidelines
+
+Private functions follow the same baseline engineering rules as public functions, even though they are not user-facing.
+
+## Baseline structure (same as public functions)
+
+- Use comment-based help with at least:
+  - `.SYNOPSIS`
+  - `.DESCRIPTION`
+  - one `.EXAMPLE`
+  - `.PARAMETER` help for every parameter.
+- Use `[CmdletBinding()]` and include `[OutputType(...)]`.
+- Use explicit .NET parameter types (`[System.String]`, `[System.Boolean]`, etc.).
+- Keep parameter names and defaults stable when consumed by public functions/tasks.
+- Follow DSC Community parameter style: `[Parameter()]` attribute, type, and variable name each on their own line, with a blank line between comma-separated parameter declarations:
+
+```powershell
+param
+(
+    [Parameter(Mandatory = $true)]
+    [System.String]
+    $ProjectName,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $Force
+)
+```
+
+## PowerShell style
+
+- Prefer `$null = <expression>` over `<expression> | Out-Null` to suppress output.
+- Prefer splatting over backtick-based line continuation for multi-line command calls.
+- Never use hardcoded backslash separators inside `Join-Path -ChildPath` strings. Build multi-level paths with chained `Join-Path` calls (one component at a time). Backslashes in a `ChildPath` are not path separators on Linux/macOS.
+- Use only ASCII characters in `.ps1` source files. Non-ASCII characters (em-dashes, smart quotes, Unicode arrows, etc.) trigger PSScriptAnalyzer rule `PSUseBOMForUnicodeEncodedFile`. Use `->` not Unicode arrows, `-` not dashes, straight quotes.
+
+## Validation model
+
+- Prefer enums over `ValidateSet` for option lists that are reused or expected to evolve.
+- Define enum values once and reuse them across commands/templates/tests to avoid drift.
+- Use `ValidateSet` only for narrow, local, non-shared option lists.
+- If an option list changes and affects command/template flow, update all three surfaces in the same change:
+  - function parameter contract
+  - template XML `Condition` logic
+  - unit/integration tests that cover those options.
+
+## Private-specific expectations
+
+- Keep private functions focused and composable; avoid embedding user interaction directly in private helpers unless explicitly required by design.
+- If a private function feeds user-facing behavior, treat compatibility and test coverage with the same rigor as a public function.
+
+## Testing expectations
+
+- Add or update matching tests under `tests/Unit/Private/<FunctionName>.tests.ps1`.
+- Validate both happy path and input validation failures.
+- Call private functions via `InModuleScope` when testing them directly.
+- Follow repository test conventions from `.github/instructions/test-writing.instructions.md`.

--- a/Sampler/Templates/Copilot/instructions/public-functions.instructions.md.template
+++ b/Sampler/Templates/Copilot/instructions/public-functions.instructions.md.template
@@ -1,0 +1,102 @@
+---
+description: 'Public function authoring instructions'
+applyTo: '<%= $PLASTER_PARAM_SourceDirectory %>/Public/**/*.ps1'
+---
+
+# Public Function Development Guidelines
+
+Public functions are user-facing and are the most critical API surface of <%= $PLASTER_PARAM_ModuleName %>.
+
+## Baseline structure (same as private functions)
+
+- Use comment-based help with at least:
+  - `.SYNOPSIS`
+  - `.DESCRIPTION`
+  - one `.EXAMPLE`
+  - `.PARAMETER` help for every parameter.
+- Use `[CmdletBinding()]` and include `[OutputType(...)]`.
+- Use explicit .NET parameter types (`[System.String]`, `[System.Boolean]`, etc.).
+- Keep parameter names and defaults stable unless intentionally introducing a breaking change.
+- Follow DSC Community parameter style: `[Parameter()]` attribute, type, and variable name each on their own line, with a blank line between comma-separated parameter declarations:
+
+```powershell
+param
+(
+    [Parameter(Mandatory = $true)]
+    [System.String]
+    $ProjectName,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $Force
+)
+```
+
+## PowerShell style
+
+- Prefer `$null = <expression>` over `<expression> | Out-Null` to suppress output.
+- Prefer splatting over backtick-based line continuation for multi-line command calls:
+
+```powershell
+# Preferred
+$params = @{
+    Path    = $OutputDirectory
+    Recurse = $true
+}
+Get-ChildItem @params
+```
+
+- Use only ASCII characters in `.ps1` source files. Non-ASCII characters (em-dashes, smart quotes, Unicode arrows, etc.) trigger PSScriptAnalyzer rule `PSUseBOMForUnicodeEncodedFile`. Use `->` not Unicode arrows, `-` not dashes, straight quotes.
+
+## Cross-platform path construction
+
+- Never use hardcoded backslash separators inside `Join-Path -ChildPath` strings. On Linux/macOS, backslashes are not path separators; a `ChildPath` containing backslashes is treated as a single filename component, not a multi-level path.
+- Build multi-level paths with chained `Join-Path` calls:
+
+```powershell
+# Wrong -- backslash is not a separator on Linux
+Join-Path -Path $root -ChildPath 'output\module\MyModule\*\MyModule.psd1'
+
+# Correct
+$p = Join-Path -Path $root -ChildPath 'output'
+$p = Join-Path -Path $p    -ChildPath 'module'
+$p = Join-Path -Path $p    -ChildPath $ModuleName
+$p = Join-Path -Path $p    -ChildPath '*'
+$p = Join-Path -Path $p    -ChildPath "$ModuleName.psd1"
+```
+
+- Never hard-code `\` in user-facing messages that include paths; use `Join-Path` to build the example path.
+
+## State-changing functions (`SupportsShouldProcess`)
+
+- Functions whose verb implies state change (`New-`, `Remove-`, `Set-`, `Start-`, etc.) must declare `[CmdletBinding(SupportsShouldProcess = $true)]` to satisfy PSScriptAnalyzer rule `PSUseShouldProcessForStateChangingFunctions`.
+- Wrap the actual mutation with `if ($PSCmdlet.ShouldProcess($target, $action))`.
+- In tests, pass `-Confirm:$false` to bypass the `ShouldProcess` prompt.
+
+## Validation model
+
+- Prefer enums over `ValidateSet` for option lists that are reused or expected to evolve.
+- Define enum values once and reuse them across commands/templates/tests to avoid drift.
+- Use `ValidateSet` only for narrow, local, non-shared option lists.
+- If an option list changes, update all three surfaces in the same change:
+  - function parameter contract
+  - template XML `Condition` logic
+  - unit/integration tests that cover those options.
+
+## Public-critical requirements
+
+- Preserve backward compatibility by default; avoid parameter renames/removals.
+- Any user-visible behavior change must include:
+  - unit tests under `tests/Unit/Public/`
+  - integration test updates if scaffolding/template behavior is affected
+  - an `Unreleased` entry in `CHANGELOG.md`.
+- Prefer non-interactive usability: users should be able to pass sufficient parameters to avoid prompts.
+- If parameters are omitted and prompting is supported, prompts must be deterministic and covered by tests.
+
+## Testing expectations
+
+- Add or update a matching test file under `tests/Unit/Public/<FunctionName>.tests.ps1`.
+- Validate both happy path and input validation failures.
+- When commands support both non-interactive and prompted flows, cover both modes.
+- Call the function under test with its module-qualified name (`<%= $PLASTER_PARAM_ModuleName %>\Get-Foo`) to avoid accidentally calling a mock or a stale imported version.
+- Follow repository test conventions from `.github/instructions/test-writing.instructions.md`.

--- a/Sampler/Templates/Copilot/instructions/test-writing.instructions.md.template
+++ b/Sampler/Templates/Copilot/instructions/test-writing.instructions.md.template
@@ -1,0 +1,117 @@
+---
+description: 'Pester test authoring instructions'
+applyTo: 'tests/**.Tests.ps1'
+---
+
+# Pester Tests Development Guidelines
+
+## Blueprint structure
+
+Every test file **must** begin with this exact top-level `BeforeAll` / `AfterAll` pair. Do not omit or reorder any line.
+
+```powershell
+BeforeAll {
+    $script:moduleName = '<%= $PLASTER_PARAM_ModuleName %>'
+
+    # If the module is not found, run the build task 'noop'.
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        # Redirect all streams to $null, except the error stream (stream 2)
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    # Re-import the module using force to get any code changes between runs.
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Remove-Module -Name $script:moduleName
+}
+```
+
+- The `$PSDefaultParameterValues` entries for `InModuleScope`, `Mock`, and `Should` scope all Pester commands to the module under test automatically -- **always include them**.
+- The `AfterAll` block must remove those same keys and unload the module to avoid state leaking between test runs.
+- If mocking is required, mock only external boundaries (functions or cmdlets outside of the module), not internal pure helpers.
+- Use `BeforeDiscovery` (outside `Describe`) for data-driven test cases passed via `-ForEach`.
+- Place test-case-specific mocks in a `BeforeAll` block **inside** the relevant `Describe` or `Context` block, not at the top level.
+
+## `It` block naming
+
+- Start every `It` description with **`Should`** followed by a plain-English statement of the expected outcome:
+  ```powershell
+  It 'Should return the correct semantic version' { ... }
+  It 'Should not throw an exception when instantiated' { ... }
+  It 'Should return $false for missing attribute' { ... }
+  ```
+- For data-driven tests use `-ForEach` (Pester 5) and embed the case variable in the name with `<VariableName>`:
+  ```powershell
+  It 'Should call Invoke-Plaster with test case <TestCaseName>' -ForEach $testCases { ... }
+  ```
+- Use `-Skip:(<booleanExpression>)` for platform-conditional tests; never delete or comment them out:
+  ```powershell
+  It 'Should set the PSModulePath correctly' -Skip:(-not $IsWindows) { ... }
+  ```
+
+## Assertion style
+
+Use the most specific assertion available -- avoid `Should -Be $true` when a dedicated form exists.
+
+| Scenario | Preferred assertion |
+|---|---|
+| Exact value match | `Should -Be 'value'` |
+| Case-sensitive match | `Should -BeExactly 'Value'` |
+| Regex match | `Should -Match 'pattern'` |
+| Boolean true/false | `Should -BeTrue` / `Should -BeFalse` |
+| Null or empty | `Should -BeNullOrEmpty` / `Should -Not -BeNullOrEmpty` |
+| Exception expected | `{ ... } \| Should -Throw` |
+| No exception expected | `{ ... } \| Should -Not -Throw` |
+| Mock was called | `Should -Invoke -CommandName X -Exactly -Times 1 -Scope It` |
+| Type check | `$x \| Should -BeOfType [ExpectedType]` |
+
+- Always scope mock-call assertions with `-Scope It` so counts reset between tests.
+- Call the function under test with its module-qualified name (`<%= $PLASTER_PARAM_ModuleName %>\Get-Foo`) to avoid accidentally calling a mock or a stale imported version.
+
+## Cross-platform test paths
+
+- Never use hardcoded Windows paths (`'C:\src\...'`, `'C:\output\...'`) as test inputs when the code under test passes those values to `Join-Path`, `[System.IO.Path]::IsPathRooted`, `Test-Path`, or `New-Item`. On Linux, `C:\` is not rooted, and `Join-Path` may produce wrong results or throw a drive-not-found error.
+- Use `$TestDrive` as the base for any absolute path in test fixtures. `$TestDrive` is always a valid, OS-appropriate absolute path on every platform:
+
+```powershell
+# Wrong -- C:\ is not rooted on Linux
+$repoRoot = 'C:\src\MyModule'
+
+# Correct
+$repoRoot = Join-Path -Path $TestDrive -ChildPath 'MyModule'
+```
+
+- When constructing expected paths, use chained `Join-Path` calls rather than hardcoded separators.
+
+## `InModuleScope` usage
+
+- Use `InModuleScope` only when the test needs to call a **private** function directly, or when the assertion relies on module-internal state.
+- Do NOT wrap calls to **public** functions in `InModuleScope`. Call them directly with the module-qualified name (`<%= $PLASTER_PARAM_ModuleName %>\Get-Foo`). The mocks registered via `$PSDefaultParameterValues['Mock:ModuleName'] = '<%= $PLASTER_PARAM_ModuleName %>'` still intercept any private function calls made internally by the public function.
+- Do NOT reference `$script:` variables inside an `InModuleScope` block. Inside `InModuleScope`, `$script:` refers to the **module's** script scope, not the test file's.
+
+## `SupportsShouldProcess` in tests
+
+- For commands that use `SupportsShouldProcess`, pass `-Confirm:$false` in unit tests that are meant to exercise the execution path. Do not rely on `$ConfirmPreference` being low enough to skip the prompt.
+
+## Windows PowerShell 5.1 compatibility
+
+- Always wrap pipeline expressions in `@()` before calling `.Count`, `.Length`, or indexing into the result (`[0]`). On Windows PowerShell 5.1, a pipeline that produces exactly one object returns a scalar, not an array, and scalars without a `Count` property return `$null` instead of `1`. PowerShell 7 adds a synthetic `Count` member to all objects, masking the bug.
+
+```powershell
+# Wrong -- returns $null on WinPS 5.1 when exactly one item matches
+($collection | Where-Object { $_.Name -eq 'X' }).Count | Should -Be 1
+
+# Correct
+@($collection | Where-Object { $_.Name -eq 'X' }).Count | Should -Be 1
+```

--- a/Sampler/Templates/Copilot/instructions/wiki-publishing.instructions.md.template
+++ b/Sampler/Templates/Copilot/instructions/wiki-publishing.instructions.md.template
@@ -1,0 +1,30 @@
+---
+description: 'GitHub wiki content and publishing instructions'
+applyTo: '<%= $PLASTER_PARAM_SourceDirectory %>/WikiSource/**/*.md,build.yaml,.pipelines/*.yml,.pipelines/*.yaml'
+---
+
+# GitHub Wiki Publishing Guidelines
+
+## Source of truth
+
+- Keep hand-authored GitHub wiki pages under `<%= $PLASTER_PARAM_SourceDirectory %>/WikiSource`.
+- Treat `<%= $PLASTER_PARAM_SourceDirectory %>/WikiSource` as the canonical source for custom wiki pages; do not edit generated files under `output/WikiContent`.
+- Prefer stable page names in `WikiSource` so published wiki links do not churn.
+
+## Build wiring
+
+- Keep wiki generation and publishing wired through `build.yaml`.
+- Ensure docs/build workflows that prepare wiki content include `Copy_Source_Wiki_Folder` so `<%= $PLASTER_PARAM_SourceDirectory %>/WikiSource` is copied into `output/WikiContent`.
+- Keep `Publish_GitHub_Wiki_Content` in the `publish` workflow so the generated wiki content is pushed to the repository wiki.
+- Keep `Generate_Wiki_Sidebar` after copying `WikiSource` content so custom pages can participate in sidebar generation.
+
+## Authoring notes
+
+- Put landing-page content in `<%= $PLASTER_PARAM_SourceDirectory %>/WikiSource/Home.md` when a custom wiki home page is needed.
+- If `Home.md` contains module version placeholders, rely on the Sampler/DscResource.DocGenerator task to update them during the build; do not hardcode release-specific versions into committed wiki pages.
+- Keep custom wiki content in Markdown that is compatible with GitHub wiki rendering.
+
+## Validation
+
+- After changing wiki workflow wiring or `<%= $PLASTER_PARAM_SourceDirectory %>/WikiSource` structure, validate with `./build.ps1 -Tasks build`.
+- When changing publish behavior, also validate the docs/publish path used by the pipeline rather than editing `output/WikiContent` manually.

--- a/Sampler/Templates/Copilot/plasterManifest.xml
+++ b/Sampler/Templates/Copilot/plasterManifest.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest
+  schemaVersion="1.0" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+  <metadata>
+    <name>Copilot</name>
+    <id>7e3a1f2d-4b8c-4e9a-b1d6-0f5c3e7a9b2f</id>
+    <version>0.0.1</version>
+    <title>GitHub Copilot Instructions Template</title>
+    <description>Scaffolds GitHub Copilot instruction files under .github/ for any Sampler-based PowerShell module.</description>
+    <author>Gael Colas</author>
+    <tags>Sampler,Template,Copilot,GitHub</tags>
+  </metadata>
+  <parameters>
+    <parameter name="ModuleName"
+               type="text"
+               store="text"
+               prompt="Module name" />
+
+    <parameter name="SourceDirectory"
+               type="text"
+               store="text"
+               default="source"
+               prompt="Source folder name (e.g. source or src)" />
+
+    <parameter name="HasClasses"
+               type="choice"
+               default="1"
+               prompt="Does the module use PSv5+ Classes with type-accelerator exports?">
+      <choice label="&amp;Yes" value="true" />
+      <choice label="&amp;No"  value="false" />
+    </parameter>
+
+    <parameter name="HasCustomBuildTasks"
+               type="choice"
+               default="1"
+               prompt="Does the module have custom InvokeBuild task files under .build/tasks/?">
+      <choice label="&amp;Yes" value="true" />
+      <choice label="&amp;No"  value="false" />
+    </parameter>
+
+    <parameter name="HasWikiSource"
+               type="choice"
+               default="1"
+               prompt="Does the module publish a GitHub wiki from a WikiSource folder?">
+      <choice label="&amp;Yes" value="true" />
+      <choice label="&amp;No"  value="false" />
+    </parameter>
+  </parameters>
+
+  <content>
+
+    <!-- COPILOT ROOT INSTRUCTIONS -->
+    <templateFile source='copilot-instructions.md.template'
+                  destination='.github/copilot-instructions.md' />
+
+    <!-- AI INSTRUCTION AUTHORING (verbatim) -->
+    <file source='instructions/ai-instruction-authoring.instructions.md'
+          destination='.github/instructions/ai-instruction-authoring.instructions.md' />
+
+    <!-- PUBLIC FUNCTIONS INSTRUCTIONS (template - uses ModuleName + SourceDirectory) -->
+    <templateFile source='instructions/public-functions.instructions.md.template'
+                  destination='.github/instructions/public-functions.instructions.md' />
+
+    <!-- PRIVATE FUNCTIONS INSTRUCTIONS (template) -->
+    <templateFile source='instructions/private-functions.instructions.md.template'
+                  destination='.github/instructions/private-functions.instructions.md' />
+
+    <!-- TEST WRITING INSTRUCTIONS (template - uses ModuleName) -->
+    <templateFile source='instructions/test-writing.instructions.md.template'
+                  destination='.github/instructions/test-writing.instructions.md' />
+
+    <!-- BUILD TASKS INSTRUCTIONS (verbatim) -->
+    <file source='instructions/build-tasks.instructions.md'
+          destination='.github/instructions/build-tasks.instructions.md' />
+
+    <!-- VALIDATE-CHANGES SKILL (template - uses ModuleName + SourceDirectory) -->
+    <templateFile source='skills/validate-changes/SKILL.md.template'
+                  destination='.github/skills/validate-changes/SKILL.md' />
+
+    <!-- CLASSES INSTRUCTIONS (template - conditional on HasClasses) -->
+    <templateFile source='instructions/classes-and-type-accelerators.instructions.md.template'
+                  destination='.github/instructions/classes-and-type-accelerators.instructions.md'
+                  condition='$PLASTER_PARAM_HasClasses -eq "true"' />
+
+    <!-- CUSTOM BUILD TASK FILES INSTRUCTIONS (verbatim - conditional on HasCustomBuildTasks) -->
+    <file source='instructions/build-task-files.instructions.md'
+          destination='.github/instructions/build-task-files.instructions.md'
+          condition='$PLASTER_PARAM_HasCustomBuildTasks -eq "true"' />
+
+    <!-- WIKI PUBLISHING INSTRUCTIONS (template - conditional on HasWikiSource) -->
+    <templateFile source='instructions/wiki-publishing.instructions.md.template'
+                  destination='.github/instructions/wiki-publishing.instructions.md'
+                  condition='$PLASTER_PARAM_HasWikiSource -eq "true"' />
+
+  </content>
+</plasterManifest>

--- a/Sampler/Templates/Copilot/skills/validate-changes/SKILL.md.template
+++ b/Sampler/Templates/Copilot/skills/validate-changes/SKILL.md.template
@@ -1,0 +1,97 @@
+---
+name: validate-changes
+description: Run targeted test scopes to validate changes quickly and safely, then run the full test suite when needed for confidence before PRs.
+argument-hint: What files or areas did you change, and how much validation do you want?
+---
+
+# Validate Changes with Tests
+
+## Purpose
+
+Run the right test scope for a change, fast first and broad only when needed.
+
+## Use this skill when
+
+- You changed PowerShell functions under `<%= $PLASTER_PARAM_SourceDirectory %>/Public` or `<%= $PLASTER_PARAM_SourceDirectory %>/Private`.
+- You changed PowerShell classes and enums under `<%= $PLASTER_PARAM_SourceDirectory %>/Classes` or `<%= $PLASTER_PARAM_SourceDirectory %>/Enum`.
+- You changed build logic under `.build/tasks` or `build.yaml`.
+- You need a confidence check before opening or updating a PR.
+
+## Inputs
+
+- `changed_paths`: list of changed files or folders.
+- `target_test`: optional single test file path for focused validation.
+- `run_quality_gate`: optional boolean to run HQRM checks.
+
+## Decision flow
+
+> **Mandatory:** every command must be invoked through `./build.ps1`. Do not run `Invoke-Pester` directly, do not call `Build-Module` directly, and do not manually prepend anything to `PSModulePath`. Running `./build.ps1 -ResolveDependency -Tasks noop` bootstraps dependencies and wires `PSModulePath` for the current shell.
+
+1. Bootstrap dependencies if needed.
+- Command:
+```powershell
+./build.ps1 -ResolveDependency -Tasks noop
+```
+
+2. Pick the smallest useful test scope first.
+- If `target_test` is provided, run only that test file:
+```powershell
+./build.ps1 -Tasks test -PesterPath '<target_test>' -CodeCoverageThreshold 0
+```
+- Else if changes are only in a specific function area, run a focused unit test file in `tests/Unit/**`.
+
+3. Expand based on change type.
+- If build/task wiring changed (`.build/tasks/**`, `build.yaml`, `build.ps1`): run default test workflow:
+```powershell
+./build.ps1 -Tasks test
+```
+
+4. Run broad integration only when needed.
+- For workflow-impacting changes:
+```powershell
+./build.ps1 -Tasks test -PesterPath 'tests/Integration' -CodeCoverageThreshold 0
+```
+
+5. Optional release-quality gate.
+- If `run_quality_gate` is true, run:
+```powershell
+./build.ps1 -Tasks hqrmtest
+```
+
+## Running these commands without hanging
+
+Always tee `./build.ps1` output to `output\agentic\` -- this subfolder is excluded from the `Clean` task so logs survive between builds:
+
+```powershell
+$null = New-Item -Path 'output\agentic' -ItemType Directory -Force
+
+./build.ps1 -Tasks test -PesterPath '<paths>' -CodeCoverageThreshold 0 2>&1 |
+    Tee-Object -FilePath 'output\agentic\test.log'
+```
+
+Poll the log with `Get-Content output\agentic\test.log -Tail 20` rather than re-running the build.
+
+## Diagnosing failures from XML output
+
+Test failures are recorded in machine-readable XML under `output/testResults/`. Always read those files instead of grepping the build log.
+
+- **Pester (`-Tasks test`)** writes NUnit XML at `output/testResults/NUnitXml_*.xml`. Each failing assertion is a `<test-case result="Failure">` node:
+
+  ```powershell
+  $latest = Get-ChildItem output\testResults\NUnitXml_*.xml |
+      Sort-Object LastWriteTime -Descending | Select-Object -First 1
+  [xml]$x = Get-Content $latest.FullName
+  $x.SelectNodes('//test-case[@result="Failure"]') | ForEach-Object {
+      "==FAIL==`n$($_.name)`n$($_.failure.message)`n"
+  }
+  ```
+
+- Always pick the **latest** result file (`Sort-Object LastWriteTime -Descending`).
+- When reporting a failure, quote the XML assertion message -- do not paraphrase the build-log tail.
+
+## Completion checks
+
+- All selected test commands exit successfully.
+- For public/private function changes: relevant unit tests pass.
+- If behavior is user-visible: ensure `CHANGELOG.md` has an `Unreleased` entry.
+- **Before declaring work complete on any PR-bound change, run the full `./build.ps1 -Tasks test` suite.**

--- a/Sampler/Templates/Sampler/plasterManifest.xml
+++ b/Sampler/Templates/Sampler/plasterManifest.xml
@@ -88,6 +88,9 @@
             <choice label='Visual Studio &amp;Code'
                   help="Adds Visual Studio Code configuration files."
                   value="vscode"/>
+            <choice label='&amp;Copilot instructions'
+                  help="Adds GitHub Copilot instruction files under .github/."
+                  value="copilot"/>
             <choice label='Test&amp;Kitchen'
                   help="Adds TestKitchen folders, yaml and an example."
                   value="TestKitchen"/>
@@ -785,6 +788,60 @@
     <templateFile source='codecov.yml.template'
           destination='${PLASTER_PARAM_ModuleName}/codecov.yml'
           condition='(${PLASTER_PARAM_UseCodeCovIo} -eq $true -or ${PLASTER_PARAM_ModuleType} -in @("dsccommunity", "CompleteSample")) -or ${PLASTER_PARAM_Features} -Contains ("All") -or ${PLASTER_PARAM_Features} -Contains ("codecov")'
+    />
+
+   <!-- COPILOT INSTRUCTIONS - always-on files -->
+    <templateFile source='../Copilot/copilot-instructions.md.template'
+          destination='${PLASTER_PARAM_ModuleName}/.github/copilot-instructions.md'
+          condition='${PLASTER_PARAM_ModuleType} -eq "CompleteSample" -or ${PLASTER_PARAM_Features} -Contains ("copilot") -or ${PLASTER_PARAM_Features} -Contains ("All")'
+    />
+
+    <file source='../Copilot/instructions/ai-instruction-authoring.instructions.md'
+          destination='${PLASTER_PARAM_ModuleName}/.github/instructions/ai-instruction-authoring.instructions.md'
+          condition='${PLASTER_PARAM_ModuleType} -eq "CompleteSample" -or ${PLASTER_PARAM_Features} -Contains ("copilot") -or ${PLASTER_PARAM_Features} -Contains ("All")'
+    />
+
+    <templateFile source='../Copilot/instructions/public-functions.instructions.md.template'
+          destination='${PLASTER_PARAM_ModuleName}/.github/instructions/public-functions.instructions.md'
+          condition='${PLASTER_PARAM_ModuleType} -eq "CompleteSample" -or ${PLASTER_PARAM_Features} -Contains ("copilot") -or ${PLASTER_PARAM_Features} -Contains ("All")'
+    />
+
+    <templateFile source='../Copilot/instructions/private-functions.instructions.md.template'
+          destination='${PLASTER_PARAM_ModuleName}/.github/instructions/private-functions.instructions.md'
+          condition='${PLASTER_PARAM_ModuleType} -eq "CompleteSample" -or ${PLASTER_PARAM_Features} -Contains ("copilot") -or ${PLASTER_PARAM_Features} -Contains ("All")'
+    />
+
+    <templateFile source='../Copilot/instructions/test-writing.instructions.md.template'
+          destination='${PLASTER_PARAM_ModuleName}/.github/instructions/test-writing.instructions.md'
+          condition='${PLASTER_PARAM_ModuleType} -eq "CompleteSample" -or ${PLASTER_PARAM_Features} -Contains ("copilot") -or ${PLASTER_PARAM_Features} -Contains ("All")'
+    />
+
+    <file source='../Copilot/instructions/build-tasks.instructions.md'
+          destination='${PLASTER_PARAM_ModuleName}/.github/instructions/build-tasks.instructions.md'
+          condition='${PLASTER_PARAM_ModuleType} -eq "CompleteSample" -or ${PLASTER_PARAM_Features} -Contains ("copilot") -or ${PLASTER_PARAM_Features} -Contains ("All")'
+    />
+
+    <templateFile source='../Copilot/skills/validate-changes/SKILL.md.template'
+          destination='${PLASTER_PARAM_ModuleName}/.github/skills/validate-changes/SKILL.md'
+          condition='${PLASTER_PARAM_ModuleType} -eq "CompleteSample" -or ${PLASTER_PARAM_Features} -Contains ("copilot") -or ${PLASTER_PARAM_Features} -Contains ("All")'
+    />
+
+   <!-- COPILOT INSTRUCTIONS - conditional on Classes feature -->
+    <templateFile source='../Copilot/instructions/classes-and-type-accelerators.instructions.md.template'
+          destination='${PLASTER_PARAM_ModuleName}/.github/instructions/classes-and-type-accelerators.instructions.md'
+          condition='(${PLASTER_PARAM_ModuleType} -eq "CompleteSample" -or ${PLASTER_PARAM_Features} -Contains ("copilot") -or ${PLASTER_PARAM_Features} -Contains ("All")) -and (${PLASTER_PARAM_ModuleType} -eq "CompleteSample" -or ${PLASTER_PARAM_Features} -Contains ("Classes") -or ${PLASTER_PARAM_Features} -Contains ("All"))'
+    />
+
+   <!-- COPILOT INSTRUCTIONS - conditional on Build feature -->
+    <file source='../Copilot/instructions/build-task-files.instructions.md'
+          destination='${PLASTER_PARAM_ModuleName}/.github/instructions/build-task-files.instructions.md'
+          condition='(${PLASTER_PARAM_ModuleType} -eq "CompleteSample" -or ${PLASTER_PARAM_Features} -Contains ("copilot") -or ${PLASTER_PARAM_Features} -Contains ("All")) -and (${PLASTER_PARAM_ModuleType} -eq "CompleteSample" -or ${PLASTER_PARAM_Features} -Contains ("Build") -or ${PLASTER_PARAM_Features} -Contains ("All"))'
+    />
+
+   <!-- COPILOT INSTRUCTIONS - conditional on WikiSource (CompleteSample only by default) -->
+    <templateFile source='../Copilot/instructions/wiki-publishing.instructions.md.template'
+          destination='${PLASTER_PARAM_ModuleName}/.github/instructions/wiki-publishing.instructions.md'
+          condition='${PLASTER_PARAM_ModuleType} -eq "CompleteSample"'
     />
   </content>
 </plasterManifest>

--- a/Sampler/WikiSource/Copilot-Instructions-Template.md
+++ b/Sampler/WikiSource/Copilot-Instructions-Template.md
@@ -1,0 +1,103 @@
+# Copilot Instructions Template
+
+The `Copilot` Plaster template scaffolds a ready-to-use set of GitHub Copilot
+instruction files and a `validate-changes` skill into any Sampler-based
+PowerShell module.
+
+## What it scaffolds
+
+| File | Condition | Purpose |
+|---|---|---|
+| `.github/copilot-instructions.md` | Always | Root instructions: git workflow, build entry point, conventions |
+| `.github/instructions/ai-instruction-authoring.instructions.md` | Always | Rules for authoring further instruction files |
+| `.github/instructions/public-functions.instructions.md` | Always | Public function style and testing conventions |
+| `.github/instructions/private-functions.instructions.md` | Always | Private function conventions |
+| `.github/instructions/test-writing.instructions.md` | Always | Pester test authoring conventions |
+| `.github/instructions/build-tasks.instructions.md` | Always | InvokeBuild/Sampler task authoring conventions |
+| `.github/skills/validate-changes/SKILL.md` | Always | Targeted test-scope selection skill for Copilot |
+| `.github/instructions/classes-and-type-accelerators.instructions.md` | `HasClasses = Yes` | PSv5+ class export and type-accelerator conventions |
+| `.github/instructions/build-task-files.instructions.md` | `HasCustomBuildTasks = Yes` | Custom `.build/tasks/` file conventions |
+| `.github/instructions/wiki-publishing.instructions.md` | `HasWikiSource = Yes` | WikiSource authoring and publish conventions |
+
+## Usage
+
+### Add to an existing module
+
+Run from the module root (where `build.ps1` lives):
+
+```powershell
+Add-Sample -Sample Copilot -DestinationPath .
+```
+
+Plaster will prompt for:
+
+| Prompt | Default | Notes |
+|---|---|---|
+| Module name | _(none)_ | The name of your module (e.g. `MyModule`) |
+| Source folder name | `source` | Usually `source` or `src` |
+| Does the module use PSv5+ Classes? | No | Adds `classes-and-type-accelerators.instructions.md` |
+| Does the module have custom build task files? | No | Adds `build-task-files.instructions.md` |
+| Does the module publish a GitHub wiki? | No | Adds `wiki-publishing.instructions.md` |
+
+### Include when scaffolding a new module
+
+Pass `copilot` in the `Features` array when calling `New-SampleModule`:
+
+```powershell
+New-SampleModule -DestinationPath 'C:\source' `
+    -ModuleType 'CustomModule' `
+    -ModuleName 'MyModule' `
+    -ModuleAuthor 'Your Name' `
+    -ModuleDescription 'My module description' `
+    -SourceDirectory 'source' `
+    -MainGitBranch 'main' `
+    -Features @('git', 'github', 'UnitTests', 'Build', 'copilot')
+```
+
+The `CompleteSample` module type includes Copilot instructions automatically.
+
+## What the files cover
+
+### `copilot-instructions.md`
+
+The root instructions file that GitHub Copilot loads for every conversation
+in the repository. It covers:
+
+- Git workflow: never commit or push; leave all commits to the owner
+- Build entry point: always use `./build.ps1`; never call `Invoke-Pester` or
+  `Build-Module` directly
+- Repository layout: source folder, do not edit the root `.psm1` directly
+- Key conventions: `$null =` over `| Out-Null`; splatting over backticks;
+  ASCII-only in `.ps1` files and `CHANGELOG.md`
+- Changelog policy: update only for user-visible module changes
+
+### `instructions/test-writing.instructions.md`
+
+Pester test conventions tuned for the module:
+
+- Required `BeforeAll`/`AfterAll` blueprint (with the correct module name)
+- `It` block naming: always start with `Should`
+- Assertion style table
+- Cross-platform path rules (`$TestDrive`, no `C:\` literals)
+- `InModuleScope` usage rules
+- WinPS 5.1 `@()` wrapping
+
+### `skills/validate-changes/SKILL.md`
+
+A Copilot skill that selects the correct test scope based on what changed:
+
+- Public/private function change -> focused unit test
+- Template change -> integration tests
+- Build task change -> full default test workflow
+- Completion check: always run the full suite before PR
+
+## Customization
+
+The scaffolded files are plain Markdown - edit them freely after scaffolding to
+reflect project-specific conventions. The instruction files under
+`.github/instructions/` apply automatically to the file patterns listed in
+their `applyTo` YAML frontmatter.
+
+To add further instruction files over time, use
+`.github/instructions/ai-instruction-authoring.instructions.md` as your style
+guide.

--- a/Sampler/WikiSource/Getting-started.md
+++ b/Sampler/WikiSource/Getting-started.md
@@ -349,6 +349,7 @@ values (they map 1:1 to the multichoice values defined in the Plaster template):
 | `vscode`          | `.vscode` folder with recommended Visual Studio Code settings.                                         |
 | `codecov`         | `codecov.yml` for code coverage reporting via CodeCov.io.                                              |
 | `azurepipelines`  | `azure-pipelines.yml` and supporting files for Azure Pipelines.                                        |
+| `copilot`         | GitHub Copilot instruction files and a `validate-changes` skill under `.github/`. See [[Copilot-Instructions-Template]]. |
 | `Gherkin`         | Gherkin/specification test scaffolding.                                                                |
 | `UnitTests`       | `tests/Unit` folder and example Pester tests for the features you selected.                            |
 | `ModuleQuality`   | Quality-assurance Pester tests (help, ScriptAnalyzer, code coverage gates).                            |
@@ -388,7 +389,8 @@ $newSampleModuleParameters = @{
         'github',
         'vscode',
         'azurepipelines',
-        'codecov'
+        'codecov',
+        'copilot'
     )
 }
 
@@ -937,6 +939,21 @@ Sampler module. With this function you can bootstrap your module project
 by adding classes, functions and associated tests, examples and configuration
 elements.
 
+The available sample types are:
+
+| Sample | What it adds |
+|---|---|
+| `Classes` | A sample of 4 classes with inheritance and how to manage load order. |
+| `ClassResource` | A class-based DSC resource with tests, Reasons, and localized strings. |
+| `Composite` | A DSC composite resource (configuration block). |
+| `Copilot` | GitHub Copilot instruction files and a `validate-changes` skill under `.github/`. See [[Copilot-Instructions-Template]]. |
+| `Enum` | An example enum. |
+| `MofResource` | A MOF-based DSC resource following DSC Community practices. |
+| `PrivateFunction` | A private function and its test. |
+| `PublicCallPrivateFunctions` | An exported function that calls a private one, with tests. |
+| `PublicFunction` | A public function and its test. |
+| `VscodeConfig` | Visual Studio Code settings and task configuration. |
+
 #### Syntax
 
 <!-- markdownlint-disable MD013 - Line length -->
@@ -957,6 +974,14 @@ Add-Sample -Sample PublicFunction -PublicFunctionName Get-MyStuff
 
 This example adds a public function to the module (in the current folder),
 with a sample unit test that test the public function.
+
+```powershell
+Add-Sample -Sample Copilot -DestinationPath .
+```
+
+This example scaffolds GitHub Copilot instruction files into an existing module
+project. You will be prompted for the module name, source directory, and whether
+to include optional files for classes, custom build tasks, and wiki publishing.
 
 ### `Invoke-SamplerGit`
 

--- a/Sampler/WikiSource/Home.md
+++ b/Sampler/WikiSource/Home.md
@@ -18,6 +18,11 @@ See [[Workspace-Dependencies]] for how to link sibling workspace module builds
 into the local output path so they are discoverable during builds and tests
 without publishing them to a feed.
 
+## GitHub Copilot integration
+
+See [[Copilot-Instructions-Template]] for how to scaffold GitHub Copilot
+instruction files and a `validate-changes` skill into a new or existing module.
+
 ## Prerequisites
 
 - PowerShell 5.or higher

--- a/tests/Integration/PlasterTemplates/Copilot/CopilotPlasterTemplate.Integration.Tests.ps1
+++ b/tests/Integration/PlasterTemplates/Copilot/CopilotPlasterTemplate.Integration.Tests.ps1
@@ -1,0 +1,228 @@
+BeforeAll {
+    $script:moduleName = 'Sampler'
+
+    # If the module is not found, run the build task 'noop'.
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        # Redirect all streams to $null, except the error stream (stream 2)
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    # Re-import the module using force to get any code changes between runs.
+    $importedModule = Import-Module -Name $script:moduleName -Force -PassThru -ErrorAction 'Stop'
+
+    Import-Module -Name "$PSScriptRoot\..\..\IntegrationTestHelpers.psm1"
+
+    Install-TreeCommand
+}
+
+AfterAll {
+    Remove-Module -Name $script:moduleName
+}
+
+Describe 'Copilot Plaster Template' {
+    Context 'When scaffolding without optional features' {
+        BeforeAll {
+            $mockDestinationPath = Join-Path -Path $TestDrive -ChildPath 'copilot-basic'
+
+            $null = New-Item -ItemType Directory -Path $mockDestinationPath -Force
+
+            $listOfExpectedFilesAndFolders = @(
+                # Folders
+                '.github'
+                '.github/instructions'
+                '.github/skills'
+                '.github/skills/validate-changes'
+
+                # Files
+                '.github/copilot-instructions.md'
+                '.github/instructions/ai-instruction-authoring.instructions.md'
+                '.github/instructions/public-functions.instructions.md'
+                '.github/instructions/private-functions.instructions.md'
+                '.github/instructions/test-writing.instructions.md'
+                '.github/instructions/build-tasks.instructions.md'
+                '.github/skills/validate-changes/SKILL.md'
+            )
+
+            $listOfAbsentFiles = @(
+                '.github/instructions/classes-and-type-accelerators.instructions.md'
+                '.github/instructions/build-task-files.instructions.md'
+                '.github/instructions/wiki-publishing.instructions.md'
+            )
+        }
+
+        It 'Should scaffold Copilot files without throwing' {
+            $invokePlasterParameters = @{
+                TemplatePath        = Join-Path -Path $importedModule.ModuleBase -ChildPath 'Templates/Copilot'
+                DestinationPath     = $mockDestinationPath
+                NoLogo              = $true
+                Force               = $true
+                ModuleName          = 'TestModule'
+                SourceDirectory     = 'source'
+                HasClasses          = 'false'
+                HasCustomBuildTasks = 'false'
+                HasWikiSource       = 'false'
+            }
+
+            { Invoke-Plaster @invokePlasterParameters } | Should -Not -Throw
+        }
+
+        It 'Should have the expected folder and file structure' {
+            $modulePaths = Get-ChildItem -Path $mockDestinationPath -Recurse -Force
+
+            # Make the path relative to destination root.
+            $relativeModulePaths = $modulePaths.FullName -replace [RegEx]::Escape($mockDestinationPath)
+
+            # Change to slash when testing on Windows.
+            $relativeModulePaths = ($relativeModulePaths -replace '\\', '/').TrimStart('/')
+
+            # Check files and folders for discrepancies.
+            $missingFilesOrFolders   = $listOfExpectedFilesAndFolders.Where{ $_ -notin $relativeModulePaths }
+            $unexpectedFilesOrFolders = $relativeModulePaths.Where{ $_ -notin $listOfExpectedFilesAndFolders }
+            $treeStructureIsOk = ($missingFilesOrFolders.Count -eq 0 -and $unexpectedFilesOrFolders.Count -eq 0)
+
+            # Format the report to be used in Because.
+            $report = ":`r`n  Missing:`r`n`t$($missingFilesOrFolders -join "`r`n`t")`r`n  Unexpected:`r`n`t$($unexpectedFilesOrFolders -join "`r`n`t")`r`n."
+
+            if (-not $treeStructureIsOk)
+            {
+                $treeOutput = Get-DirectoryTree -Path $mockDestinationPath
+                Write-Verbose -Message ($treeOutput | Out-String) -Verbose
+            }
+
+            $treeStructureIsOk | Should -BeTrue -Because $report
+        }
+
+        It 'Should not scaffold optional files when all optional features are disabled' {
+            foreach ($absentFile in $listOfAbsentFiles)
+            {
+                $fullPath = Join-Path -Path $mockDestinationPath -ChildPath ($absentFile -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+                $fullPath | Should -Not -Exist -Because "Optional file '$absentFile' should not exist when the feature is disabled"
+            }
+        }
+
+        It 'Should substitute the module name in copilot-instructions.md' {
+            $filePath = Join-Path -Path $mockDestinationPath -ChildPath '.github'
+            $filePath = Join-Path -Path $filePath -ChildPath 'copilot-instructions.md'
+            $content  = Get-Content -Path $filePath -Raw
+            $content | Should -Match 'TestModule'
+        }
+
+        It 'Should substitute the source directory in public-functions.instructions.md' {
+            $filePath = Join-Path -Path $mockDestinationPath -ChildPath '.github'
+            $filePath = Join-Path -Path $filePath -ChildPath 'instructions'
+            $filePath = Join-Path -Path $filePath -ChildPath 'public-functions.instructions.md'
+            $content  = Get-Content -Path $filePath -Raw
+            $content | Should -Match 'source/Public'
+        }
+    }
+
+    Context 'When scaffolding with HasClasses enabled' {
+        BeforeAll {
+            $mockDestinationPath = Join-Path -Path $TestDrive -ChildPath 'copilot-classes'
+
+            $null = New-Item -ItemType Directory -Path $mockDestinationPath -Force
+        }
+
+        It 'Should scaffold with HasClasses without throwing' {
+            $invokePlasterParameters = @{
+                TemplatePath        = Join-Path -Path $importedModule.ModuleBase -ChildPath 'Templates/Copilot'
+                DestinationPath     = $mockDestinationPath
+                NoLogo              = $true
+                Force               = $true
+                ModuleName          = 'TestModule'
+                SourceDirectory     = 'source'
+                HasClasses          = 'true'
+                HasCustomBuildTasks = 'false'
+                HasWikiSource       = 'false'
+            }
+
+            { Invoke-Plaster @invokePlasterParameters } | Should -Not -Throw
+        }
+
+        It 'Should create the classes instructions file' {
+            $filePath = Join-Path -Path $mockDestinationPath -ChildPath '.github'
+            $filePath = Join-Path -Path $filePath -ChildPath 'instructions'
+            $filePath = Join-Path -Path $filePath -ChildPath 'classes-and-type-accelerators.instructions.md'
+            $filePath | Should -Exist
+        }
+
+        It 'Should substitute the source directory in the classes instructions file' {
+            $filePath = Join-Path -Path $mockDestinationPath -ChildPath '.github'
+            $filePath = Join-Path -Path $filePath -ChildPath 'instructions'
+            $filePath = Join-Path -Path $filePath -ChildPath 'classes-and-type-accelerators.instructions.md'
+            $content  = Get-Content -Path $filePath -Raw
+            $content | Should -Match 'source'
+        }
+    }
+
+    Context 'When scaffolding with HasCustomBuildTasks enabled' {
+        BeforeAll {
+            $mockDestinationPath = Join-Path -Path $TestDrive -ChildPath 'copilot-buildtasks'
+
+            $null = New-Item -ItemType Directory -Path $mockDestinationPath -Force
+        }
+
+        It 'Should scaffold with HasCustomBuildTasks without throwing' {
+            $invokePlasterParameters = @{
+                TemplatePath        = Join-Path -Path $importedModule.ModuleBase -ChildPath 'Templates/Copilot'
+                DestinationPath     = $mockDestinationPath
+                NoLogo              = $true
+                Force               = $true
+                ModuleName          = 'TestModule'
+                SourceDirectory     = 'source'
+                HasClasses          = 'false'
+                HasCustomBuildTasks = 'true'
+                HasWikiSource       = 'false'
+            }
+
+            { Invoke-Plaster @invokePlasterParameters } | Should -Not -Throw
+        }
+
+        It 'Should create the build-task-files instructions file' {
+            $filePath = Join-Path -Path $mockDestinationPath -ChildPath '.github'
+            $filePath = Join-Path -Path $filePath -ChildPath 'instructions'
+            $filePath = Join-Path -Path $filePath -ChildPath 'build-task-files.instructions.md'
+            $filePath | Should -Exist
+        }
+    }
+
+    Context 'When scaffolding with HasWikiSource enabled' {
+        BeforeAll {
+            $mockDestinationPath = Join-Path -Path $TestDrive -ChildPath 'copilot-wiki'
+
+            $null = New-Item -ItemType Directory -Path $mockDestinationPath -Force
+        }
+
+        It 'Should scaffold with HasWikiSource without throwing' {
+            $invokePlasterParameters = @{
+                TemplatePath        = Join-Path -Path $importedModule.ModuleBase -ChildPath 'Templates/Copilot'
+                DestinationPath     = $mockDestinationPath
+                NoLogo              = $true
+                Force               = $true
+                ModuleName          = 'TestModule'
+                SourceDirectory     = 'source'
+                HasClasses          = 'false'
+                HasCustomBuildTasks = 'false'
+                HasWikiSource       = 'true'
+            }
+
+            { Invoke-Plaster @invokePlasterParameters } | Should -Not -Throw
+        }
+
+        It 'Should create the wiki-publishing instructions file' {
+            $filePath = Join-Path -Path $mockDestinationPath -ChildPath '.github'
+            $filePath = Join-Path -Path $filePath -ChildPath 'instructions'
+            $filePath = Join-Path -Path $filePath -ChildPath 'wiki-publishing.instructions.md'
+            $filePath | Should -Exist
+        }
+
+        It 'Should substitute the source directory in the wiki-publishing instructions file' {
+            $filePath = Join-Path -Path $mockDestinationPath -ChildPath '.github'
+            $filePath = Join-Path -Path $filePath -ChildPath 'instructions'
+            $filePath = Join-Path -Path $filePath -ChildPath 'wiki-publishing.instructions.md'
+            $content  = Get-Content -Path $filePath -Raw
+            $content | Should -Match 'source/WikiSource'
+        }
+    }
+}

--- a/tests/Integration/PlasterTemplates/Sampler/CompleteSamplePlasterTemplate.Integration.Tests.ps1
+++ b/tests/Integration/PlasterTemplates/Sampler/CompleteSamplePlasterTemplate.Integration.Tests.ps1
@@ -30,6 +30,9 @@ Describe 'Complete Module Plaster Template' {
                 # Folders (relative to module root)
                 '.github'
                 '.github/ISSUE_TEMPLATE'
+                '.github/instructions'
+                '.github/skills'
+                '.github/skills/validate-changes'
                 '.vscode'
                 'output'
                 'output/RequiredModules'
@@ -58,6 +61,16 @@ Describe 'Complete Module Plaster Template' {
                 'tests/Unit/Public'
 
                 # Files (relative to module root)
+                '.github/copilot-instructions.md'
+                '.github/instructions/ai-instruction-authoring.instructions.md'
+                '.github/instructions/build-task-files.instructions.md'
+                '.github/instructions/build-tasks.instructions.md'
+                '.github/instructions/classes-and-type-accelerators.instructions.md'
+                '.github/instructions/private-functions.instructions.md'
+                '.github/instructions/public-functions.instructions.md'
+                '.github/instructions/test-writing.instructions.md'
+                '.github/instructions/wiki-publishing.instructions.md'
+                '.github/skills/validate-changes/SKILL.md'
                 '.github/ISSUE_TEMPLATE/config.yml'
                 '.github/ISSUE_TEMPLATE/General.md'
                 '.github/ISSUE_TEMPLATE/Problem_with_module.yml'

--- a/tests/Integration/PlasterTemplates/Sampler/CustomModulePlasterTemplate.Integration.Tests.ps1
+++ b/tests/Integration/PlasterTemplates/Sampler/CustomModulePlasterTemplate.Integration.Tests.ps1
@@ -30,6 +30,9 @@ Describe 'Custom Module Plaster Template' {
                 # Folders (relative to module root)
                 '.github'
                 '.github/ISSUE_TEMPLATE'
+                '.github/instructions'
+                '.github/skills'
+                '.github/skills/validate-changes'
                 '.vscode'
                 'output'
                 'output/RequiredModules'
@@ -58,6 +61,15 @@ Describe 'Custom Module Plaster Template' {
                 'tests/Unit/Public'
 
                 # Files (relative to module root)
+                '.github/copilot-instructions.md'
+                '.github/instructions/ai-instruction-authoring.instructions.md'
+                '.github/instructions/build-task-files.instructions.md'
+                '.github/instructions/build-tasks.instructions.md'
+                '.github/instructions/classes-and-type-accelerators.instructions.md'
+                '.github/instructions/private-functions.instructions.md'
+                '.github/instructions/public-functions.instructions.md'
+                '.github/instructions/test-writing.instructions.md'
+                '.github/skills/validate-changes/SKILL.md'
                 '.github/ISSUE_TEMPLATE/config.yml'
                 '.github/ISSUE_TEMPLATE/General.md'
                 '.github/ISSUE_TEMPLATE/Problem_with_module.yml'
@@ -183,6 +195,9 @@ Describe 'Custom Module Plaster Template' {
                 # Folders (relative to module root)
                 '.github'
                 '.github/ISSUE_TEMPLATE'
+                '.github/instructions'
+                '.github/skills'
+                '.github/skills/validate-changes'
                 '.vscode'
                 'output'
                 'output/RequiredModules'
@@ -211,6 +226,15 @@ Describe 'Custom Module Plaster Template' {
                 'tests/Unit/Public'
 
                 # Files (relative to module root)
+                '.github/copilot-instructions.md'
+                '.github/instructions/ai-instruction-authoring.instructions.md'
+                '.github/instructions/build-task-files.instructions.md'
+                '.github/instructions/build-tasks.instructions.md'
+                '.github/instructions/classes-and-type-accelerators.instructions.md'
+                '.github/instructions/private-functions.instructions.md'
+                '.github/instructions/public-functions.instructions.md'
+                '.github/instructions/test-writing.instructions.md'
+                '.github/skills/validate-changes/SKILL.md'
                 '.github/ISSUE_TEMPLATE/config.yml'
                 '.github/ISSUE_TEMPLATE/General.md'
                 '.github/ISSUE_TEMPLATE/Problem_with_module.yml'
@@ -338,6 +362,9 @@ Describe 'Custom Module Plaster Template' {
                 # Folders (relative to module root)
                 '.github'
                 '.github/ISSUE_TEMPLATE'
+                '.github/instructions'
+                '.github/skills'
+                '.github/skills/validate-changes'
                 '.vscode'
                 'output'
                 'output/RequiredModules'
@@ -366,6 +393,15 @@ Describe 'Custom Module Plaster Template' {
                 'tests/Unit/Public'
 
                 # Files (relative to module root)
+                '.github/copilot-instructions.md'
+                '.github/instructions/ai-instruction-authoring.instructions.md'
+                '.github/instructions/build-task-files.instructions.md'
+                '.github/instructions/build-tasks.instructions.md'
+                '.github/instructions/classes-and-type-accelerators.instructions.md'
+                '.github/instructions/private-functions.instructions.md'
+                '.github/instructions/public-functions.instructions.md'
+                '.github/instructions/test-writing.instructions.md'
+                '.github/skills/validate-changes/SKILL.md'
                 '.github/ISSUE_TEMPLATE/config.yml'
                 '.github/ISSUE_TEMPLATE/General.md'
                 '.github/ISSUE_TEMPLATE/Problem_with_module.yml'
@@ -493,6 +529,9 @@ Describe 'Custom Module Plaster Template' {
                 # Folders (relative to module root)
                 '.github'
                 '.github/ISSUE_TEMPLATE'
+                '.github/instructions'
+                '.github/skills'
+                '.github/skills/validate-changes'
                 '.vscode'
                 'output'
                 'output/RequiredModules'
@@ -521,6 +560,15 @@ Describe 'Custom Module Plaster Template' {
                 'tests/Unit/Public'
 
                 # Files (relative to module root)
+                '.github/copilot-instructions.md'
+                '.github/instructions/ai-instruction-authoring.instructions.md'
+                '.github/instructions/build-task-files.instructions.md'
+                '.github/instructions/build-tasks.instructions.md'
+                '.github/instructions/classes-and-type-accelerators.instructions.md'
+                '.github/instructions/private-functions.instructions.md'
+                '.github/instructions/public-functions.instructions.md'
+                '.github/instructions/test-writing.instructions.md'
+                '.github/skills/validate-changes/SKILL.md'
                 '.github/ISSUE_TEMPLATE/config.yml'
                 '.github/ISSUE_TEMPLATE/General.md'
                 '.github/ISSUE_TEMPLATE/Problem_with_module.yml'


### PR DESCRIPTION
# Pull Request

- Introduced a new set of instruction templates for GitHub Copilot, including guidelines for public and private functions, test writing, and wiki publishing.
- Added a `validate-changes` skill to streamline testing based on modified files.
- Updated the Plaster manifest to include new templates and conditions for optional features.
- Created integration tests to ensure proper scaffolding of Copilot-related files and functionality.
- Enhanced documentation in the WikiSource to reflect new Copilot features and usage instructions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gaelcolas/Sampler/584)
<!-- Reviewable:end -->
